### PR TITLE
DSWx-HLS PGE 1.0.0-rc.2.0 update

### DIFF
--- a/cluster_provisioning/dev-common/variables.tf
+++ b/cluster_provisioning/dev-common/variables.tf
@@ -344,7 +344,7 @@ variable "pge_names" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-rc.1.0"
+  default = "1.0.0-rc.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/dev-e2e-baseline-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-baseline-pge/variables.tf
@@ -1,6 +1,6 @@
 # globals
 #
-# venue : userId 
+# venue : userId
 # counter : 1-n
 # private_key_file : the equivalent to .ssh/id_rsa or .pem file
 #
@@ -369,7 +369,7 @@ variable "pge_snapshots_date" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-er.3.0"
+  default = "1.0.0-er.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -361,7 +361,7 @@ variable "pge_snapshots_date" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-er.3.0"
+  default = "1.0.0-er.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -1,6 +1,6 @@
 # globals
 #
-# venue : userId 
+# venue : userId
 # counter : 1-n
 # private_key_file : the equivalent to .ssh/id_rsa or .pem file
 #
@@ -444,7 +444,7 @@ variable "pge_snapshots_date" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-er.3.0"
+  default = "1.0.0-er.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -365,7 +365,7 @@ variable "pge_names" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-rc.1.0"
+  default = "1.0.0-rc.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -1,6 +1,6 @@
 # globals
 #
-# venue : userId 
+# venue : userId
 # counter : 1-n
 # private_key_file : the equivalent to .ssh/id_rsa or .pem file
 #
@@ -361,7 +361,7 @@ variable "pge_snapshots_date" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-er.3.0"
+  default = "1.0.0-er.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -372,7 +372,7 @@ variable "pge_names" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-rc.1.0"
+  default = "1.0.0-rc.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -29,7 +29,7 @@ variable "pge_snapshots_date" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-er.3.0"
+  default = "1.0.0-er.2.0"
 }
 
 variable "private_key_file" {

--- a/cluster_provisioning/int/variables.tf
+++ b/cluster_provisioning/int/variables.tf
@@ -336,7 +336,7 @@ variable "pge_names" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-rc.1.0"
+  default = "1.0.0-rc.2.0"
 }
 
 variable "crid" {

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -399,7 +399,7 @@ variable "pge_snapshots_date" {
 }
 
 variable "pge_release" {
-  default = "1.0.0-rc.1.0"
+  default = "1.0.0-rc.2.0"
 }
 
 variable "crid" {

--- a/conf/RunConfig.yaml.L3_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_HLS.jinja2.tmpl
@@ -17,7 +17,6 @@ RunConfig:
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        ProductCounter: 001
         OutputProductPath: {{ data.product_path_group.product_path }}
         ScratchPath: {{ data.product_path_group.scratch_path }}
       PrimaryExecutable:
@@ -27,8 +26,8 @@ RunConfig:
           - proteus-0.1/bin/dswx_hls.py
           - --full-log-format
         ErrorCodeBase: 100000
-        SchemaPath: dswx_hls_sas_schema.yaml
-        IsoTemplatePath: OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
+        SchemaPath: /home/conda/opera/pge/dswx_hls/schema/dswx_hls_sas_schema.yaml
+        IsoTemplatePath: /home/conda/opera/pge/dswx_hls/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
       QAExecutable:
         Enabled: False
         ProgramPath:

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -26,14 +26,14 @@ L3_HLS:
       # Pattern for parsing output image filenames, such as:
       # * "OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20220105T143156Z_v0.1_001_B01_WTF.tiff"
       # * "OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20220207T163901Z_v0.1_001_B09_CLOUD.tiff"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<collection_version>v\d+[.]\d+)_(?P<product_counter>\d{3}))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tiff)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<collection_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tiff)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # * "OPERA_L3_DSWx_HLS_LANDSAT-8_T22VEQ_20210905T143156_v2.0_001.catalog.json"
       # * "OPERA_L3_DSWx_HLS_SENTINEL-2A_T15SXR_20210907T163901_v2.0_001.iso.xml"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<collection_version>v\d+[.]\d+)_(?P<product_counter>\d{3}))[.](?P<ext>log|qa\.log|iso\.xml|catalog\.json)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<collection_version>v\d+[.]\d+))[.](?P<ext>log|qa\.log|iso\.xml|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames

--- a/conf/schema/RunConfig_schema.L3_HLS.yaml
+++ b/conf/schema/RunConfig_schema.L3_HLS.yaml
@@ -13,7 +13,6 @@ RunConfig:
         AncillaryFileMap: map(str(), key=str(), min=0)
 
       ProductPathGroup:
-        ProductCounter: int(min=1, max=999, required=False)
         OutputProductPath: str(required=True)
         ScratchPath: str(required=True)
 

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -220,7 +220,7 @@
       "ipath": "hysds::data/L3_DSWx_HLS",
       "level": "L3",
       "type": "L3_DSWx_HLS",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<collection_version>v\\d+[.]\\d+)_(?P<product_counter>\\d{3}))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<collection_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -220,7 +220,7 @@
       "ipath": "hysds::data/L3_DSWx_HLS",
       "level": "L3",
       "type": "L3_DSWx_HLS",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<collection_version>v\\d+[.]\\d+)_(?P<product_counter>\\d{3}))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<collection_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -81,7 +81,7 @@ PRODUCT_TYPES:
         # This pattern groups the metadata information in the filename using named groups.
         #
         # Note: POSIX character class "[[:alnum:]]" is not supported in python's re, and so has been replaced with "[^\W_]" here.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<collection_version>v\d+[.]\d+)_(?P<product_counter>\d{3}))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tiff)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<sensor>S2A|S2B|L8)_(?P<spacing>30)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<collection_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tiff)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:

--- a/opera_chimera/configs/pge_configs/PGE_L3_HLS.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_HLS.yaml
@@ -143,4 +143,4 @@ localize_groups:
 input_file_base_name_regexes: # regexes taken from settings.yaml > L2_HLS_L30 and L2_HLS_S30
     - '(?P<id>(?P<product_shortname>HLS[.]L30)[.](?P<tile_id>T[^\W_]{5})[.](?P<acquisition_ts>(?P<year>\d{4})(?P<day_of_year>\d{3})T(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2}))[.](?P<collection_version>v\d+[.]\d+)_state_config)$'
     - '(?P<id>(?P<product_shortname>HLS[.]S30)[.](?P<tile_id>T[^\W_]{5})[.](?P<acquisition_ts>(?P<year>\d{4})(?P<day_of_year>\d{3})T(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2}))[.](?P<collection_version>v\d+[.]\d+)_state_config)$'
-output_base_name: OPERA_L3_DSWx_HLS_{sensor}_30_{tile_id}_{acquisition_ts}Z_{creation_ts}Z_{collection_version}_{product_counter}
+output_base_name: OPERA_L3_DSWx_HLS_{sensor}_30_{tile_id}_{acquisition_ts}Z_{creation_ts}Z_{collection_version}

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -14,7 +14,7 @@ REPO_DIR = abspath(join(TEST_DIR, os.pardir, os.pardir))
 
 def test_simulate_run_pge__when_product_shortname_is_l30():
     # before
-    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001*.tiff'):
+    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0*.tiff'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_HLS.yaml')
@@ -41,26 +41,26 @@ def test_simulate_run_pge__when_product_shortname_is_l30():
         )
     # ASSERT
     for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
-        assert Path(f'/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001_B{band_idx:02}_{band_name}.tiff').exists()
+        assert Path(f'/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_B{band_idx:02}_{band_name}.tiff').exists()
 
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.log').exists()
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.qa.log').exists()
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.catalog.json').exists()
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.iso.xml').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.log').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.qa.log').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.catalog.json').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.iso.xml').exists()
 
     # after
-    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001*.tiff'):
+    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0*.tiff'):
         Path(path).unlink(missing_ok=True)
 
-    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.log').unlink(missing_ok=False)
-    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.qa.log').unlink(missing_ok=False)
-    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.catalog.json').unlink(missing_ok=False)
-    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0_001.iso.xml').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.log').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.qa.log').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.catalog.json').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_L8_30_T22VEQ_20210905T143156Z_20210905T143156Z_v2.0.iso.xml').unlink(missing_ok=False)
 
 
 def test_simulate_run_pge__when_product_shortname_is_s30():
     # before
-    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001*.tiff'):
+    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0*.tiff'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_HLS.yaml')
@@ -88,21 +88,21 @@ def test_simulate_run_pge__when_product_shortname_is_s30():
 
     # ASSERT
     for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
-        assert Path(f'/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001_B{band_idx:02}_{band_name}.tiff').exists()
+        assert Path(f'/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_B{band_idx:02}_{band_name}.tiff').exists()
 
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.log').exists()
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.qa.log').exists()
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.catalog.json').exists()
-    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.iso.xml').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.log').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.qa.log').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.catalog.json').exists()
+    assert Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.iso.xml').exists()
 
     # after
-    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001*.tiff'):
+    for path in glob.iglob('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0*.tiff'):
         Path(path).unlink(missing_ok=False)
 
-    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.log').unlink(missing_ok=False)
-    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.qa.log').unlink(missing_ok=False)
-    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.catalog.json').unlink(missing_ok=False)
-    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0_001.iso.xml').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.log').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.qa.log').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.catalog.json').unlink(missing_ok=False)
+    Path('/tmp/OPERA_L3_DSWx_HLS_S2A_30_T15SXR_20210907T163901Z_20210907T163901Z_v2.0.iso.xml').unlink(missing_ok=False)
 
 
 def test_simulate_run_pge__when_product_shortname_is_unsupported():

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -64,8 +64,7 @@ def simulate_run_pge(runconfig: Dict, pge_config: Dict, context: Dict, output_di
             acquisition_ts=datetime.strptime(match.groupdict()['acquisition_ts'], '%Y%jT%H%M%S').strftime('%Y%m%dT%H%M%S'),
             # make creation time a duplicate of the acquisition time for ease of testing
             creation_ts=datetime.strptime(match.groupdict()['acquisition_ts'], '%Y%jT%H%M%S').strftime('%Y%m%dT%H%M%S'),
-            collection_version=match.groupdict()['collection_version'],
-            product_counter="001",
+            collection_version=match.groupdict()['collection_version']
         )
         metadata = {}
         simulate_output(pge_name, metadata, base_name, output_dir, output_types[output_type])


### PR DESCRIPTION
This PR updates PCM to utilize the 1.0.0-rc.2.0 version of the DSWx-HLS PGE.

Notable updates with the new PGE version:

- Utilizes the CalVal release of the DSWx-HLS SAS
- Fixes several issues with the ISO 19115 metadata file sent to PO.DAAC
- Product Counter usage has been removed from all output file names (PCM updated to match)