### PR TITLE
On-demand DSWx-HLS Jobs

### DIFF
--- a/conf/RunConfig.yaml.L3_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_HLS.jinja2.tmpl
@@ -75,14 +75,14 @@ RunConfig:
             save_rgb: False   # Reflectance RGB color composition
             save_infrared_rgb: False  # SWIR-1, NIR, and Red reflectance color composition
           hls_thresholds:
-            wigt: 0.0124         # Modified Normalized Difference Wetness Index (MNDWI) Threshold
-            awgt: 0.0            # Automated Water Extent Shadow Threshold
-            pswt_1_mndwi: -0.44  # Partial Surface Water Test-1 MNDWI Threshold
-            pswt_1_nir: 1500     # Partial Surface Water Test-1 NIR Threshold
-            pswt_1_swir1: 900    # Partial Surface Water Test-1 SWIR1 Threshold
-            pswt_1_ndvi: 0.7     # Partial Surface Water Test-1 NDVI Threshold
-            pswt_2_mndwi: -0.5   # Partial Surface Water Test-2 MNDWI Threshold
-            pswt_2_blue: 1000    # Partial Surface Water Test-2 Blue Threshold
-            pswt_2_nir: 2500     # Partial Surface Water Test-2 NIR Threshold
-            pswt_2_swir1: 3000   # Partial Surface Water Test-2 SWIR1 Threshold
-            pswt_2_swir2: 1000   # Partial Surface Water Test-2 SWIR2 Threshold
+            wigt: {{ data.hls_thresholds.wigt or 0.0124 }}         # Modified Normalized Difference Wetness Index (MNDWI) Threshold
+            awgt: {{ data.hls_thresholds.awgt or 0.0 }}            # Automated Water Extent Shadow Threshold
+            pswt_1_mndwi: {{ data.hls_thresholds.pswt_1_mndwi or -0.44 }}  # Partial Surface Water Test-1 MNDWI Threshold
+            pswt_1_nir: {{ data.hls_thresholds.pswt_1_nir or 1500 }}     # Partial Surface Water Test-1 NIR Threshold
+            pswt_1_swir1: {{ data.hls_thresholds.pswt_1_swir1 or 900 }}    # Partial Surface Water Test-1 SWIR1 Threshold
+            pswt_1_ndvi: {{ data.hls_thresholds.pswt_1_ndvi or 0.7 }}     # Partial Surface Water Test-1 NDVI Threshold
+            pswt_2_mndwi: {{ data.hls_thresholds.pswt_2_mndwi or -0.5 }}   # Partial Surface Water Test-2 MNDWI Threshold
+            pswt_2_blue: {{ data.hls_thresholds.pswt_2_blue or 1000 }}    # Partial Surface Water Test-2 Blue Threshold
+            pswt_2_nir: {{ data.hls_thresholds.pswt_2_nir or 2500 }}     # Partial Surface Water Test-2 NIR Threshold
+            pswt_2_swir1: {{ data.hls_thresholds.pswt_2_swir1 or 3000 }}   # Partial Surface Water Test-2 SWIR1 Threshold
+            pswt_2_swir2: {{ data.hls_thresholds.pswt_2_swir2 or 1000 }}   # Partial Surface Water Test-2 SWIR2 Threshold

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_HLS
@@ -65,6 +65,72 @@
       "from": "value",
       "type": "text",
       "value": "pge_output_dir"
