### PR TITLE
R2 PGE ER4.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -382,8 +382,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -454,8 +454,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -378,8 +378,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -378,8 +378,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -380,8 +380,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -32,8 +32,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/int/variables.tf
+++ b/cluster_provisioning/int/variables.tf
@@ -348,8 +348,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -419,8 +419,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/ops/variables.tf
+++ b/cluster_provisioning/ops/variables.tf
@@ -354,8 +354,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/pst/variables.tf
+++ b/cluster_provisioning/pst/variables.tf
@@ -336,8 +336,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.0-rc.5.0"
-    "cslc_s1" = "2.0.0-er.3.0"
-    "rtc_s1" = "2.0.0-er.3.0"
+    "cslc_s1" = "2.0.0-er.4.0"
+    "rtc_s1" = "2.0.0-er.4.0"
   }
 }
 

--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -21,8 +21,7 @@ RunConfig:
         ScratchPath: {{ data.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: CSLC_S1
-        # TODO remove quotes for next release
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: {{ data.product_path_group.product_version }}
         ProgramPath: conda
         ProgramOptions:
           - run
@@ -68,4 +67,4 @@ RunConfig:
           primary_executable:
             product_type: CSLC_S1
           processing:
-            polarization: co-pol
+            polarization: {{ data.processing.polarization }}

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -21,8 +21,7 @@ RunConfig:
         ScratchPath: {{ data.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: RTC_S1
-        # TODO: remove quotes for next release
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: {{ data.product_path_group.product_version }}
         ProgramPath: conda
         ProgramOptions:
           - run
@@ -31,8 +30,7 @@ RunConfig:
           - rtc_s1.py
         ErrorCodeBase: 300000
         SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
-        # TODO: fill in once available
-        IsoTemplatePath:
+        IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
       QAExecutable:
         Enabled: False
         ProgramPath:
@@ -72,4 +70,4 @@ RunConfig:
           primary_executable:
             product_type: RTC_S1
           processing:
-            polarization: co-pol
+            polarization: {{ data.processing.polarization }}

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -24,14 +24,15 @@ L2_CSLC_S1:
   Outputs:
     Primary:
       # Pattern for parsing output image filenames, such as:
-      # OPERA_L2_CSLC_S1A_IW_048-101101-IW3_VV_20190906T232711Z_v1.0_20230101T100506Z.tiff
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)_(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{3}-\w{6}-\w{3})_(?P<pol>VV|VH|VV\+VH)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>tiff|slc)$'
+      # OPERA_L2_CSLC-S1A_IW_048-101101-IW3_VV_20190906T232711Z_v1.0_20230101T100506Z.tif
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{3}-\w{6}-\w{3})_(?P<pol>VV|VH|VV\+VH)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>tif|tiff|slc|json)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
-      # OPERA_L2_CSLC_S1A_IW_048-101101-IW3_VV_20190906T232711Z_v1.0_20230101T100506Z.json
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)_(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{3}-\w{6}-\w{3})_(?P<pol>VV|VH|VV\+VH)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>json|log|qa\.log|iso\.xml|catalog\.json)$'
+      # OPERA_L2_CSLC-S1A_IW_048-101101-IW3_VV_20190906T232711Z_v1.0_20230101T100506Z.json
+      # TODO: this will remove burst_id and acquisition_ts in next release
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{3}-\w{6}-\w{3})_(?P<pol>VV|VH|VV\+VH)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>log|qa\.log|iso\.xml|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames
@@ -43,14 +44,14 @@ L2_RTC_S1:
   Outputs:
     Primary:
       # Pattern for parsing output image filenames, such as:
-      # OPERA_L2_RTC_S1_t069_147170_iw1_20220913T215519Z_20220913T215519Z_S1A_30_v0.1.nc
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)_(?P<source>S1)_(?P<burst_id>\w{4}_\w{6}_\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>tif|tiff|nc|iso\.xml)$'
+      # OPERA_L2_RTC-S1_T069-147170-IW1_20220913T215519Z_20220913T215519Z_S1A_30_v0.1.nc
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>tif|tiff|nc)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
-      # OPERA_L2_RTC_S1_20220913T215519Z_S1A_30_v0.1.log
-      - regex: !!python/regexp '(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)_(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+)[.](?P<ext>log|qa\.log|iso\.xml|catalog\.json)'
+      # OPERA_L2_RTC-S1_20220913T215519Z_S1A_30_v0.1.log
+      - regex: !!python/regexp '(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+)[.](?P<ext>log|qa\.log|iso\.xml|catalog\.json)'
         verify: false
     Optional: []
       # Pattern for optional output product filenames

