### PR TITLE
DSWx-HLS PGE RC7.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -380,7 +380,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -452,7 +452,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -376,7 +376,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -376,7 +376,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -379,7 +379,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,7 +31,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/int/int_override.tf
+++ b/cluster_provisioning/int/int_override.tf
@@ -98,15 +98,15 @@ variable "amis" {
 
 ####### Release Branches #############
 variable "pge_snapshots_date" {
-  default = "20220609-1.0.0-rc.1.0"
+  default = "20230203-1.0.0-rc.7.0"
 }
 
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
-    "cslc_s1" = "2.0.0-er.4.0"
-    "rtc_s1" = "2.0.0-er.4.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
+    "cslc_s1" = "2.0.0-er.5.0"
+    "rtc_s1" = "2.0.0-er.5.0"
   }
 }
 
@@ -115,27 +115,27 @@ variable "hysds_release" {
 }
 
 variable "lambda_package_release" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "pcm_commons_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "pcm_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "product_delivery_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "bach_api_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "bach_ui_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 ###### Roles ########

--- a/cluster_provisioning/int/variables.tf
+++ b/cluster_provisioning/int/variables.tf
@@ -347,7 +347,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -426,7 +426,7 @@ variable "lambda_log_retention_in_days" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/ops/override.tf
+++ b/cluster_provisioning/ops/override.tf
@@ -154,14 +154,13 @@ variable "amis" {
 
 ####### Release Branches #############
 variable "pge_snapshots_date" {
-  default = "20220609-1.0.0-rc.1.0"
+  default = "20230203-1.0.0-rc.7.0"
 }
 
 variable "pge_releases" {
    type = map(string)
    default = {
-     "dswx_hls" = "1.0.0-rc.6.0"
-     "cslc_s1" = "2.0.0-er.4.0"
+     "dswx_hls" = "1.0.0-rc.7.0"
   }
 }
 
@@ -170,27 +169,27 @@ variable "hysds_release" {
 }
 
 variable "lambda_package_release" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "pcm_commons_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "pcm_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "product_delivery_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "bach_api_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "bach_ui_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 ###### Roles ########

--- a/cluster_provisioning/ops/variables.tf
+++ b/cluster_provisioning/ops/variables.tf
@@ -353,7 +353,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/cluster_provisioning/pst/override.tf
+++ b/cluster_provisioning/pst/override.tf
@@ -158,14 +158,13 @@ variable "amis" {
 
 ####### Release Branches #############
 variable "pge_snapshots_date" {
-  default = "20220901-1.0.0-rc.4.0"
+  default = "20230203-1.0.0-rc.7.0"
 }
 
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
-    "cslc_s1" = "2.0.0-er.4.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
   }
 }
 
@@ -174,27 +173,27 @@ variable "hysds_release" {
 }
 
 variable "lambda_package_release" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "pcm_commons_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "pcm_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "product_delivery_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "bach_api_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 variable "bach_ui_branch" {
-  default = "1.0.0-rc.7.0"
+  default = "1.0.0-rc.8.0"
 }
 
 ###### Roles ########

--- a/cluster_provisioning/pst/variables.tf
+++ b/cluster_provisioning/pst/variables.tf
@@ -335,7 +335,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.6.0"
+    "dswx_hls" = "1.0.0-rc.7.0"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.0"
   }

--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -24,7 +24,7 @@ RunConfig:
         ProductVersion: {{ data.product_path_group.product_version }}
         ProgramPath: python3
         ProgramOptions:
-          - /home/conda/proteus-0.5.1/bin/dswx_hls.py
+          - /home/conda/proteus-0.5.2/bin/dswx_hls.py
           - --full-log-format
         ErrorCodeBase: 100000
         SchemaPath: /home/conda/opera/pge/dswx_hls/schema/dswx_hls_sas_schema.yaml
@@ -56,9 +56,10 @@ RunConfig:
             {%- endif %}
             {%- endfor %}
             # TODO: update descriptions as necessary when new ancillary releases are available
-            dem_description: Copernicus DEM GLO-30 2021
-            landcover_description: Land Cover 100m - collection 3 - epoch 2019 discrete classification map
-            worldcover_description: ESA WorldCover 10m 2020 v1.0
+            dem_file_description: Copernicus DEM GLO-30 2021
+            landcover_file_description: Land Cover 100m - collection 3 - epoch 2019 discrete classification map
+            worldcover_file_description: ESA WorldCover 10m 2020 v1.0
+            shoreline_shapefile_description: NOAA GSHHS Level 1 resolution f - GSHHS_f_L1
           primary_executable:
             product_type: DSWX_HLS
           product_path_group:
@@ -74,6 +75,7 @@ RunConfig:
             max_sun_local_inc_angle: 40
             mask_adjacent_to_cloud_mode: 'mask'
             copernicus_forest_classes: [ 20, 111, 113, 115, 116, 121, 123, 125, 126 ]
+            ocean_masking_shoreline_distance_km: 1.0
             save_wtr: True    # Layer 1 - WTR
             save_bwtr: True   # Layer 2 - BWTR
             save_conf: True   # Layer 3 - CONF

--- a/conf/schema/RunConfig_schema.L3_DSWx_HLS.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_HLS.yaml
@@ -47,23 +47,33 @@ RunConfig:
             input_file_path: list(str(), min=1)
 
           dynamic_ancillary_file_group:
-            # Digital elevation model
+            # Digital elevation model file
+            # (REQUIRED if check_ancillary_inputs_coverage is True)
             dem_file: str(required=False)
 
             # Digital elevation model description
-            dem_description: str(required=False)
+            dem_file_description: str(required=False)
 
-            # Land cover map
+            # Copernicus Global Land Service (CGLS) Land Cover Layer file
+            # (REQUIRED if check_ancillary_inputs_coverage is True)
             landcover_file: str(required=False)
 
             # Copernicus Global Land Service (CGLS) Land Cover Layer description
-            landcover_description: str(required=False)
+            landcover_file_description: str(required=False)
 
-            # ESA worldcover map
+            # ESA WorldCover map file
+            # (REQUIRED if check_ancillary_inputs_coverage is True)
             worldcover_file: str(required=False)
 
             # ESA WorldCover map description
-            worldcover_description: str(required=False)
+            worldcover_file_description: str(required=False)
+
+            # NOAA GSHHS shapefile
+            # (REQUIRED if check_ancillary_inputs_coverage is True)
+            shoreline_shapefile: str(required=False)
+
+            # NOAA GSHHS shapefile description
+            shoreline_shapefile_description: str(required=False)
 
           primary_executable:
             product_type: enum('DSWX_HLS')
@@ -78,9 +88,12 @@ RunConfig:
             # SAS writes DSWx-HLS products as a set of GeoTIFF layers
             # All files are saved within the output_directory following
             # the scheme:
-            # {output_dir}/{product_id}_{layer_name}.tif
-            # If the field product_id is left empty, the prefix "dswx_hls"
-            # will be used instead
+            # {output_dir}/{product_id}_v{product_version}_B{layer_number}_{layer_name}.tif
+            # The default value for `product_id` is "dswx_hls".
+            # The default value for `product_version` is the PROTEUS software version.
+            # `layer_number` and `layer_name` are automatically set by the DSWx-HLS SAS
+            # The PGE should update `product_id` and `product_version`
+            # according to the DSWx-HLS product specs.
 
             output_dir: str()
             product_id: str()
@@ -105,6 +118,9 @@ RunConfig:
 
             # Copernicus CGLS Land Cover 100m forest classes
             copernicus_forest_classes: list(int(), min=0, required=False)
+
+            # Ocean masking distance from shoreline in km
+            ocean_masking_shoreline_distance_km: num(required=False)
 
             # Layer 1 - WTR
             save_wtr: bool(required=False)
@@ -152,10 +168,10 @@ RunConfig:
             # of 3660 pixels x 3660 pixels for the PNG browse image.
             # If these fields are left empty, 1024 x 1024 will be used.
 
-            # Height in pixels
+            # Height in pixels for the PNG browse image
             browse_image_height: int(min=1, required=False)
 
-            # Width in pixels
+            # Width in pixels for the PNG browse image
             browse_image_width: int(min=1, required=False)
 
             # Flag to exclude the Partial Surface Water Aggressive (PSW-Agg)

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.6.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.6.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.7.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.7.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.6.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.6.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.7.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.7.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml
@@ -16,12 +16,14 @@ runconfig:
   input_file_group:
     input_file_path: []
   dynamic_ancillary_file_group:
-    # Digital elevation model
+    # Digital elevation model file
     dem_file:  __CHIMERA_VAL__
     # Copernicus Global Land Service (CGLS) Land Cover Layer file
     landcover_file: __CHIMERA_VAL__
     # ESA WorldCover map file
     worldcover_file: __CHIMERA_VAL__
+    # NOAA GSHHS shapefile description
+    shoreline_shapefile: __CHIMERA_VAL__
   product_path_group:
     product_version: __CHIMERA_VAL__
     product_path: output_dir
@@ -56,6 +58,7 @@ preconditions:
   - get_dswx_hls_dem
   - get_landcover
   - get_worldcover
+  - get_shoreline_shapefiles
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
@@ -108,6 +111,18 @@ get_worldcover:
   # They should only be changed when updated Worldcover files are available (yearly)
   worldcover_version: "v100"
   worldcover_year: "2020"
+
+get_shoreline_shapefiles:
+  # The s3 bucket containing the Shoreline shapefile data set
+  s3_bucket: "opera-dist2coast"
+  # Key paths to the files that comprise the Shoreline shapefile data set
+  # Typically should be a set of 4 files, one of which MUST be the .shp which
+  # gets configured within the PGE RunConfig
+  s3_keys:
+    - "GSHHS_f_L1.dbf"
+    - "GSHHS_f_L1.prj"
+    - "GSHHS_f_L1.shp"
+    - "GSHHS_f_L1.shx"
 
 set_daac_product_type:
   template: OPERA_L3_DSWX_HLS_{cnm_version}

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -123,6 +123,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     WORLDCOVER_YEAR = "worldcover_year"
 
+    SHORELINE_SHAPEFILE = "shoreline_shapefile"
+
     PLANNED_OBSERVATION_ID = "PlannedObservationId"
 
     PLANNED_OBSERVATION_TIMESTAMP = "PlannedObservationTimestamp"
@@ -183,6 +185,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     S3_KEY = "s3_key"
 
+    S3_KEYS = "s3_keys"
+
     # PGE names
     #L3_DSWX_HLS = "L3_DSWX_HLS"
 
@@ -238,5 +242,7 @@ class OperaChimeraConstants(ChimeraConstants):
     GET_LANDCOVER = "get_landcover"
 
     GET_WORLDCOVER = "get_worldcover"
+
+    GET_SHORELINE_SHAPEFILES = "get_shoreline_shapefiles"
 
     GET_PGE_SETTINGS_VALUES = "get_pge_settings_values"

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -3,7 +3,7 @@ PGE-specific functions for use with the OPERA PGE Wrapper
 """
 import glob
 import os
-from os.path import basename
+from os.path import basename, splitext
 from typing import Dict
 
 
@@ -52,6 +52,11 @@ def dswx_hls_lineage_metadata(context, work_dir):
     local_worldcover_filepaths = glob.glob(os.path.join(work_dir, "worldcover*.*"))
     lineage_metadata.extend(local_worldcover_filepaths)
 
+    shoreline_shape_filename = run_config["dynamic_ancillary_file_group"]["shoreline_shapefile"]
+    shoreline_shape_basename = splitext(basename(shoreline_shape_filename))[0]
+    local_shoreline_filepaths = glob.glob(os.path.join(work_dir, f"{shoreline_shape_basename}.*"))
+    lineage_metadata.extend(local_shoreline_filepaths)
+
     return lineage_metadata
 
 
@@ -99,5 +104,8 @@ def update_dswx_hls_runconfig(context, work_dir):
     run_config["dynamic_ancillary_file_group"]["dem_file"] = f'{container_home}/input_dir/dem.vrt'
     run_config["dynamic_ancillary_file_group"]["landcover_file"] = f'{container_home}/input_dir/landcover.tif'
     run_config["dynamic_ancillary_file_group"]["worldcover_file"] = f'{container_home}/input_dir/worldcover.vrt'
+
+    shoreline_shape_filename = basename(run_config["dynamic_ancillary_file_group"]["shoreline_shapefile"])
+    run_config["dynamic_ancillary_file_group"]["shoreline_shapefile"] = f'{container_home}/input_dir/{shoreline_shape_filename}'
 
     return run_config


### PR DESCRIPTION
This branch integrates the RC7.0 delivery of the DSWx-HLS PGE with OPERA PCM.

Changes with this version include incorporation of the CalVal v3.3 delivery of the DSWx-HLS SAS and adds support for usage of the Shoreline shapefile static ancillary input products.