+    },
+    {
+      "name": "wigt",
+      "from": "value",
+      "type": "number",
+      "value": "0.0124"
+    },
+    {
+      "name": "awgt",
+      "from": "value",
+      "type": "number",
+      "value": "0.0"
+    },
+    {
+      "name": "pswt_1_mndwi",
+      "from": "value",
+      "type": "number",
+      "value": "-0.44"
+    },
+    {
+      "name": "pswt_1_nir",
+      "from": "value",
+      "type": "number",
+      "value": "1500"
+    },
+    {
+      "name": "pswt_1_swir1",
+      "from": "value",
+      "type": "number",
+      "value": "900"
+    },
+    {
+      "name": "pswt_1_ndvi",
+      "from": "value",
+      "type": "number",
+      "value": "0.7"
+    },
+    {
+      "name": "pswt_2_mndwi",
+      "from": "value",
+      "type": "number",
+      "value": "-0.5"
+    },
+    {
+      "name": "pswt_2_blue",
+      "from": "value",
+      "type": "number",
+      "value": "1000"
+    },
+    {
+      "name": "pswt_2_nir",
+      "from": "value",
+      "type": "number",
+      "value": "2500"
+    },
+    {
+      "name": "pswt_2_swir1",
+      "from": "value",
+      "type": "number",
+      "value": "3000"
+    },
+    {
+      "name": "pswt_2_swir2",
+      "from": "value",
+      "type": "number",
+      "value": "1000"
     }
   ]
 }

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_HLS_on_demand
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_HLS_on_demand
@@ -1,0 +1,150 @@
+{
+  "label": "SCIFLO_L3_HLS_on_demand",
+  "allowed_accounts": [ "ops" ],
+  "submission_type": "individual",
+  "enable_dedup": true,
+  "params": [
+    {
+      "name": "module_path",
+      "from": "value",
+      "type": "text",
+      "value": "/home/ops/verdi/ops/opera-pcm"
+    },
+    {
+      "name": "wf_dir",
+      "from": "value",
+      "type": "text",
+      "value": "/home/ops/verdi/ops/opera-pcm/opera_chimera/wf_xml"
+    },
+    {
+      "name": "wf_name",
+      "from": "value",
+      "type": "text",
+      "value": "L3_HLS"
+    },
+    {
+      "name": "accountability_module_path",
+      "from": "value",
+      "type": "text",
+      "value": "opera_chimera.accountability"
+    },
+    {
+      "name": "accountability_class",
+      "from": "value",
+      "type": "text",
+      "value": "OperaAccountability"
+    },
+    {
+      "name": "pge_runconfig_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_runconfig_dir"
+    },
+    {
+      "name": "pge_input_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_input_dir"
+    },
+    {
+      "name": "pge_output_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_output_dir"
+    },
+    {
+      "name":"input_dataset_id",
+      "from":"submitter",
+      "type":"text",
+      "optional": false
+    },
+    {
+      "name": "wigt",
+      "from": "submitter",
+      "type": "number",
+      "default": "0.0124",
+      "optional": true,
+      "placeholder": "0.0124"
+    },
+    {
+      "name": "awgt",
+      "from": "submitter",
+      "type": "number",
+      "default": "0.0",
+      "optional": true,
+      "placeholder": "0.0"
+    },
+    {
+      "name": "pswt_1_mndwi",
+      "from": "submitter",
+      "type": "number",
+      "default": "-0.44",
+      "optional": true,
+      "placeholder": "-0.44"
+    },
+    {
+      "name": "pswt_1_nir",
+      "from": "submitter",
+      "type": "number",
+      "default": "1500",
+      "optional": true,
+      "placeholder": "1500"
+    },
+    {
+      "name": "pswt_1_swir1",
+      "from": "submitter",
+      "type": "number",
+      "default": "900",
+      "optional": true,
+      "placeholder": "900"
+    },
+    {
+      "name": "pswt_1_ndvi",
+      "from": "submitter",
+      "type": "number",
+      "default": "0.7",
+      "optional": true,
+      "placeholder": "0.7"
+    },
+    {
+      "name": "pswt_2_mndwi",
+      "from": "submitter",
+      "type": "number",
+      "default": "-0.5",
+      "optional": true,
+      "placeholder": "-0.5"
+    },
+    {
+      "name": "pswt_2_blue",
+      "from": "submitter",
+      "type": "number",
+      "default": "1000",
+      "optional": true,
+      "placeholder": "1000"
+    },
+    {
+      "name": "pswt_2_nir",
+      "from": "submitter",
+      "type": "number",
+      "default": "2500",
+      "optional": true,
+      "placeholder": "2500"
+    },
+    {
+      "name": "pswt_2_swir1",
+      "from": "submitter",
+      "type": "number",
+      "default": "3000",
+      "optional": true,
+      "placeholder": "3000"
+    },
+    {
+      "name": "pswt_2_swir2",
+      "from": "submitter",
+      "type": "number",
+      "default": "1000",
+      "optional": true,
+      "placeholder": "1000"
+    }
+  ]
+}

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -64,6 +64,50 @@
     {
       "name": "pge_output_dir",
       "destination": "context"
+    },
+    {
+      "name": "wigt",
+      "destination": "context"
+    },
+    {
+      "name": "awgt",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_mndwi",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_nir",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_swir1",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_ndvi",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_mndwi",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_blue",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_nir",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_swir1",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_swir2",
+      "destination": "context"
     }
   ]
 }

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
@@ -1,0 +1,105 @@
+{
+  "command": "/home/ops/verdi/ops/opera-pcm/on_demand/run_on_demand.sh",
+  "disk_usage":"10GB",
+  "soft_time_limit": 3600,
+  "time_limit": 3660,
+  "imported_worker_files": {
+    "$HOME/.netrc": "/home/ops/.netrc",
+    "$HOME/.aws": "/home/ops/.aws",
+    "$HOME/verdi/etc/settings.yaml": "/home/ops/verdi/ops/opera-pcm/conf/settings.yaml"
+  },
+  "dependency_images": [
+    {
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.1.0.tar.gz",
+      "container_mappings": {
+        "$HOME/.netrc": ["/root/.netrc"],
+        "$HOME/.aws": ["/root/.aws", "ro"]
+      }
+    }
+  ],
+  "recommended-queues": [ "opera-job_worker-sciflo-l3_dswx_hls"],
+  "post": [ "hysds.utils.triage"],
+  "params": [
+    {
+      "name": "module_path",
+      "destination": "context"
+    },
+    {
+      "name": "wf_dir",
+      "destination": "context"
+    },
+    {
+      "name": "wf_name",
+      "destination": "context"
+    },
+    {
+      "name": "accountability_module_path",
+      "destination": "context"
+    },
+    {
+      "name": "accountability_class",
+      "destination": "context"
+    },
+    {
+      "name": "pge_runconfig_dir",
+      "destination": "context"
+    },
+    {
+      "name": "pge_input_dir",
+      "destination": "context"
+    },
+    {
+      "name": "pge_output_dir",
+      "destination": "context"
+    },
+    {
+      "name":"input_dataset_id",
+      "destination": "context"
+    },
+    {
+      "name": "wigt",
+      "destination": "context"
+    },
+    {
+      "name": "awgt",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_mndwi",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_nir",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_swir1",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_1_ndvi",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_mndwi",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_blue",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_nir",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_swir1",
+      "destination": "context"
+    },
+    {
+      "name": "pswt_2_swir2",
+      "destination": "context"
+    }
+  ]
+}

