### PR TITLE
DSWx-HLS Ancillary Margin Fix

### DIFF
--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -236,7 +236,8 @@ def create_parser():
 
     native_id = {"positionals": ["--native-id"],
                  "kwargs": {"dest": "native_id",
-                            "help": "The native ID of a single product granule to be queried, overriding other query arguments if present."}}
+                            "help": "The native ID of a single product granule to be queried, overriding other query arguments if present. "
+                                    "The native ID value supports the '*' and '?' wildcards."}}
 
     parser_arg_list = [verbose, file, provider]
     _add_arguments(parser, parser_arg_list)
@@ -557,6 +558,9 @@ def query_cmr(args, token, cmr, settings, timerange: DateTimeRange, now: datetim
 
     if args.native_id:
         params["native-id"] = args.native_id
+
+        if any(wildcard in args.native_id for wildcard in ['*', '?']):
+            params["options[native-id][pattern]"] = 'true'
 
     # derive and apply param "temporal"
     now_date = now.strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1033,7 +1033,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.s3_bucket = s3_bucket
         args.outfile = output_filepath
         args.filepath = None
-        args.margin = 5  # KM
+        args.margin = 50  # KM
         args.log_level = LogLevels.INFO.value
 
         # Provide both the bounding box and tile code, stage_dem.py should
@@ -1141,7 +1141,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.worldcover_ver = worldcover_ver
         args.worldcover_year = worldcover_year
         args.outfile = output_filepath
-        args.margin = 5  # KM
+        args.margin = 50  # KM
         args.log_level = LogLevels.INFO.value
 
         # Provide both the bounding box and tile code, stage_worldcover.py should

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -66,8 +66,10 @@ def polygon_from_mgrs_tile(mgrs_tile_code):
     for offset_x_multiplier in range(2):
         for offset_y_multiplier in range(2):
 
-            x = x_min + offset_x_multiplier * 109.8 * 1000
-            y = y_min + offset_y_multiplier * 109.8 * 1000
+            # We are using MGRS 100km x 100km tiles
+            # HLS tiles have 4.9 km of margin => width/length = 109.8 km
+            x = x_min - 4.9 * 1000 + offset_x_multiplier * 109.8 * 1000
+            y = y_min - 4.9 * 1000 + offset_y_multiplier * 109.8 * 1000
             lat, lon, z = transformation.TransformPoint(x, y, elevation)
 
             if lat_min is None or lat_min > lat:


### PR DESCRIPTION
This branch addresses the issues with longitudinal striping in DSWx-HLS products by adjusting the amount of margin used when acquiring the tile-based ancillary inputs (DEM and worldcover).

As an added bonus, this branch also adds support for including wildcards supported by CMR (* and ?) in the native-id argument of the daac_data_subscriber.py script.