### PR TITLE
R2 PGE DEM Staging

### DIFF
--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -27,12 +27,12 @@ runconfig:
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
-  - get_slc_burst_id
-  - get_safe_file_path
+  - get_slc_s1_burst_id
+  - get_slc_s1_safe_file
+  - get_slc_s1_orbit_file
+  - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
   - get_cnm_version
   - set_daac_product_type
-  - get_cslc_orbit_file
-  - get_cslc_dem
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
@@ -44,11 +44,9 @@ get_cslc_orbit_file:
   s3_bucket: "opera-dev-lts-fwd-collinss"
   s3_key: "S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF"
 
-get_cslc_dem:
-  # TODO: utilize a sample DEM provided by ADT until we figure out how to
-  #       derive a region boundary based on the input product
-  s3_bucket: "opera-dev-lts-fwd-collinss"
-  s3_key: "dem_4326.tiff"
+get_cslc_s1_dem:
+  # The s3 bucket containing the global DEM(s) to download regions from
+  s3_bucket: "opera-dem"
 
 set_daac_product_type:
   template: OPERA_L2_CSLC_S1_{cnm_version}

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml
@@ -50,7 +50,7 @@ preconditions:
   - get_input_filepaths_from_state_config
   - get_cnm_version
   - set_daac_product_type
-  - get_dems
+  - get_dswx_hls_dem
   - get_landcover
   - get_worldcover
 
@@ -74,7 +74,7 @@ get_metadata:
     - pswt_2_swir1
     - pswt_2_swir2
 
-get_dems:
+get_dswx_hls_dem:
   # Specify a specific bounding box to obtain the corresponding DEM for.
   # If not provided, the bounding box will be determined based on the tile code
   # of the HLS dataset to be processed

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -217,7 +217,7 @@ class OperaChimeraConstants(ChimeraConstants):
 
     GET_DEM_BBOX = "get_dem_bbox"
 
-    GET_DEMS = "get_dems"
+    GET_DSWX_HLS_DEM = "get_dswx_hls_dem"
 
     GET_LANDCOVER = "get_landcover"
 

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -211,9 +211,13 @@ class OperaChimeraConstants(ChimeraConstants):
 
     BBOX = "bbox"
 
-    GET_CSLC_ORBIT_FILE = "get_cslc_orbit_file"
+    GET_SLC_S1_BURST_ID = "get_slc_s1_burst_id"
 
-    GET_CSLC_DEM = "get_cslc_dem"
+    GET_SLC_S1_SAFE_FILE = "get_slc_s1_safe_file"
+
+    GET_SLC_S1_ORBIT_FILE = "get_slc_s1_orbit_file"
+
+    GET_SLC_S1_DEM = "get_slc_s1_dem"
 
     GET_DEM_BBOX = "get_dem_bbox"
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -869,7 +869,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return latlong
 
-    def get_dems(self):
+    def get_dswx_hls_dem(self):
         """
         This function downloads dems over the bbox provided in the PGE yaml config,
         or derives the appropriate bbox based on the tile code of the product's
@@ -885,10 +885,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         output_filepath = os.path.join(working_dir, 'dem.vrt')
 
         # get s3_bucket param
-        s3_bucket = self._pge_config.get(oc_const.GET_DEMS, {}).get(oc_const.S3_BUCKET)
+        s3_bucket = self._pge_config.get(oc_const.GET_DSWX_HLS_DEM, {}).get(oc_const.S3_BUCKET)
 
         # get bbox param
-        bbox = self._pge_config.get(oc_const.GET_DEMS, {}).get(oc_const.BBOX)
+        bbox = self._pge_config.get(oc_const.GET_DSWX_HLS_DEM, {}).get(oc_const.BBOX)
 
         if bbox:
             # Convert to list if we were given a space-delimited string
@@ -910,8 +910,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
             raise RuntimeError(
                 f"Can not determine a region to obtain DEM for.\n"
                 f"The product metadata must specify an MGRS tile code, "
-                f"or the 'bbox' parameter must be provided in the '{oc_const.GET_DEMS}' "
-                f"area of the PGE config"
+                f"or the 'bbox' parameter must be provided in the "
+                f"'{oc_const.GET_DSWX_HLS_DEM}' area of the PGE config"
             )
 
         # Set up arguments to stage_dem.py

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -11,10 +11,12 @@ import json
 import os
 import re
 import traceback
+import zipfile
 from datetime import datetime
+from lxml import etree as ET
 from typing import Dict, List
+from urllib.parse import urlparse
 
-import boto3
 import psutil
 from chimera.precondition_functions import PreConditionFunctions
 
@@ -708,8 +710,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
                 )
             )
 
-    def get_slc_burst_id(self):
-        """Returns the SLC burst ID to be processed with a CSLC-S1 job"""
+    def get_slc_s1_burst_id(self):
+        """Returns the SLC burst ID to be processed with a S1 based job"""
         # TODO: dummy implementation until we figure out how to properly source
         #       the burst ID (or IDs?) from the input SAFE file
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
@@ -723,31 +725,59 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
-    def get_safe_file_path(self):
+    def get_slc_s1_safe_file(self):
         """