--- a/conf/schema/RunConfig_schema.L2_CSLC_S1.yaml
+++ b/conf/schema/RunConfig_schema.L2_CSLC_S1.yaml
@@ -18,8 +18,7 @@ RunConfig:
 
       PrimaryExecutable:
         ProductIdentifier: str(required=False)
-        # TODO: this will become num with next release
-        ProductVersion: str(required=False)
+        ProductVersion: num(required=False)
         CompositeReleaseID: str(required=False)
         ProgramPath: str(required=True)
         ProgramOptions: list(str(), min=0, required=False)

--- a/conf/schema/RunConfig_schema.L2_RTC_S1.yaml
+++ b/conf/schema/RunConfig_schema.L2_RTC_S1.yaml
@@ -18,8 +18,7 @@ RunConfig:
 
       PrimaryExecutable:
         ProductIdentifier: str(required=False)
-        # TODO: this will become num with next release
-        ProductVersion: str(required=False)
+        ProductVersion: num(required=False)
         CompositeReleaseID: str(required=False)
         ProgramPath: str(required=True)
         ProgramOptions: list(str(), min=0, required=False)

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -244,7 +244,7 @@
       "ipath": "hysds::data/L2_CSLC_S1",
       "level": "L2",
       "type": "L2_CSLC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)_(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{3}-\\w{6}-\\w{3})_(?P<pol>VV|VH|VV\\+VH)_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{3}-\\w{6}-\\w{3})_(?P<pol>VV|VH|VV\\+VH)_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L2_RTC_S1",
       "level": "L2",
       "type": "L2_RTC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)_(?P<source>S1)_(?P<burst_id>\\w{4}_\\w{6}_\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -244,7 +244,7 @@
       "ipath": "hysds::data/L2_CSLC_S1",
       "level": "L2",
       "type": "L2_CSLC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)_(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{3}-\\w{6}-\\w{3})_(?P<pol>VV|VH|VV\\+VH)_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{3}-\\w{6}-\\w{3})_(?P<pol>VV|VH|VV\\+VH)_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L2_RTC_S1",
       "level": "L2",
       "type": "L2_RTC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)_(?P<source>S1)_(?P<burst_id>\\w{4}_\\w{6}_\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -17,7 +17,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"ProductType\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
@@ -31,7 +31,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.nc\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"ProductType\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.nc\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -84,9 +84,9 @@ PRODUCT_TYPES:
             Date_Time_Keys: ['start_ts', 'stop_ts']
         Dataset_Keys: {}
 
-    L1_S1_POD:
-        # Pattern for parsing Precise Orbit Determination (POD) files containing the orbit
-        # ephemerides data for Sentinel-1 A/B, such as:
+    L1_S1_ORB:
+        # Pattern for parsing Orbit files, both Precise (POE) and Restituted (RES) files
+        # containing the orbit ephemerides data for Sentinel-1 A/B, such as:
         # S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF
         # This pattern groups the metadata information in the filename using named groups.
         #
@@ -156,9 +156,9 @@ PRODUCT_TYPES:
 
     L2_CSLC_S1:
         # Pattern for parsing output L2_CSLC_S1 product filenames, such as:
-        # OPERA_L2_CSLC_S1A_IW_048-101101-IW3_VV_20190906T232711Z_v1.0_20230101T100506Z.tiff
+        # OPERA_L2_CSLC-S1A_IW_048-101101-IW3_VV_20190906T232711Z_v1.0_20230101T100506Z.tif
         # This pattern groups the metadata information in the filename using named groups.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)_(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{3}-\w{6}-\w{3})_(?P<pol>VV|VH|VV\+VH)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>tiff|slc|json)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{3}-\w{6}-\w{3})_(?P<pol>VV|VH|VV\+VH)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>tif|tiff|slc|json)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:
