### PR TITLE
DSWx-HLS PGE RC6.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -380,7 +380,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -452,7 +452,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -376,7 +376,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -376,7 +376,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -379,7 +379,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,7 +31,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/int/variables.tf
+++ b/cluster_provisioning/int/variables.tf
@@ -347,7 +347,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -418,7 +418,7 @@ variable "lambda_log_retention_in_days" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/ops/variables.tf
+++ b/cluster_provisioning/ops/variables.tf
@@ -353,7 +353,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/cluster_provisioning/pst/variables.tf
+++ b/cluster_provisioning/pst/variables.tf
@@ -335,7 +335,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.5.0"
+    "dswx_hls" = "1.0.0-rc.6.0"
     "cslc_s1" = "2.0.0-er.4.0"
     "rtc_s1" = "2.0.0-er.4.0"
   }

--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -24,7 +24,7 @@ RunConfig:
         ProductVersion: {{ data.product_path_group.product_version }}
         ProgramPath: python3
         ProgramOptions:
-          - proteus-0.1/bin/dswx_hls.py
+          - /home/conda/proteus-0.5.1/bin/dswx_hls.py
           - --full-log-format
         ErrorCodeBase: 100000
         SchemaPath: /home/conda/opera/pge/dswx_hls/schema/dswx_hls_sas_schema.yaml
@@ -56,7 +56,7 @@ RunConfig:
             {%- endif %}
             {%- endfor %}
             # TODO: update descriptions as necessary when new ancillary releases are available
-            dem_description: Copernicus DEM GLO-30 2021 WGS84
+            dem_description: Copernicus DEM GLO-30 2021
             landcover_description: Land Cover 100m - collection 3 - epoch 2019 discrete classification map
             worldcover_description: ESA WorldCover 10m 2020 v1.0
           primary_executable:
@@ -68,10 +68,12 @@ RunConfig:
             product_id: dswx_hls
             product_version: {{ data.product_path_group.product_version }}
           processing:
-            flag_use_otsu_terrain_masking: False
+            check_ancillary_inputs_coverage: True
+            shadow_masking_algorithm: sun_local_inc_angle
             min_slope_angle: -5
             max_sun_local_inc_angle: 40
-            mask_adjacent_to_cloud_mode: mask
+            mask_adjacent_to_cloud_mode: 'mask'
+            copernicus_forest_classes: [ 20, 111, 113, 115, 116, 121, 123, 125, 126 ]
             save_wtr: True    # Layer 1 - WTR
             save_bwtr: True   # Layer 2 - BWTR
             save_conf: True   # Layer 3 - CONF
@@ -88,6 +90,10 @@ RunConfig:
             save_browse: True
             browse_image_height: 1024
             browse_image_width: 1024
+            exclude_psw_aggressive_in_browse: False
+            not_water_in_browse: 'white'
+            cloud_in_browse: 'gray'
+            snow_in_browse: 'cyan'
           hls_thresholds:
             wigt: {{ data.hls_thresholds.wigt or 0.124 }}         # Modified Normalized Difference Wetness Index (MNDWI) Threshold
             awgt: {{ data.hls_thresholds.awgt or 0.0 }}            # Automated Water Extent Shadow Threshold

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -63,16 +63,16 @@ L3_DSWx_HLS:
   Outputs:
     Primary:
       # Pattern for parsing output image filenames, such as:
-      # * "OPERA_L3_DSWx_HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v0.1_B01_WTF.tiff"
-      # * "OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v0.1_B09_CLOUD.tiff"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<collection_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tiff)$'
+      # * "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v0.1_B01_WTF.tif"
+      # * "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v0.1_B09_CLOUD.tif"
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tif|tiff)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
-      # * "OPERA_L3_DSWx_HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v2.0.catalog.json"
-      # * "OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v2.0.iso.xml"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<collection_version>v\d+[.]\d+))[.](?P<ext>log|png|qa\.log|iso\.xml|catalog\.json)$'
+      # * "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v2.0.catalog.json"
+      # * "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v2.0.iso.xml"
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>log|png|tif|qa\.log|iso\.xml|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames

--- a/conf/schema/RunConfig_schema.L3_DSWx_HLS.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_HLS.yaml
@@ -87,8 +87,12 @@ RunConfig:
             product_version: num(required=False)
 
           processing:
-            # Use terrain-masking based on the Otsu method
-            flag_use_otsu_terrain_masking: bool(required=False)
+
+            # Check if ancillary inputs cover entirely the output product
+            check_ancillary_inputs_coverage: bool(required=False)
+
+            # Select shadow masking algorithm
+            shadow_masking_algorithm: enum('otsu', 'sun_local_inc_angle', required=False)
 
             # Minimum slope angle in degrees for terrain masking
             min_slope_angle: num(min=-180, max=180, required=False)
@@ -98,6 +102,9 @@ RunConfig:
 
             # Define how areas adjacent to cloud/cloud-shadow should be handled
             mask_adjacent_to_cloud_mode: enum('mask', 'ignore', 'cover', required=False)
+
+            # Copernicus CGLS Land Cover 100m forest classes
+            copernicus_forest_classes: list(int(), min=0, required=False)
 
             # Layer 1 - WTR
             save_wtr: bool(required=False)
@@ -136,19 +143,51 @@ RunConfig:
             save_infrared_rgb: bool(required=False)
 
           browse_image_group:
-            # Save a browse image PNG of the WTR layer.
+            # Save a full-res Cloud-Optimized GEOTIFF DSWx-HLS browse image and
+            # a modified-resolution PNG of the browse image for DSWx-HLS
             save_browse: bool(required=False)
 
             # Setting `browse_image_height` and `browse_image_width` equal
             # will maintain this original HLS and DSWx-HLS aspect ratio
-            # of 3660 pixels x 3660 pixels.
-            # If these fields are left empty, 3660 x 3660 will be used.
+            # of 3660 pixels x 3660 pixels for the PNG browse image.
+            # If these fields are left empty, 1024 x 1024 will be used.
 
             # Height in pixels
             browse_image_height: int(min=1, required=False)
 
             # Width in pixels
             browse_image_width: int(min=1, required=False)
+
+            # Flag to exclude the Partial Surface Water Aggressive (PSW-Agg)
+            # class in the browse image. If True, PSW-Agg pixels will
+            # appear as Not Water. If False, this class will be displayed
+            # in the browse image, same as in WTR. Default is False.
+            exclude_psw_aggressive_in_browse: bool(required=False)
+
+            # Define how Not Water (e.g. land) appears in the browse image.
+            # Defaults to 'white'.
+            # Options are: 'white', 'nodata'
+            #   'white'         : Not Water pixels will be white
+            #   'nodata'        : Not Water pixels will be marked as not having
+            #                     valid data, and will be fully transparent
+            not_water_in_browse: enum('white', 'nodata', required=False)
+
+            # Define how cloud appears in the browse image.
+            # Defaults to 'gray'.
+            # Options are: 'gray', 'nodata'
+            #   'gray'          : cloud pixels will be opaque gray
+            #   'nodata'        : cloud pixels will be marked as not having
+            #                     valid data, and will be fully transparent
+            cloud_in_browse: enum('gray', 'nodata', required=False)
+
+            # Define how snow appears in the browse image.
+            # Defaults to 'cyan'.
+            # Options are: 'cyan', 'gray', 'nodata'
+            #   'cyan'          : snow will be opaque cyan
+            #   'gray'          : snow will be opaque gray
+            #   'nodata'        : snow pixels will be marked as not having
+            #                     valid data, and will be fully transparent
+            snow_in_browse: enum('cyan', 'gray', 'nodata', required=False)
 
           hls_thresholds: include('hls_thresholds_options', required=False)
 

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -292,7 +292,7 @@
       "ipath": "hysds::data/L3_DSWx_HLS",
       "level": "L3",
       "type": "L3_DSWx_HLS",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<collection_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -292,7 +292,7 @@
       "ipath": "hysds::data/L3_DSWx_HLS",
       "level": "L3",
       "type": "L3_DSWx_HLS",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<collection_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -17,7 +17,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\",\"*Z.json\","\*.tif\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\",\"*Z.json\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