-        Obtains the s3 URI of the input SAFE file for use with CSLC-S1 job.
-        This URI is then configured as the value of safe_file_path within the
-        interim RunConfig. Chimera will then localize this file from S3 to
-        local disk before starting the OPERA PGE wrapper.
+        Obtains the input SAFE file for use with an CSLC-S1 or RTC-S1 job.
+        This local path is then configured as the value of safe_file_path within the
+        interim RunConfig.
+
+        The SAFE file is manually localized here, so it will be available for
+        use when obtaining the corresponding DEM.
         """
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        # get the working directory
+        working_dir = get_working_dir()
 
         metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
 
         s3_product_path = f"{self._context['product_path']}/{metadata['FileName']}"
+        parsed_s3_url = urlparse(s3_product_path)
+        s3_path = parsed_s3_url.path
+
+        # Strip leading forward slash from url path
+        if s3_path.startswith('/'):
+            s3_path = s3_path[1:]
+
+        # Bucket name should be first part of url path, the key is the rest
+        s3_bucket = s3_path.split('/')[0]
+        s3_key = '/'.join(s3_path.split('/')[1:])
+
+        output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
+
+        logger.info(f"working_dir : {working_dir}")
+        logger.info(f"s3_product_path : {s3_product_path}")
+        logger.info(f"s3_bucket: {s3_bucket}")
+        logger.info(f"output_filepath: {output_filepath}")
+
+        pge_metrics = download_object_from_s3(
+            s3_bucket, s3_key, output_filepath, filetype="SAFE"
+        )
+
+        write_pge_metrics(os.path.join(working_dir, "pge_metrics.json"), pge_metrics)
 
         rc_params = {
-            oc_const.SAFE_FILE_PATH: s3_product_path
+            oc_const.SAFE_FILE_PATH: output_filepath
         }
 
         logger.info(f"rc_params : {rc_params}")
 
         return rc_params
 
-    def get_cslc_orbit_file(self):
+    def get_slc_s1_orbit_file(self):
         """
-        Copies a static orbit file configured for use with a CSLC-S1 job
-        to the job's local working area.
+        Copies a static orbit file configured for use with a CSLC-S1 or RTC-S1
+        job to the job's local working area.
 
         TODO this is a temporary implementation for initial testing purposes
              eventually this function will need to determine the appropriate
@@ -760,8 +790,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         logger.info("working_dir : {}".format(working_dir))
 
-        s3_bucket = self._pge_config.get(oc_const.GET_CSLC_ORBIT_FILE, {}).get(oc_const.S3_BUCKET)
-        s3_key = self._pge_config.get(oc_const.GET_CSLC_ORBIT_FILE, {}).get(oc_const.S3_KEY)
+        s3_bucket = self._pge_config.get(oc_const.GET_SLC_S1_ORBIT_FILE, {}).get(oc_const.S3_BUCKET)
+        s3_key = self._pge_config.get(oc_const.GET_SLC_S1_ORBIT_FILE, {}).get(oc_const.S3_KEY)
 
         output_filepath = os.path.join(working_dir, s3_key)
 
@@ -779,34 +809,93 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
-    def get_cslc_dem(self):
+    def get_slc_s1_dem(self):
         """
-        Copies a static DEM file configured for use with a CSLC-S1 job
-        to the job's local working area.
+        Stages a DEM file corresponding to the region covered by an input
+        S1 SLC SAFE archive.
 
-        TODO this may or may not be a temporary implementation based on whether
-             the static dem provided by ADT is suitable for all CSLC-S1 jobs
+        The manifest.safe file is extracted from the archive and used to
+        determine the lat/lon bounding box of the S1 swath. This bbox is then
+        used with the stage_dem tool to obtain the appropriate DEM.
+
         """
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 
         # get the working directory
         working_dir = get_working_dir()
 
-        logger.info("working_dir : {}".format(working_dir))
+        # get the local file path of the input SAFE archive (should have already
+        # been downloaded by the get_safe_file precondition function)
+        safe_file_path = self._job_params.get(oc_const.SAFE_FILE_PATH)
+        safe_file_name = os.path.splitext(os.path.basename(safe_file_path))[0]
 
-        s3_bucket = self._pge_config.get(oc_const.GET_CSLC_DEM, {}).get(oc_const.S3_BUCKET)
-        s3_key = self._pge_config.get(oc_const.GET_CSLC_DEM, {}).get(oc_const.S3_KEY)
+        # get s3_bucket param
+        s3_bucket = self._pge_config.get(oc_const.GET_SLC_S1_DEM, {}).get(oc_const.S3_BUCKET)
 
