### PR TITLE
DSWx-HLS ancillary margin setting

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -49,8 +49,12 @@ URGENT_RESPONSE_LATENCY:
 # during production.
 
 DSWX_HLS:
+  # Toggle ancillary overlap coverage check during processing
   CHECK_ANCILLARY_INPUTS_COVERAGE: !!bool true
+  # Toggle application of ocean/shoreline masking during processing
   APPLY_OCEAN_MASKING: !!bool false
+  # Amount of margin in km to apply to staged ancillaries (DEM/worldcover)
+  ANCILLARY_MARGIN: 200
 
 PRODUCT_TYPES:
     Observation_Accountability_Report:

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1130,8 +1130,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.s3_bucket = s3_bucket
         args.outfile = output_filepath
         args.filepath = None
-        args.margin = 200  # KM
+        args.margin = int(self._settings.get("DSWX_HLS", {}).get("ANCILLARY_MARGIN", 50))  # KM
         args.log_level = LogLevels.INFO.value
+
+        logger.info(f'Using margin value of {args.margin} with staged DEM')
 
         # Provide both the bounding box and tile code, stage_dem.py should
         # give preference to the tile code over the bbox if both are provided.
@@ -1238,8 +1240,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         args.worldcover_ver = worldcover_ver
         args.worldcover_year = worldcover_year
         args.outfile = output_filepath
-        args.margin = 200  # KM
+        args.margin = int(self._settings.get("DSWX_HLS", {}).get("ANCILLARY_MARGIN", 50))  # KM
         args.log_level = LogLevels.INFO.value
+
+        logger.info(f'Using margin value of {args.margin} with staged Worldcover')
 
         # Provide both the bounding box and tile code, stage_worldcover.py should
         # give preference to the tile code over the bbox if both are provided.

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -328,8 +328,9 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
             }
         }
 
+        settings = {"DSWX_HLS": {"ANCILLARY_MARGIN": 50}}
+
         # These are not used with get_dems()
-        settings = None
         job_params = None
 
         precondition_functions = OperaPreConditionFunctions(
@@ -414,8 +415,9 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
             }
         }
 
+        settings = {"DSWX_HLS": {"ANCILLARY_MARGIN": 50}}
+
         # These are not used with get_worldcover()
-        settings = None
         job_params = None
 
         precondition_functions = OperaPreConditionFunctions(


### PR DESCRIPTION
This branch exposes the margin value used when staging the DEM and worldcover ancillaries files for DSWx-HLS jobs in settings.yaml. This should hopefully make it easier to adjust the value as necessary without necessitating a full redeployment.

Note this branch does not resolve the current issue with the overlap check on anti-meridian HLS tiles.