@@ -168,9 +168,9 @@ PRODUCT_TYPES:
 
     L2_RTC_S1:
         # Pattern for parsing output L2_RTC_S1 product filenames, such as:
-        # OPERA_L2_RTC_S1_t069_147170_iw1_20220913T215519Z_20220913T215519Z_S1A_30_v0.1.nc
+        # OPERA_L2_RTC-S1_T069-147170-IW1_20220913T215519Z_20220913T215519Z_S1A_30_v0.1.nc
         # This pattern groups the metadata information in the filename using named groups.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)_(?P<source>S1)_(?P<burst_id>\w{4}_\w{6}_\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>tif|tiff|nc)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>tif|tiff|nc)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-er.3.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-er.3.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-er.4.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-er.4.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -1,8 +1,8 @@
 {
   "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
   "disk_usage":"10GB",
-  "soft_time_limit": 3600,
-  "time_limit": 3660,
+  "soft_time_limit": 5400,
+  "time_limit": 5460,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.0-er.3.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-er.3.0.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.0.0-er.4.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-er.4.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -24,12 +24,16 @@ runconfig:
     product_path: /home/compass_user/output_dir
     # Scratch path is defined relative to output_dir to avoid file system permission issues
     scratch_path: /home/compass_user/output_dir/scratch_dir
+  processing:
+    # TODO: set to __CHIMERA_VAL__ and determine dynamically from input SLC file name
+    #       once beta SAS for CSLC-S1 is available
+    polarization: co-pol
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
   - get_product_version
-  - get_slc_s1_burst_id
+  - get_slc_s1_burst_id  # TODO: this should go away with CSLC-S1 beta delivery
   - get_slc_s1_safe_file
   - get_slc_s1_orbit_file
   - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
@@ -42,12 +46,6 @@ postprocess:
 
 get_product_version:
   version_key: "CSLC_S1_PRODUCT_VERSION"
-
-get_slc_s1_orbit_file:
-  # TODO: use the sample orbit file provided by ADT until we figure out how
-  #       derive the appropriate file based on input product
-  s3_bucket: "opera-dev-lts-fwd-collinss"
-  s3_key: "S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF"
 
 get_slc_s1_dem:
   # The s3 bucket containing the global DEM(s) to download regions from

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
@@ -23,11 +23,14 @@ runconfig:
     product_path: /home/rtc_user/output_dir
     # Scratch path is defined relative to output_dir to avoid file system permission issues
     scratch_path: /home/rtc_user/output_dir/scratch_dir
+  processing:
+    polarization: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
   - get_product_version
+  - get_slc_polarization
   - get_slc_s1_safe_file
   - get_slc_s1_orbit_file
   - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
@@ -40,12 +43,6 @@ postprocess:
 
 get_product_version:
   version_key: "RTC_S1_PRODUCT_VERSION"
-
-get_slc_s1_orbit_file:
-  # TODO: use the sample orbit file provided by ADT until the stage_orbit_file.py
-  #       script is integrated with the download job for SLC products
-  s3_bucket: "opera-dev-lts-fwd-collinss"
-  s3_key: "S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF"
 
 get_slc_s1_dem:
   # The s3 bucket containing the global DEM(s) to download regions from

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -103,6 +103,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     BASE_NAME = "base_name"
 
+    POLARIZATION = "polarization"
+
     SAFE_FILE_PATH = "safe_file_path"
 
     ORBIT_FILE_PATH = "orbit_file_path"
@@ -214,6 +216,8 @@ class OperaChimeraConstants(ChimeraConstants):
     CAST_STRING_TO_INT = "cast_string_to_int"
 
     BBOX = "bbox"
+
+    GET_SLC_S1_POLARIZATION = "get_slc_s1_polarization"
 
     GET_SLC_S1_BURST_ID = "get_slc_s1_burst_id"
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -949,10 +949,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         write_pge_metrics(os.path.join(working_dir, "pge_metrics.json"), pge_metrics)
 
-        # TODO set this back to output_filepath once vrt file is supported by PGE validation
-        kludge_output_filepath = os.path.join(working_dir, 'dem_0.tif')
         rc_params = {
-            oc_const.DEM_FILE: kludge_output_filepath
+            oc_const.DEM_FILE: output_filepath
         }
 
         logger.info(f"rc_params : {rc_params}")

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -160,7 +160,7 @@ def convert(
             dataset_met_json["pge_version"] = dataset_catalog_dict["PGE_Version"]
             dataset_met_json["sas_version"] = dataset_catalog_dict["SAS_Version"]
 
-        if "dswx-hls" in dataset_id.lower():
+        if "dswx_hls" in dataset_id.lower():
             collection_name = settings.get("DSWX_COLLECTION_NAME")
             product_version = settings.get("DSWX_HLS_PRODUCT_VERSION")
         elif "cslc-s1" in dataset_id.lower():

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -160,13 +160,13 @@ def convert(
             dataset_met_json["pge_version"] = dataset_catalog_dict["PGE_Version"]
             dataset_met_json["sas_version"] = dataset_catalog_dict["SAS_Version"]
 
-        if "dswx_hls" in dataset_id.lower():
+        if "dswx-hls" in dataset_id.lower():
             collection_name = settings.get("DSWX_COLLECTION_NAME")
             product_version = settings.get("DSWX_HLS_PRODUCT_VERSION")
-        elif "cslc_s1" in dataset_id.lower():
+        elif "cslc-s1" in dataset_id.lower():
             collection_name = settings.get("CSLC_COLLECTION_NAME")
             product_version = settings.get("CSLC_S1_PRODUCT_VERSION")
-        elif "rtc_s1" in dataset_id.lower():
+        elif "rtc-s1" in dataset_id.lower():
             collection_name = settings.get("RTC_COLLECTION_NAME")
             product_version = settings.get("RTC_S1_PRODUCT_VERSION")
         else:

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 from zipfile import ZipFile
 
 import boto3.s3.inject
+import boto3.resources.collection
 
 import tools.stage_dem
 import tools.stage_worldcover
@@ -64,6 +65,24 @@ def _object_download_file_patch(self, Filename, ExtraArgs=None, Callback=None, C
     # Create a dummy file in the expected location to simulate download
     with open(Filename, 'w') as outfile:
         outfile.write("fake ancillary data")
+
+
+class MockCollectionManager:
+    """
+    Mock class for boto3.resources.collection.CollectionManager for use with
+    tests that filter on s3 objects to locate an ancillary file
+    """
+    class MockS3Object:
+        def __init__(self):
+            self.key = None
+
+    def __init__(self, collection_model, parent, factory, service_context):
+        self.s3_object = self.MockS3Object()
+
+    def filter(self, **kwargs):
+        self.s3_object.key = "fake/key/to/S1A_OPER_AUX_RESORB_OPOD.EOF"
+
+        return [self.s3_object]
 
 
 class TestOperaPreConditionFunctions(unittest.TestCase):
@@ -126,6 +145,86 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
         # Make sure the metrics for the "download" were written to disk
         expected_pge_metrics = join(self.working_dir.name, 'pge_metrics.json')
         self.assertTrue(exists(expected_pge_metrics))
+
+    def test_get_slc_polarization(self):
+        """Unit tests for the get_slc_polarization() function"""
+
+        # Set up the arguments to OperaPreConditionFunctions
+        context = {
+            "product_metadata": {
+                "metadata":
+                    {
+                        'FileName': "S1A_IW_SLC__1SDV_..._043011_0522A4_42CC.zip"
+                    }
+            }
+        }
+
+        pge_config = {
+            oc_const.GET_SLC_S1_POLARIZATION: {}
+        }
+
+        # These are not used by get_slc_s1_orbit_file
+        settings = None
+        job_params = None
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        rc_params = precondition_functions.get_slc_polarization()
+
+        self.assertIsNotNone(rc_params)
+        self.assertIsInstance(rc_params, dict)
+        self.assertIn(oc_const.POLARIZATION, rc_params)
+
+        # "DV" portion of test file name should translate to "dual-pol" setting
+        # for runconfig
+        expected_polarization = 'dual-pol'
+        self.assertEqual(rc_params[oc_const.POLARIZATION], expected_polarization)
+
+        # Test again with single polarization setting ("SH")
+        context['product_metadata']['metadata']['FileName'] = "S1A_IW_SLC__1SSH_..._043011_0522A4_42CC.zip"
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        rc_params = precondition_functions.get_slc_polarization()
+
+        expected_polarization = 'co-pol'
+        self.assertEqual(rc_params[oc_const.POLARIZATION], expected_polarization)
+
+    @patch.object(boto3.resources.collection, "CollectionManager", MockCollectionManager)
+    def test_get_slc_s1_orbit_file(self):
+        """Unit tests for the get_slc_s1_orbit_file() function"""
+
+        # Set up the arguments to OperaPreConditionFunctions
+        context = {
+            "product_path": "s3://s3-us-west-2.amazonaws.com:80/opera-bucket/fake/key/to",
+        }
+
+        pge_config = {
+            oc_const.GET_SLC_S1_SAFE_FILE: {}
+        }
+
+        # These are not used by get_slc_s1_orbit_file
+        settings = None
+        job_params = None
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        rc_params = precondition_functions.get_slc_s1_orbit_file()
+
+        # Make sure we got a path back for replacement within the PGE runconfig
+        self.assertIsNotNone(rc_params)
+        self.assertIsInstance(rc_params, dict)
+        self.assertIn(oc_const.ORBIT_FILE_PATH, rc_params)
+
+        # Make sure the path to the orbit file was assigned to the runconfig params as expected
+        expected_s3_path = "s3://opera-bucket/fake/key/to/S1A_OPER_AUX_RESORB_OPOD.EOF"
+        self.assertEqual(rc_params[oc_const.ORBIT_FILE_PATH], expected_s3_path)
 
     @patch.object(tools.stage_dem, "check_aws_connection", _check_aws_connection_patch)
     @patch.object(tools.stage_dem, "gdal", MockGdal)

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -288,8 +288,7 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
 
         # Make sure the vrt file was created
         expected_dem_vrt = join(self.working_dir.name, 'dem.vrt')
-        # TODO uncomment once vrt files are accpeted by PGE validation
-        #self.assertEqual(rc_params[oc_const.DEM_FILE], expected_dem_vrt)
+        self.assertEqual(rc_params[oc_const.DEM_FILE], expected_dem_vrt)
         self.assertTrue(exists(expected_dem_vrt))
 
         # Make sure the tif was created

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -28,10 +28,9 @@ List of band identifiers for the multiple tif outputs produced by the DSWx-HLS
 PGE.
 """
 
-# TODO: these may go to all-caps at some point
-RTC_BURST_IDS = ['t069_147170_iw1', 't069_147170_iw3', 't069_147171_iw1',
-                 't069_147171_iw2', 't069_147171_iw3', 't069_147172_iw1',
-                 't069_147172_iw2', 't069_147172_iw3', 't069_147173_iw1']
+RTC_BURST_IDS = ['T069-147170-IW1', 'T069-147170-IW3', 'T069-147171-IW1',
+                 'T069-147171-IW2', 'T069-147171-IW3', 'T069-147172-IW1',
+                 'T069-147172-IW2', 'T069-147172-IW3', 'T069-147173-IW1']
 """List of sample burst ID's to simulate RTC-S1 multi-product output"""
 
 


### PR DESCRIPTION
This branch updates OPERA PCM to utilize v2.0.0-er.4.0 of the R2 PGEs (CSLC-S1, RTC-S1).
The high level changes are as follows:

- Updated file naming conventions for CSLC/RTC output products to use hyphens for product shortname, as well as capitalize burst ID portion of file name
- Precondition logic for both CSLC and RTC now obtains the s3 path to the orbit file obtained by the downloader script
- Added a precondition function to assign the appropriate polarization value based on the name of the input SLC granule (RTC-S1 only, CSLC will get added with beta delivery)
- Bumped the soft/hard time limit for RTC-S1 to 90 minutes, since it takes about an hour for the PGE to process all available bursts

Note that due to limitations with the current version of the CSLC-S1 SAS, the 2.0.0-er.4.0 delivery should only be tested with the sample SLC granule that was provided with the initial delivery. The following command can be used to queue up the specific dataset that allows the CSLC-S1 PGE to run to completion:

`python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -p ASF -c SENTINEL-1A_SLC --release-version=$branch --job-queue=opera-job_worker-slc_data_download --chunk-size=1 --native-id=S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC*`