@@ -31,7 +31,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.nc\",\"*.tif\",\"*.h5\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.nc\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -3,7 +3,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ PO_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ PO_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ PO_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\",\"*.png\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ PO_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ PO_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ PO_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\",\"*.png\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
@@ -17,7 +17,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\",\"*Z.json\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
@@ -31,7 +31,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.nc\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\",\"*.nc\",\"*.h5\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -17,7 +17,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\",\"*Z.json\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tiff\",\"*Z.json\","\*.tif\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
@@ -31,7 +31,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\",\"*.nc\",\"*.h5\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.nc\",\"*.tif\",\"*.h5\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -17,7 +17,7 @@ SHORTNAME_FILTERS:
   HLSL30:
 #   - L.07 # Landsat-7
     - L.08 # Landsat-8
-#    - L.09 # Landsat-9
+#   - L.09 # Landsat-9
   HLSS30:
 #   - S1 # Sentinel-1
     - S2A # Sentinel-2A
@@ -29,7 +29,7 @@ SHORTNAME_FILTERS:
   HLSL30:
 #   - L.07 # Landsat-7
     - L.08 # Landsat-8
-    - L.09 # Landsat-9
+#   - L.09 # Landsat-9
   HLSS30:
 #   - S1 # Sentinel-1
     - S2A # Sentinel-2A

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -186,12 +186,12 @@ PRODUCT_TYPES:
 
     L3_DSWx_HLS:
         # Pattern for parsing filenames such as:
-        # * "OPERA_L3_DSWx_HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v0.1_B01_WTF.tiff"
-        # * "OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v0.1_B09_CLOUD.tiff"
+        # * "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v0.1_B01_WTF.tif"
+        # * "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v0.1_B09_CLOUD.tif"
         # This pattern groups the metadata information in the filename using named groups.
         #
         # Note: POSIX character class "[[:alnum:]]" is not supported in python's re, and so has been replaced with "[^\W_]" here.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx_(?P<source>HLS))_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<collection_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tiff)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tif|tiff)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:
@@ -209,7 +209,7 @@ PRODUCT_TYPES:
             Date_Time_Keys: ['acquisition_ts', 'creation_ts']
             # Specify the metadata key to use as the dataset version.
             #  Note: this affects the data product index name
-            Dataset_Version_Key: 'collection_version'
+            Dataset_Version_Key: 'product_version'
         Dataset_Keys: {}
 
 

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.5.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.5.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.6.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.6.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.5.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.5.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.6.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.6.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml
@@ -119,7 +119,7 @@ set_extra_pge_output_metadata:
 # List the extensions that the PGE generates
 output_types:
   L3_DSWx_HLS:
-    - tiff
+    - tif
     - png
     - catalog.json
     - iso.xml
@@ -151,4 +151,4 @@ localize_groups:
 input_file_base_name_regexes: # regexes taken from settings.yaml > L2_HLS_L30 and L2_HLS_S30
     - '(?P<id>(?P<product_shortname>HLS[.]L30)[.](?P<tile_id>T[^\W_]{5})[.](?P<acquisition_ts>(?P<year>\d{4})(?P<day_of_year>\d{3})T(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2}))[.](?P<collection_version>v\d+[.]\d+))$'
     - '(?P<id>(?P<product_shortname>HLS[.]S30)[.](?P<tile_id>T[^\W_]{5})[.](?P<acquisition_ts>(?P<year>\d{4})(?P<day_of_year>\d{3})T(?P<hour>\d{2})(?P<minute>\d{2})(?P<second>\d{2}))[.](?P<collection_version>v\d+[.]\d+))$'
