### PR TITLE
Update `stage_dem.py` and `stage_worldcover.py` to properly handle the antimeridian crossing

### DIFF
--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -124,6 +124,19 @@ def translate_dem(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     logger.info(f"Translating DEM for projection window {str([x_min, y_max, x_max, y_min])} "
                 f"to {output_path}")
     ds = gdal.Open(vrt_filename, gdal.GA_ReadOnly)
+
+    # update cropping coordinates to not exceed the input DEM bounding box
+    input_x_min, xres, _, input_y_max, _, yres = ds.GetGeoTransform()
+    length = ds.GetRasterBand(1).YSize
+    width = ds.GetRasterBand(1).XSize
+    input_y_min = input_y_max + (length * yres)
+    input_x_max = input_x_min + (width * xres)
+
+    x_min = max(x_min, input_x_min)
+    x_max = min(x_max, input_x_max)
+    y_min = max(y_min, input_y_min)
+    y_max = min(y_max, input_y_max)
+
     gdal.Translate(
         output_path, ds, format='GTiff', projWin=[x_min, y_max, x_max, y_min]
     )

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -130,6 +130,19 @@ def translate_worldcover(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     logger.info(f"Translating Worldcover for projection window {str([x_min, y_max, x_max, y_min])} "
                 f"to {output_path}")
     ds = gdal.Open(vrt_filename, gdal.GA_ReadOnly)
+
+    # update cropping coordinates to not exceed the input DEM bounding box
+    input_x_min, xres, _, input_y_max, _, yres = ds.GetGeoTransform()
+    length = ds.GetRasterBand(1).YSize
+    width = ds.GetRasterBand(1).XSize
+    input_y_min = input_y_max + (length * yres)
+    input_x_max = input_x_min + (width * xres)
+
+    x_min = max(x_min, input_x_min)
+    x_max = min(x_max, input_x_max)
+    y_min = max(y_min, input_y_min)
+    y_max = min(y_max, input_y_max)
+
     gdal.Translate(
         output_path, ds, format='GTiff', projWin=[x_min, y_max, x_max, y_min]
     )

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -122,6 +122,16 @@ def check_dateline(poly):
         decomp = shapely.ops.polygonize(border_lines)
 
         polys = list(decomp)
+        for polygon_count in range(2):
+            x, y = polys[polygon_count].exterior.coords.xy
+            # if there are no longitude values above 180, continue
+            if not any([k > 180 for k in x]):
+                continue
+
+            # otherwise, wrap longitude values down by 360 degrees
+            x_wrapped_minus_360 = np.asarray(x) - 360
+            polys[polygon_count] = Polygon(zip(x_wrapped_minus_360, y))
+
         assert (len(polys) == 2)
     else:
         # If dateline is not crossed, treat input poly as list


### PR DESCRIPTION
This PR fixes `stage_dem.py` and `stage_worldcover.py` to properly handle the antimeridian ("dateline") crossing.

If the antimeridian crossing is detected for `stage_dem.py` and `stage_worldcover.py`, the function `check_dateline()` in `geo_util.py` divides the cropping polygon into two parts, one at the left side, and another one at the right side of the antimeridian crossing. In the current implementation, the polygon at the right side of the antimeridian crossing has longitude values greater than or equal `+180`. However, the input datasets, i.e. the DEM prepared for OPERA (based on the Copernicus DEM) and the ESA Worldcover have longitude ranges around [`-180`, `+180`]. The current version of GDAL translate does not wraps the cropping coordinates above `180` down to `-180` in order to match the input dataset. To fix that, this PR updates the longitude values of the polygon at the right side of the dateline, wrapping them down by `360` degrees.

This PR also limits the cropping coordinates to not exceed the input dataset bounding box. This is done in the functions `download_dem()` and `translate_worldcover()` where the input dataset bounding box is available and can be used to update the cropping coordinates `x_min`, `y_max`, `x_max`, `y_min`.

--- 

Example 1 (`T01UBT`) - Before (left: `dem_0.tif`, center: `dem_1.tif`, and right: `dem.vrt`):
![stage_dem_T01UBT_before](https://user-images.githubusercontent.com/52007211/224846650-0f33eef0-fbc6-4a05-892a-833217c106d0.png)

Example 1 (`T01UBT`) - After (left: `dem_0.tif`, center: `dem_1.tif`, and right: `dem.vrt`):
![stage_dem_T01UBT_after](https://user-images.githubusercontent.com/52007211/224846675-2a9a4d3c-3b5f-4f95-a342-d92bc7a4520c.png)

---

Example 2 (`T60UXC`)- Before (left: `dem_0.tif`, center: `dem_1.tif`, and right: `dem.vrt`):
![stage_dem_T60UXC_before](https://user-images.githubusercontent.com/52007211/224848845-2a0db4a7-258b-426e-bbc5-6dd48c66fef3.png)

Example 2 (`T60UXC`) - After (left: `dem_0.tif`, center: `dem_1.tif`, and right: `dem.vrt`):
![stage_dem_T60UXC_after](https://user-images.githubusercontent.com/52007211/224848883-8073af9f-de3d-4132-a34e-6cece9b94369.png)