--- a/on_demand/run_on_demand.py
+++ b/on_demand/run_on_demand.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+"""
+Run an on-demand PGE/Sciflo job
+"""
+
+import argparse
+import os
+import sys
+
+from chimera.run_sciflo import main as run_sciflo
+from commons.es_connection import get_grq_es
+from commons.logger import logger
+from opera_chimera.constants.opera_chimera_const import (
+    OperaChimeraConstants as oc_const,
+)
+from util.ctx_util import JobContext
+
+ancillary_es = get_grq_es(logger)
+
+BASE_PATH = os.path.dirname(__file__)
+
+
+def main(context_file):
+    context_file = os.path.abspath(context_file)
+
+    logger.info(f'Running on-demand job with context file {context_file}')
+
+    if not os.path.exists(context_file):
+        raise RuntimeError(f'Context file {context_file} cannot be found')
+
+    # Read the provided context file
+    jc = JobContext(context_file)
+    job_context = jc.ctx
+
+    logger.info(f"job_context: {job_context}")
+
+    if oc_const.INPUT_DATASET_ID not in job_context:
+        raise RuntimeError(f'No {oc_const.INPUT_DATASET_ID} key set in provided context')
+
+    # Extract the dataset ID, and append "_state_config" for the elasticsearch
+    # lookup
+    input_dataset_id = job_context[oc_const.INPUT_DATASET_ID]
+    input_dataset_id += "_state_config"
+
+    logger.info(f"Querying metadata for input dataset ID {input_dataset_id}")
+
+    index = "grq_*-state-config"
+    query = {
+        "query": {
+            "bool": {
+                "must": [
+                    {
+                        "term": {"_id": input_dataset_id}
+                    }
+                ]
+            }
+        }
+    }
+
+    try:
+        # Query elasticsearch for the provided dataset ID
+        result = ancillary_es.search(body=query, index=index)
+
+        hits = result.get("hits", {}).get("hits", [])
+        logger.info("query hit count: {}".format(len(hits)))
+
+        if len(hits) > 0:
+            # Update _context.json with fields needed by sciflo
+            metadata = hits[0]["_source"]["metadata"]
+            product_metadata = {'metadata': metadata}
+
+            logger.info(f"Setting product_metadata in context: {product_metadata}")
+            jc.set('product_metadata', product_metadata)
+
+            dataset_type = hits[0]["_source"][oc_const.DATASET_TYPE]
+            logger.info(f"Setting dataset_type in context: {dataset_type}")
+            jc.set(oc_const.DATASET_TYPE, dataset_type)
+
+            logger.info(f"Updating input_dataset_id to {input_dataset_id}")
+            jc.set(oc_const.INPUT_DATASET_ID, input_dataset_id)
+
+            jc.save()
+        else:
+            raise RuntimeError(
+                f"No hits returned querying for dataset ID {input_dataset_id}.\n"
+                f"Please ensure the dataset has been ingested before reattempting "
+                f"the on-demand job."
+            )
+    except Exception as err:
+        raise RuntimeError(
+            f"Exception caught while querying for dataset ID {input_dataset_id}, "
+            f"reason: {str(err)}"
+        )
+
+    if not all([key in job_context for key in ['wf_dir', 'wf_name']]):
+        raise RuntimeError(
+            'Workflow data missing from provided context.\n'
+            'Please ensure the "wf_dir" and "wf_name" keys are set properly.'
+        )
+
+    # Hand off to sciflo to execute the on-demand PGE job
+    sfl_file = "/".join([job_context['wf_dir'], job_context['wf_name'] + '.sf.xml'])
+    output_folder = "output"
+
+    return run_sciflo(sfl_file, context_file, output_folder)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("context_file", help="HySDS context file")
+    args = parser.parse_args()
+    sys.exit(main(args.context_file))

