### PR TITLE
DSWx-HLS RC 7.1 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -382,7 +382,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -454,7 +454,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -378,7 +378,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -169,7 +169,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -378,7 +378,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -380,7 +380,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,7 +31,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/int/int_override.tf
+++ b/cluster_provisioning/int/int_override.tf
@@ -104,7 +104,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/int/variables.tf
+++ b/cluster_provisioning/int/variables.tf
@@ -347,7 +347,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -428,7 +428,7 @@ variable "lambda_log_retention_in_days" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -328,7 +328,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_dswx_hls" = {
       "instance_type" = ["c5a.large", "c6a.large", "c6i.large"]
       "root_dev_size" = 50
-      "data_dev_size" = 200
+      "data_dev_size" = 50
       "min_size"      = 0
       "max_size"      = 10
       "total_jobs_metric" = true

--- a/cluster_provisioning/ops/override.tf
+++ b/cluster_provisioning/ops/override.tf
@@ -160,7 +160,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
    type = map(string)
    default = {
-     "dswx_hls" = "1.0.0-rc.7.0"
+     "dswx_hls" = "1.0.0-rc.7.1"
   }
 }
 

--- a/cluster_provisioning/ops/variables.tf
+++ b/cluster_provisioning/ops/variables.tf
@@ -353,7 +353,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/pst/override.tf
+++ b/cluster_provisioning/pst/override.tf
@@ -164,7 +164,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
   }
 }
 

--- a/cluster_provisioning/pst/variables.tf
+++ b/cluster_provisioning/pst/variables.tf
@@ -335,7 +335,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0-rc.7.0"
+    "dswx_hls" = "1.0.0-rc.7.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -24,7 +24,7 @@ RunConfig:
         ProductVersion: {{ data.product_path_group.product_version }}
         ProgramPath: python3
         ProgramOptions:
-          - /home/conda/proteus-0.5.2/bin/dswx_hls.py
+          - /home/conda/proteus-0.5.3/bin/dswx_hls.py
           - --full-log-format
         ErrorCodeBase: 100000
         SchemaPath: /home/conda/opera/pge/dswx_hls/schema/dswx_hls_sas_schema.yaml

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.7.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.7.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.7.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.7.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.7.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.7.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.0-rc.7.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0-rc.7.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1102,7 +1102,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.s3_bucket = s3_bucket
         args.outfile = output_filepath
         args.filepath = None
-        args.margin = 400  # KM
+        args.margin = 50  # KM
         args.log_level = LogLevels.INFO.value
 
         # Provide both the bounding box and tile code, stage_dem.py should
@@ -1210,7 +1210,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.worldcover_ver = worldcover_ver
         args.worldcover_year = worldcover_year
         args.outfile = output_filepath
-        args.margin = 400  # KM
+        args.margin = 50  # KM
         args.log_level = LogLevels.INFO.value
 
         # Provide both the bounding box and tile code, stage_worldcover.py should

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -147,26 +147,11 @@ def download_dem(polys, epsgs, dem_bucket, margin, outfile):
         Path to the where the output DEM file is to be staged.
 
     """
-    if 3031 in epsgs:
-        epsgs = [3031] * len(epsgs)
-        polys = transform_polygon_coords_to_epsg(polys, epsgs)
+    # set epsg to 4326 for each element in the list
+    epsgs = [4326] * len(epsgs)
 
-        # Need one EPSG as in polar stereo we have one big polygon
-        epsgs = [3031]
-        margin = margin * 1000
-    elif 3413 in epsgs:
-        epsgs = [3413] * len(epsgs)
-        polys = transform_polygon_coords_to_epsg(polys, epsgs)
-
-        # Need one EPSG as in polar stereo we have one big polygon
-        epsgs = [3413]
-        margin = margin * 1000
-    else:
-        # set epsg to 4326 for each element in the list
-        epsgs = [4326] * len(epsgs)
-
-        # convert margin to degree (approx formula)
-        margin = margin / 40000 * 360
+    # convert margin to degree (approx formula)
+    margin = margin / 40000 * 360
 
     # Download DEM for each polygon/epsg
     file_prefix = os.path.splitext(outfile)[0]


### PR DESCRIPTION
This branch integrates the RC7.1 delivery of the DSWx-HLS PGE with OPERA PCM.

Changes with this version include incorporation of the CalVal v3.4 delivery of the DSWx-HLS SAS, which addresses issues with the ancillary input overlap validation check. 