### PR TITLE
issue 283: feat(mozart): increase root device disk space to fix smoke tests

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -166,7 +166,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r5.xlarge"
-    root_dev_size = 50
+    root_dev_size = 100
     private_ip    = ""
     public_ip     = ""
   }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -166,7 +166,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r5.xlarge"
-    root_dev_size = 50
+    root_dev_size = 100
     private_ip    = ""
     public_ip     = ""
   }

--- a/cluster_provisioning/dev-releaser/variables.tf
+++ b/cluster_provisioning/dev-releaser/variables.tf
@@ -166,7 +166,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r5.xlarge"
-    root_dev_size = 50
+    root_dev_size = 100
     private_ip    = ""
     public_ip     = ""
   }


### PR DESCRIPTION
increase root device disk space across multiple environments, basing this new minimum off of the `dev` environment which does not exhibit smoke test failures.

smoke test failures were caused by Elasticsearch on mozart entering read-only mode due to exhausted disk space.

Refs #283