--- a/on_demand/run_on_demand.sh
+++ b/on_demand/run_on_demand.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+
+# source PGE env
+export OPERA_HOME=/home/ops/verdi/ops/opera-pcm
+export VERDI_ROOT=$(dirname $(dirname "${OPERA_HOME}"))
+export CHIMERA_HOME=$VERDI_ROOT/ops/chimera
+export PYTHONPATH=$BASE_PATH:$OPERA_HOME:$CHIMERA_HOME:$PYTHONPATH
+export PATH=$BASE_PATH:$PATH
+export PYTHONDONTWRITEBYTECODE=1
+
+# source environment
+source $VERDI_ROOT/bin/activate
+
+echo "##########################################" 1>&2
+echo -n "Running run_on_demand.py: " 1>&2
+date 1>&2
+python $BASE_PATH/run_on_demand.py _context.json > run_on_demand.log 2>&1
+STATUS=$?
+echo -n "Finished running run_on_demand.py: " 1>&2
+date 1>&2
+if [ $STATUS -ne 0 ]; then
+  echo "Failed to run run_on_demand.py." 1>&2
+  cat run_on_demand.log 1>&2
+  echo "{}"
+  exit $STATUS
+fi

--- a/opera_chimera/configs/pge_configs/PGE_L3_HLS.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_HLS.yaml
@@ -26,6 +26,18 @@ runconfig:
     product_path: output_dir
     # Scratch path is defined relative to output_dir to avoid file system permission issues
     scratch_path: output_dir/scratch_dir
+  hls_thresholds:
+    wigt: __CHIMERA_VAL__           # Modified Normalized Difference Wetness Index (MNDWI) Threshold
+    awgt: __CHIMERA_VAL__           # Automated Water Extent Shadow Threshold
+    pswt_1_mndwi: __CHIMERA_VAL__   # Partial Surface Water Test-1 MNDWI Threshold
+    pswt_1_nir: __CHIMERA_VAL__     # Partial Surface Water Test-1 NIR Threshold
+    pswt_1_swir1: __CHIMERA_VAL__   # Partial Surface Water Test-1 SWIR1 Threshold
+    pswt_1_ndvi: __CHIMERA_VAL__    # Partial Surface Water Test-1 NDVI Threshold
+    pswt_2_mndwi: __CHIMERA_VAL__   # Partial Surface Water Test-2 MNDWI Threshold
+    pswt_2_blue: __CHIMERA_VAL__    # Partial Surface Water Test-2 Blue Threshold
+    pswt_2_nir: __CHIMERA_VAL__     # Partial Surface Water Test-2 NIR Threshold
+    pswt_2_swir1: __CHIMERA_VAL__   # Partial Surface Water Test-2 SWIR1 Threshold
+    pswt_2_swir2: __CHIMERA_VAL__   # Partial Surface Water Test-2 SWIR2 Threshold
   cnm_version: "__CHIMERA_VAL__"
 
   product_paths:
@@ -34,6 +46,7 @@ runconfig:
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
+  - get_metadata
   - get_input_filepaths_from_state_config
   - get_cnm_version
   - set_daac_product_type
@@ -47,6 +60,19 @@ postprocess:
 
 # For any of the precondition evaluation steps listed in the preconditions area,
 # specify function arguments here
+get_metadata:
+  keys:
+    - wigt
+    - awgt
+    - pswt_1_mndwi
+    - pswt_1_nir
+    - pswt_1_swir1
+    - pswt_1_ndvi
+    - pswt_2_mndwi
+    - pswt_2_blue
+    - pswt_2_nir
+    - pswt_2_swir1
+    - pswt_2_swir2
 
 get_dems:
   # Specify a specific bounding box to obtain the corresponding DEM for.


### PR DESCRIPTION
This PR adds a new job spec which allows submission of an on-demand DSWx-HLS PGE job from the Tosca UI:

<img width="751" alt="Screen Shot 2022-07-08 at 12 50 16 PM" src="https://user-images.githubusercontent.com/72415379/178061146-313a2137-d823-4fdc-b816-d4ec14a54b99.png">

The job allows the operator to tweak the available DSWx-HLS parameters, and to specify the HLS dataset ID to run the PGE with. If the HLS dataset has not been ingested (no entry found in the state config elasticsearch index), the job will fail.