-        output_filepath = os.path.join(working_dir, s3_key)
+        output_filepath = os.path.join(working_dir, 'dem.vrt')
 
-        pge_metrics = download_ancillary_from_s3(
-            s3_bucket, s3_key, output_filepath, filetype="Static DEM"
-        )
+        logger.info(f"working_dir : {working_dir}")
+        logger.info(f"safe_file_path: {safe_file_path}")
+        logger.info(f"s3_bucket: {s3_bucket}")
+        logger.info(f"output_filepath: {output_filepath}")
+
+        if not safe_file_path:
+            raise RuntimeError(f'No value set for {oc_const.SAFE_FILE_PATH} in '
+                               f'job parameters. Please ensure the get_safe_file '
+                               f'precondition function has been run prior to this one.')
+
+        # Extract the contents of the manifest.safe XML file from the top-level
+        # of the zip archive. This file contains the bounding box of the full
+        # SLC swath covered by the data
+        with zipfile.ZipFile(safe_file_path) as myzip:
+            with myzip.open(f'{safe_file_name}.SAFE/manifest.safe', 'r') as infile:
+                manifest_tree = ET.parse(infile)
+
+        coordinates_elem = manifest_tree.xpath('.//*[local-name()="coordinates"]')
+
+        if coordinates_elem is None:
+            raise RuntimeError(
+                'Could not find gml:coordinates element within the manifest.safe '
+                'of the provided SAFE archive, cannot determine DEM bounding box.'
+            )
+
+        coordinates_str = coordinates_elem[0].text
+        coordinates = coordinates_str.split()
+        lats = [float(coordinate.split(',')[0]) for coordinate in coordinates]
+        lons = [float(coordinate.split(',')[-1]) for coordinate in coordinates]
+
+        lat_min = min(lats)
+        lat_max = max(lats)
+        lon_min = min(lons)
+        lon_max = max(lons)
+
+        bbox = [lon_min, lat_min, lon_max, lat_max]  # WSEN order
+
+        logger.info(f"Derived DEM bounding box: {bbox}")
+
+        # Set up arguments to stage_dem.py
+        # Note that since we provide an argparse.Namespace directly,
+        # all arguments must be specified, even if it's only with a null value
+        args = argparse.Namespace()
+        args.s3_bucket = s3_bucket
+        args.outfile = output_filepath
+        args.filepath = None
+        args.margin = 5  # KM
+        args.log_level = LogLevels.INFO.value
+        args.bbox = bbox
+        args.tile_code = None
+
+        pge_metrics = self.get_opera_ancillary(ancillary_type='S1 DEM',
+                                               output_filepath=output_filepath,
+                                               staging_func=stage_dem,
+                                               staging_func_args=args)
 
         write_pge_metrics(os.path.join(working_dir, "pge_metrics.json"), pge_metrics)
 
+        # TODO set this back to output_filepath once vrt file is supported by PGE validation
+        kludge_output_filepath = os.path.join(working_dir, 'dem_0.tif')
         rc_params = {
-            oc_const.DEM_FILE: output_filepath
+            oc_const.DEM_FILE: kludge_output_filepath
         }
 
         logger.info(f"rc_params : {rc_params}")
@@ -929,10 +1018,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.bbox = bbox
         args.tile_code = tile_code
 
-        pge_metrics = self.get_dswx_ancillary(ancillary_type='DEM',
-                                              output_filepath=output_filepath,
-                                              staging_func=stage_dem,
-                                              staging_func_args=args)
+        pge_metrics = self.get_opera_ancillary(ancillary_type='DSWx DEM',
+                                               output_filepath=output_filepath,
+                                               staging_func=stage_dem,
+                                               staging_func_args=args)
 
         write_pge_metrics(os.path.join(working_dir, "pge_metrics.json"), pge_metrics)
 
@@ -1037,10 +1126,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.bbox = bbox
         args.tile_code = tile_code
 
-        pge_metrics = self.get_dswx_ancillary(ancillary_type='Worldcover',
-                                              output_filepath=output_filepath,
-                                              staging_func=stage_worldcover,
-                                              staging_func_args=args)
+        pge_metrics = self.get_opera_ancillary(ancillary_type='Worldcover',
+                                               output_filepath=output_filepath,
+                                               staging_func=stage_worldcover,
+                                               staging_func_args=args)
 
         write_pge_metrics(os.path.join(working_dir, "pge_metrics.json"), pge_metrics)
 
