### PR TITLE
Disable Ancillary Overlap Check for DSWx-HLS

### DIFF
--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -69,7 +69,8 @@ RunConfig:
             product_id: dswx_hls
             product_version: {{ data.product_path_group.product_version }}
           processing:
-            check_ancillary_inputs_coverage: True
+            # TODO: re-enable this check once anti-meridian case for Landcover is resolved in DSWx-HLS SAS
+            check_ancillary_inputs_coverage: False
             shadow_masking_algorithm: sun_local_inc_angle
             min_slope_angle: -5
             max_sun_local_inc_angle: 40


### PR DESCRIPTION
This PR sets the `check_ancillary_inputs_coverage` flag to False in the template RunConfig for DSWx-HLS. This check is disabled while a bug is corrected in the SAS to fix the anti-meridian case with the global Landcover file.

The underlying SAS issue is being addressed here: https://github.com/nasa/PROTEUS/pull/43