-output_base_name: OPERA_L3_DSWx_HLS_{tile_id}_{acquisition_ts}Z_{creation_ts}Z_{sensor}_30_{collection_version}
+output_base_name: OPERA_L3_DSWx-HLS_{tile_id}_{acquisition_ts}Z_{creation_ts}Z_{sensor}_30_{product_version}

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -160,7 +160,7 @@ def convert(
             dataset_met_json["pge_version"] = dataset_catalog_dict["PGE_Version"]
             dataset_met_json["sas_version"] = dataset_catalog_dict["SAS_Version"]
 
-        if "dswx_hls" in dataset_id.lower():
+        if "dswx-hls" in dataset_id.lower():
             collection_name = settings.get("DSWX_COLLECTION_NAME")
             product_version = settings.get("DSWX_HLS_PRODUCT_VERSION")
         elif "cslc-s1" in dataset_id.lower():

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -94,10 +94,10 @@ def test_simulate_rtc_s1_pge():
 
 
 def test_simulate_dswx_hls_pge_with_l30():
-    expected_output_base_name = "OPERA_L3_DSWx_HLS_T22VEQ_20210905T143156Z_20210905T143156Z_L8_30_v2.0"
+    expected_output_base_name = "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20210905T143156Z_L8_30_v2.0"
 
     # before
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*.tiff'):
+    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml')
@@ -125,30 +125,25 @@ def test_simulate_dswx_hls_pge_with_l30():
 
     # ASSERT
     for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
-        assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tiff').exists()
+        assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tif').exists()
 
     assert Path(f'/tmp/{expected_output_base_name}.log').exists()
-    assert Path(f'/tmp/{expected_output_base_name}.png').exists()
+    assert Path(f'/tmp/{expected_output_base_name}_BROWSE.png').exists()
+    assert Path(f'/tmp/{expected_output_base_name}_BROWSE.tif').exists()
     assert Path(f'/tmp/{expected_output_base_name}.qa.log').exists()
     assert Path(f'/tmp/{expected_output_base_name}.catalog.json').exists()
     assert Path(f'/tmp/{expected_output_base_name}.iso.xml').exists()
 
     # after
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*.tiff'):
+    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
         Path(path).unlink(missing_ok=True)
-
-    Path(f'/tmp/{expected_output_base_name}.log').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.png').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.qa.log').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.catalog.json').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.iso.xml').unlink(missing_ok=False)
 
 
 def test_simulate_dswx_hls_pge_with_s30():
-    expected_output_base_name = "OPERA_L3_DSWx_HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0"
+    expected_output_base_name = "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0"
 
     # before
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*.tiff'):
+    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml')
@@ -176,23 +171,18 @@ def test_simulate_dswx_hls_pge_with_s30():
 
     # ASSERT
     for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
-        assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tiff').exists()
+        assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tif').exists()
 
     assert Path(f'/tmp/{expected_output_base_name}.log').exists()
-    assert Path(f'/tmp/{expected_output_base_name}.png').exists()
+    assert Path(f'/tmp/{expected_output_base_name}_BROWSE.png').exists()
+    assert Path(f'/tmp/{expected_output_base_name}_BROWSE.tif').exists()
     assert Path(f'/tmp/{expected_output_base_name}.qa.log').exists()
     assert Path(f'/tmp/{expected_output_base_name}.catalog.json').exists()
     assert Path(f'/tmp/{expected_output_base_name}.iso.xml').exists()
 
     # after
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*.tiff'):
+    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
         Path(path).unlink(missing_ok=False)
-
-    Path(f'/tmp/{expected_output_base_name}.log').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.png').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.qa.log').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.catalog.json').unlink(missing_ok=False)
-    Path(f'/tmp/{expected_output_base_name}.iso.xml').unlink(missing_ok=False)
 
 
 def test_simulate_dswx_hls_pge_with_unsupported():

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -215,13 +215,16 @@ def get_dswx_hls_simulated_output_filenames(dataset_match, pge_config, extension
         # make creation time a duplicate of the acquisition time for ease of testing
         creation_ts=acq_time,
         sensor=sensor,
-        collection_version=dataset_match.groupdict()['collection_version']
+        product_version=dataset_match.groupdict()['collection_version']
     )
 
     # Simulate the multiple output tif files created by this PGE
-    if extension.endswith('tiff'):
+    if extension.endswith('tiff') or extension.endswith('tif'):
         for band_idx, band_name in enumerate(DSWX_BAND_NAMES, start=1):
-            output_filenames.append(f'{base_name}_B{band_idx:02}_{band_name}.{extension}')
+            output_filenames.append(f'{base_name}_B{band_idx:02}_{band_name}.tif')
+    elif extension.endswith('png'):
+        output_filenames.append(f'{base_name}_BROWSE.png')
+        output_filenames.append(f'{base_name}_BROWSE.tif')
     else:
         output_filenames.append(f'{base_name}.{extension}')
 


### PR DESCRIPTION
This branch integrates the RC6.0 delivery of the DSWx-HLS PGE with OPERA PCM.
 
Changes with this version include incorporation of the v3.2 CalVal SAS delivery, support for using a hyphen in the product shortname (DSWx-HLS), and support for including both the PNG and GeoTIFF Browse images with each output HySDS dataset.