@@ -1052,9 +1141,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
-    def get_dswx_ancillary(self, ancillary_type, output_filepath, staging_func, staging_func_args):
+    def get_opera_ancillary(self, ancillary_type, output_filepath, staging_func, staging_func_args):
         """
-        Handles common operations for obtaining ancillary data used with DSWx-HLS processing
+        Handles common operations for obtaining ancillary data used with OPERA
+        PGE processing
         """
         pge_metrics = {"download": [], "upload": []}
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -27,7 +27,7 @@ from opera_chimera.constants.opera_chimera_const import (
     OperaChimeraConstants as oc_const,
 )
 from util.common_util import convert_datetime, get_working_dir
-from util.pge_util import (download_ancillary_from_s3,
+from util.pge_util import (download_object_from_s3,
                            get_input_dataset_tile_code,
                            write_pge_metrics)
 from util.type_util import set_type
@@ -765,7 +765,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         output_filepath = os.path.join(working_dir, s3_key)
 
-        pge_metrics = download_ancillary_from_s3(
+        pge_metrics = download_object_from_s3(
             s3_bucket, s3_key, output_filepath, filetype="Orbit Ephemerides"
         )
 
@@ -961,7 +961,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         s3_bucket = self._pge_config.get(oc_const.GET_LANDCOVER, {}).get(oc_const.S3_BUCKET)
         s3_key = self._pge_config.get(oc_const.GET_LANDCOVER, {}).get(oc_const.S3_KEY)
 
-        pge_metrics = download_ancillary_from_s3(
+        pge_metrics = download_object_from_s3(
             s3_bucket, s3_key, output_filepath, filetype="Landcover"
         )
 

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -19,8 +19,8 @@ PGE.
 """
 
 
-def download_ancillary_from_s3(s3_bucket, s3_key, output_filepath, filetype="Ancillary"):
-    """Helper function to download an arbitrary ancillary file from S3"""
+def download_object_from_s3(s3_bucket, s3_key, output_filepath, filetype="Ancillary"):
+    """Helper function to download an arbitrary file from S3"""
     if not s3_bucket or not s3_key:
         raise RuntimeError(
             f"Incomplete S3 location for {filetype} file.\n"

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -21,8 +21,9 @@ def cslc_s1_lineage_metadata(context, work_dir):
 
         lineage_metadata.append(input_filepath)
 
-    for input_ancillary_path in run_config["dynamic_ancillary_file_group"].values():
-        lineage_metadata.append(input_ancillary_path)
+    # Copy the DEM (vrt and tif) downloaded for this job to the pge input directory
+    local_dem_filepaths = glob.glob(os.path.join(work_dir, "dem*.*"))
+    lineage_metadata.extend(local_dem_filepaths)
 
     return lineage_metadata
 
@@ -60,8 +61,9 @@ def update_cslc_s1_runconfig(context, work_dir):
     run_config["input_file_group"]["safe_file_path"] = f'/home/compass_user/input_dir/{basename(safe_file_path)}'
     run_config["input_file_group"]["orbit_file_path"] = f'/home/compass_user/input_dir/{basename(orbit_file_path)}'
 
-    # TODO: update once DEM staging is implemented for CSLC-S1
-    run_config["dynamic_ancillary_file_group"]["dem_file"] = '/home/compass_user/input_dir/dem_4326.tiff'
+    # TODO: update once better naming is implemented for ancillary files
+    # TODO: revert back to using .vrt file once format is supported by PGE validation
+    run_config["dynamic_ancillary_file_group"]["dem_file"] = '/home/compass_user/input_dir/dem_0.tif'
 
     return run_config
 
@@ -73,6 +75,8 @@ def update_dswx_hls_runconfig(context, work_dir):
     # Point the PGE to the input directory and ancillary files,
     # they should already have been made locally available by PCM
     run_config["input_file_group"]["input_file_path"] = ['/home/conda/input_dir']
+
+    # TODO: update once better naming is implemented for ancillary files
     run_config["dynamic_ancillary_file_group"]["dem_file"] = '/home/conda/input_dir/dem.vrt'
     run_config["dynamic_ancillary_file_group"]["landcover_file"] = '/home/conda/input_dir/landcover.tif'
     run_config["dynamic_ancillary_file_group"]["worldcover_file"] = '/home/conda/input_dir/worldcover.vrt'


### PR DESCRIPTION
This branch updates the opera_chimera precondition functions to dynamically stage a DEM file based on the swath covered by the input S1 SLC SAFE archive.

In order to obtain the bounding box from the SAFE metadata, a precondition function has been added to manually localize the SAFE zip file to a worker. From there, a second precondition function extracts the lat/lon bounding box from the relevant metadata, and uses it with the stage_dem tool to obtain the appropriate region from the opera-dem S3 bucket.

Note: there are also some kludge fixes to address a validation issue in the current engineering release of the CSLC-S1 PGE. These should be addressed with the next PGE ER.