### PR TITLE
Add margin before antimeridian crossing test

### DIFF
--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -53,7 +53,7 @@ def get_parser():
     parser.add_argument('-m', '--margin', type=int, action='store',
                         default=5, help='Margin for DEM bounding box in km.')
     parser.add_argument("--log-level",
-                        gype=lambda log_level: LogLevels[log_level].value,
+                        type=lambda log_level: LogLevels[log_level].value,
                         choices=LogLevels.list(),
                         default=LogLevels.INFO.value,
                         help="Specify a logging verbosity level.")

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -75,8 +75,8 @@ def determine_polygon(tile_code, bbox=None, margin_in_km=50):
         code.
     margin_in_km: float, optional
         Margin in kilometers to be added to MGRS bounding box obtained from the
-        MGRS `tile_code`. This margin is not added when the parameter `bbox` is
-        used.
+        MGRS `tile_code`. This margin is not added to the bounding box
+        defined from the input parameter `bbox`.
 
     Returns
     -------

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -279,7 +279,7 @@ def main(opts):
     if not opts.s3_bucket:
         opts.s3_bucket = S3_DEM_BUCKET
 
-    # Determine polygon based on MGRS grid reference with a margin or bbox
+    # Determine polygon based on MGRS grid reference with a margin, or bbox
     poly = determine_polygon(opts.tile_code, opts.bbox, opts.margin)
 
     # Check dateline crossing. Returns list of polygons

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -173,8 +173,6 @@ def download_worldcover(polys, worldcover_bucket, worldcover_ver,
         Path to the where the output Worldcover file is to be staged.
 
     """
-    # convert margin to degree (approx formula)
-    margin = margin / 40000 * 360
 
     # Download Worldcover map for each polygon/epsg
     file_prefix = os.path.splitext(outfile)[0]

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -259,7 +259,7 @@ def main(opts):
     if not opts.worldcover_year:
         opts.worldcover_year = WORLDCOVER_YEAR
 
-    # Determine polygon based on MGRS info or bbox
+    # Determine polygon based on MGRS grid reference with a margin, or bbox
     poly = determine_polygon(opts.tile_code, opts.bbox, opts.margin)
 
     # Check dateline crossing. Returns list of polygons

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -67,7 +67,7 @@ def get_parser():
     return parser
 
 
-def determine_polygon(tile_code, bbox=None):
+def determine_polygon(tile_code, bbox=None, margin_in_km=50):
     """
     Determine bounding polygon using MGRS tile code or user-defined bounding box.
 
@@ -79,6 +79,10 @@ def determine_polygon(tile_code, bbox=None):
         Bounding box with lat/lon coordinates (decimal degrees) in the form of
         [West, South, East, North]. If provided, takes precedence over the tile
         code.
+    margin_in_km: float, optional
+        Margin in kilometers to be added to MGRS bounding box obtained from the
+        MGRS `tile_code`. This margin is not added when the parameter `bbox` is
+        used.
 
     Returns
     -------
@@ -92,7 +96,7 @@ def determine_polygon(tile_code, bbox=None):
         poly = box(bbox[0], bbox[1], bbox[2], bbox[3])
     else:
         logger.info(f'Determining polygon from MGRS tile code {tile_code}')
-        poly = polygon_from_mgrs_tile(tile_code)
+        poly = polygon_from_mgrs_tile(tile_code, margin_in_km)
 
     logger.debug(f'Derived polygon {str(poly)}')
 
@@ -149,7 +153,7 @@ def translate_worldcover(vrt_filename, output_path, x_min, x_max, y_min, y_max):
 
 
 def download_worldcover(polys, worldcover_bucket, worldcover_ver,
-                        worldcover_year, margin, outfile):
+                        worldcover_year, outfile):
     """
     Download a Worldcover map from the esa-worldcover bucket.
 
@@ -165,8 +169,6 @@ def download_worldcover(polys, worldcover_bucket, worldcover_ver,
     worldcover_year : str
         Year of the full Worldcover map to download from. Becomes part of the
         S3 key used to download.
-    margin: float
-        Buffer margin (in km) applied for Worldcover download.
     outfile:
         Path to the where the output Worldcover file is to be staged.
 
@@ -184,7 +186,6 @@ def download_worldcover(polys, worldcover_bucket, worldcover_ver,
             f'ESA_WorldCover_10m_{worldcover_year}_{worldcover_ver}_Map_AWS.vrt'
         )
 
-        poly = poly.buffer(margin)
         output_path = f'{file_prefix}_{idx}.tif'
         wc_list.append(output_path)
         x_min, y_min, x_max, y_max = poly.bounds
@@ -259,7 +260,7 @@ def main(opts):
         opts.worldcover_year = WORLDCOVER_YEAR
 
     # Determine polygon based on MGRS info or bbox
-    poly = determine_polygon(opts.tile_code, opts.bbox)
+    poly = determine_polygon(opts.tile_code, opts.bbox, opts.margin)
 
     # Check dateline crossing. Returns list of polygons
     polys = check_dateline(poly)
@@ -271,7 +272,7 @@ def main(opts):
 
     # Download Worldcover map(s)
     download_worldcover(polys, opts.s3_bucket, opts.worldcover_ver,
-                        opts.worldcover_year, opts.margin, opts.outfile)
+                        opts.worldcover_year, opts.outfile)
 
     logger.info(f'Done, Worldcover map stored locally to {opts.outfile}')
 

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -81,8 +81,8 @@ def determine_polygon(tile_code, bbox=None, margin_in_km=50):
         code.
     margin_in_km: float, optional
         Margin in kilometers to be added to MGRS bounding box obtained from the
-        MGRS `tile_code`. This margin is not added when the parameter `bbox` is
-        used.
+        MGRS `tile_code`. This margin is not added to the bounding box
+        defined from the input parameter `bbox`.
 
     Returns
     -------


### PR DESCRIPTION
This PR fixes `stage_dem.py` and `stage_worldcover.py` for the case in which the MGRS tile does not cross the antimeridian, but the added margin should result in antimeridian crossing. The fact that the MGRS tile does not cross the dateline prevents the current code from detecting the antimeridian crossing and subsequently dividing the tile polygon into two pieces.

The solution is to add the margin before the antimeridian crossing test. This PR adds the margin (in km) to the tile coordinates in meters, which may be preferable, but keeps them conversion using the meters-to-degrees conversion at the Equator (i.e., with longitude margin matching the latitude margin) as the default. This option is selected by the flag `flag_use_m_to_deg_conversion_at_equator` in the call to the function `polygon_from_mgrs_tile()`.