### PR TITLE
DSWx-HLS PGE v1.0.1 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -382,7 +382,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -454,7 +454,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -378,7 +378,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -172,7 +172,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -378,7 +378,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -380,7 +380,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -30,7 +30,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -435,7 +435,7 @@ variable "lambda_log_retention_in_days" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-er.5.0"
     "rtc_s1" = "2.0.0-er.5.1"
   }

--- a/cluster_provisioning/ops/override.tf
+++ b/cluster_provisioning/ops/override.tf
@@ -137,11 +137,11 @@ variable "artifactory_repo" {
   default = "general-stage"
 }
 
-<<<<<<< HEAD
 variable "use_artifactory" {
-  type = bool
+  type    = bool
   default = true
-=======
+}
+
 ######### ami vars #######
 variable "amis" {
   type = map(string)
@@ -165,9 +165,8 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
    type = map(string)
    default = {
-     "dswx_hls" = "1.0.0"
+     "dswx_hls" = "1.0.1"
   }
->>>>>>> develop
 }
 
 variable "hysds_release" {

--- a/cluster_provisioning/pst/override.tf
+++ b/cluster_provisioning/pst/override.tf
@@ -150,7 +150,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.0"
+    "dswx_hls" = "1.0.1"
   }
 }
 

--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -24,7 +24,7 @@ RunConfig:
         ProductVersion: {{ data.product_path_group.product_version }}
         ProgramPath: python3
         ProgramOptions:
-          - /home/conda/proteus-1.0.0/bin/dswx_hls.py
+          - /home/conda/proteus-1.0.1/bin/dswx_hls.py
           - --full-log-format
         ErrorCodeBase: 100000
         SchemaPath: /home/conda/opera/pge/dswx_hls/schema/dswx_hls_sas_schema.yaml

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS_on_demand
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
This branch integrates the latest v1.0.1 release of the DSWx-HLS PGE, which wraps the corresponding version of the SAS. This version fixes more issues in the SAS when performing the DEM overlap check on HLS tiles that cross the anti-meridian/dateline.

Note: while updating the terraform scripts, I noticed that an unresolved code conflict was checked in for the `cluster_provisioning/ops/override.tf` file. I have resolved the conflicting section as part of the PR.