### PR TITLE
Restitued Orbit File Support 

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -132,10 +132,10 @@ variable "purge_es_snapshot" {
 variable "amis" {
   type = map(string)
   default = {
-    # HySDS v4.1.0-beta.4 
+    # HySDS v4.1.0-beta.4
     mozart    = "ami-0a4c8f9c7f5a2daec" # mozart v4.18 - 221107
     metrics   = "ami-0c61e7c8b1bfd14a3" # metrics v4.13 - 221107
-    grq       = "ami-0f52442c2bd506303" # grq v4.14 - 221107 
+    grq       = "ami-0f52442c2bd506303" # grq v4.14 - 221107
     factotum  = "ami-03fdbdb8c7caa736e" # factotum v4.14 - 221107
     autoscale = "ami-003e368c872ea1099" # verdi v4.15 - 221031
   }
@@ -366,7 +366,7 @@ variable "queues" {
     "opera-job_worker-slc_data_download" = {
       "instance_type" = ["c5n.2xlarge", "m5dn.2xlarge"]
       "root_dev_size" = 50
-      "data_dev_size" = 25
+      "data_dev_size" = 100
       "min_size"      = 0
       "max_size"      = 80
       "total_jobs_metric" = true

--- a/data_subscriber/slc/slc_catalog.py
+++ b/data_subscriber/slc/slc_catalog.py
@@ -31,7 +31,7 @@ class SLCProductCatalog(ElasticsearchUtility):
                                      "mappings": {
                                          "properties": {
                                              "granule_id": {"type": "keyword"},
-                                             # "s3_url": {"type": "keyword"},
+                                             "s3_url": {"type": "keyword"},
                                              "https_url": {"type": "keyword"},
                                              "creation_timestamp": {"type": "date"},
                                              "download_datetime": {"type": "date"},
@@ -48,9 +48,15 @@ class SLCProductCatalog(ElasticsearchUtility):
     def get_all_between(self, start_dt: datetime, end_dt: datetime, use_temporal: bool):
         undownloaded = self._query_undownloaded(start_dt, end_dt, use_temporal)
 
-        return [{  # "s3_url": result['_source']['s3_url'],
-            "https_url": result['_source'].get('https_url')}
-            for result in (undownloaded or [])]
+        urls = [
+            {
+                "https_url": result['_source'].get('https_url'),
+                "s3_url": result['_source'].get('s3_url')
+            }
+            for result in (undownloaded or [])
+        ]
+
+        return urls
 
     def process_url(
             self,
@@ -75,8 +81,8 @@ class SLCProductCatalog(ElasticsearchUtility):
 
         if "https://" in url:
             doc["https_url"] = url
-        # elif "s3://" in url:
-        # doc["s3_url"] = url
+        elif "s3://" in url:
+            doc["s3_url"] = url
         else:
             raise Exception(f"Unrecognized URL format. {url=}")
 

--- a/tests/data_subscriber/test_daac_data_subscriber.py
+++ b/tests/data_subscriber/test_daac_data_subscriber.py
@@ -468,7 +468,7 @@ def test_download_from_asf(monkeypatch):
     )
 
     # ACT
-    data_subscriber.daac_data_subscriber.download_from_asf(es_conn=MagicMock(), download_urls=["https://www.example.com/dummy_slc_product.zip"], args=Args(), token=None, job_id=None)
+    data_subscriber.daac_data_subscriber.download_from_asf(session=None, es_conn=MagicMock(), download_urls=["https://www.example.com/dummy_slc_product.zip"], args=Args(), token=None, job_id=None)
 
     # ASSERT
     mock_extract_one_to_one.assert_called_once()


### PR DESCRIPTION
This PR updates the stage_orbit_file.py tool to support querying/downloading of Restitued Orbit File (ROEORB) in addition to the current support for Precise Orbit (POEORB) files. Selection of the orbit file type is accomplished via a --orbit-type argument added to stage_orbit_file.py.

The daac_data_subscriber.py script has also been updated to fall back to querying for RESORB files if an initial query for POEORB files returns no results.

In the course of testing this branch, I discovered that ASF DAAC had started serving s3 URL's in addition to the HTTPS locations, so the subscriber script has been updated to store the s3 URL's, if provided, in elasticsearch along side the HTTPS address. When downloading, if HTTPS is present it is still prioritized over the S3 location.

Lastly, the branch ups the EBS size for the /data partition on SLC download workers to 100 gigs, as the previous size was shown to quickly fill up for hourly query windows.