### PR TITLE
issue_331: Additional fix for PGE r2_er4.0_integration

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -164,6 +164,9 @@ PRODUCT_TYPES:
         Configuration:
             Date_Time_Patterns: ['%Y%m%dT%H%M%SZ']
             Date_Time_Keys: ['acquisition_ts', 'creation_ts']
+            # Specify the metadata key to use as the dataset version.
+            #  Note: this affects the data product index name
+            Dataset_Version_Key: 'product_version'
         Dataset_Keys: {}
 
     L2_RTC_S1:
@@ -176,6 +179,9 @@ PRODUCT_TYPES:
         Configuration:
           Date_Time_Patterns: ['%Y%m%dT%H%M%SZ']
           Date_Time_Keys: ['acquisition_ts', 'creation_ts']
+          # Specify the metadata key to use as the dataset version.
+          #  Note: this affects the data product index name
+          Dataset_Version_Key: 'product_version'
         Dataset_Keys: {}
 
     L3_DSWx_HLS:

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -13,7 +13,7 @@ REPO_DIR = abspath(join(TEST_DIR, os.pardir, os.pardir))
 
 
 def test_simulate_cslc_s1_pge():
-    for path in glob.iglob('/tmp/OPERA_L2_CSLC_S1A_IW_*_VV_*Z_v0.1_*Z.*'):
+    for path in glob.iglob('/tmp/OPERA_L2_CSLC-S1A_IW_*_VV_*Z_v0.1_*Z.*'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml')
@@ -37,7 +37,7 @@ def test_simulate_cslc_s1_pge():
         output_dir='/tmp'
     )
 
-    expected_output_base_name = "OPERA_L2_CSLC_S1A_IW_T64-135524-IW2_VV_20220501T015035Z_v0.1_20220501T015102Z"
+    expected_output_base_name = "OPERA_L2_CSLC-S1A_IW_T64-135524-IW2_VV_20220501T015035Z_v0.1_20220501T015102Z"
 
     try:
         assert Path(f'/tmp/{expected_output_base_name}.tiff').exists()
@@ -47,12 +47,12 @@ def test_simulate_cslc_s1_pge():
         assert Path(f'/tmp/{expected_output_base_name}.log').exists()
         assert Path(f'/tmp/{expected_output_base_name}.qa.log').exists()
     finally:
-        for path in glob.iglob('/tmp/OPERA_L2_CSLC_S1A_IW_*_VV_*Z_v0.1_*Z.*'):
+        for path in glob.iglob('/tmp/OPERA_L2_CSLC-S1A_IW_*_VV_*Z_v0.1_*Z.*'):
             Path(path).unlink(missing_ok=True)
 
 
 def test_simulate_rtc_s1_pge():
-    for path in glob.iglob('/tmp/OPERA_L2_RTC_S1*.*'):
+    for path in glob.iglob('/tmp/OPERA_L2_RTC-S1*.*'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml')
@@ -76,12 +76,12 @@ def test_simulate_rtc_s1_pge():
         output_dir='/tmp'
     )
 
-    expected_output_basename = 'OPERA_L2_RTC_S1_{burst_id}_20180504T104507Z_20180504T104535Z_S1B_30_v0.1'
+    expected_output_basename = 'OPERA_L2_RTC-S1_{burst_id}_20180504T104507Z_20180504T104535Z_S1B_30_v0.1'
 
     for burst_id in pge_util.RTC_BURST_IDS:
         assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}.nc').exists()
 
-    expected_ancillary_basename = 'OPERA_L2_RTC_S1_20180504T104535Z_S1B_30_v0.1'
+    expected_ancillary_basename = 'OPERA_L2_RTC-S1_20180504T104535Z_S1B_30_v0.1'
 
     try:
         assert Path(f'/tmp/{expected_ancillary_basename}.catalog.json').exists()
@@ -89,7 +89,7 @@ def test_simulate_rtc_s1_pge():
         assert Path(f'/tmp/{expected_ancillary_basename}.log').exists()
         assert Path(f'/tmp/{expected_ancillary_basename}.qa.log').exists()
     finally:
-        for path in glob.iglob('/tmp/OPERA_L2_RTC_S1*.*'):
+        for path in glob.iglob('/tmp/OPERA_L2_RTC-S1*.*'):
             Path(path).unlink(missing_ok=True)
 
 


### PR DESCRIPTION
- Update expected_output_base_name for CSLC & RTC simulated tests
- Add 'product_version' as Dataset_Version_Key for L2_CSLC_S1 & L2_RTC_S1