### PR TITLE
feat(tests): fix typo

### DIFF
--- a/integration/test_integration.py
+++ b/integration/test_integration.py
@@ -5,7 +5,6 @@ from pathlib import Path
 import conftest
 from int_test_util import \
     mock_cnm_r_success_sns, \
-    mock_cnm_r_success_sqs, \
     upload_file, \
     wait_for_cnm_s_success, \
     wait_for_cnm_r_success, \
@@ -216,12 +215,11 @@ def test_s30():
     assert_cnm_s_success(response)
 
     logging.info("TRIGGER AND CHECK FOR CNM-R SUCCESS")
-    mock_cnm_r_success_sqs(id="OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0")
+    mock_cnm_r_success_sns(id="OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0")
 
     logging.info("Sleeping for CNM-R execution...")
     sleep_for(150)
 
-    mock_cnm_r_success(id="OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0")
     response = wait_for_cnm_r_success(_id="OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0", index="grq_v2.0_l3_dswx_hls")
 
     assert_cnm_r_success(response)


### PR DESCRIPTION
typo causing smoke tests to fail due to missing function with given name. function was renamed previously.

Refs #205