### PR TITLE
Fix "index out of range" in check_dateline() function 

### DIFF
--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -166,7 +166,8 @@ def check_dateline(poly):
         decomp = shapely.ops.polygonize(border_lines)
 
         polys = list(decomp)
-        for polygon_count in range(2):
+
+        for polygon_count in range(len(polys)):
             x, y = polys[polygon_count].exterior.coords.xy
             # if there are no longitude values above 180, continue
             if not any([k > 180 for k in x]):
@@ -176,7 +177,6 @@ def check_dateline(poly):
             x_wrapped_minus_360 = np.asarray(x) - 360
             polys[polygon_count] = Polygon(zip(x_wrapped_minus_360, y))
 
-        assert (len(polys) == 2)
     else:
         # If dateline is not crossed, treat input poly as list
         polys = [poly]

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -123,8 +123,9 @@ def polygon_from_mgrs_tile(mgrs_tile_code, margin_in_km,
             if lat_max is None or lat_max < lat:
                 lat_max = lat
 
-            # Need to check `offset_x_multiplier` because of the wrapping of
-            # longitude angles (example: 179 + 2 = -179 degrees)
+            # The computation of min and max longitude values may be affected
+            # by antimeridian crossing. Notice that: 179 degrees +
+            # 2 degrees = -179 degrees
             #
             # The condition `abs(lon_min - lon) < 180`` tests if both longitude
             # values are both at the same side of the dateline (either left
@@ -134,14 +135,18 @@ def polygon_from_mgrs_tile(mgrs_tile_code, margin_in_km,
             # longitude point is at the left side of the antimeridian crossing
             # (`> 100`) or at the right side (`< 100`)
             #
-            # West boundaries (offset_x_multiplier == 0) update `lon_min`
+            # We also want to check if the point is at the west or east
+            # side of the tile.
+            # Points at the west, i.e, where offset_x_multiplier == 0
+            # may update `lon_min`
             if (offset_x_multiplier == 0 and
                     (lon_min is None or
                     (abs(lon_min - lon) < 180 and lon_min > lon) or
                     (lon > 100 and lon_min < -100))):
                 lon_min = lon
 
-            # East boundaries (offset_x_multiplier == 1) update `lon_max`
+            # Points at the east, i.e, where offset_x_multiplier == 1
+            # may update `lon_max`
             if (offset_x_multiplier == 1 and
                     (lon_max is None or
                     (abs(lon_min - lon) < 180 and lon_max < lon) or

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -92,6 +92,8 @@ def polygon_from_mgrs_tile(mgrs_tile_code, margin_in_km,
     else:
         margin_in_deg = 0
 
+    vertices_list = []
+
     for offset_x_multiplier in range(2):
         for offset_y_multiplier in range(2):
 
@@ -112,24 +114,11 @@ def polygon_from_mgrs_tile(mgrs_tile_code, margin_in_km,
                 lon += 2 * (float(offset_x_multiplier) - 0.5) * margin_in_deg
                 lat += 2 * (float(offset_y_multiplier) - 0.5) * margin_in_deg
 
-            if lat_min is None or lat_min > lat:
-                lat_min = lat
-            if lat_max is None or lat_max < lat:
-                lat_max = lat
-            if lon_min is None or lon_min > lon:
-                lon_min = lon
-            if lon_max is None or lon_max < lon:
-                lon_max = lon
+            vertices_list.append([lon, lat])
 
-    # In the case of antimeridian crossing, `lon_max - lon_min` will be greater
-    # than 180 deg, and the MGRS tile polygon will represent the complement
-    # (in longitude) of the actual tile polygon. This edge case will be detected
-    # and handled by the subsequent function `check_dateline()`
-    coords = [lon_min, lat_min, lon_max, lat_max]
+    poly = Polygon(vertices_list)
 
-    poly = box(*coords)
-
-    return poly
+    return poly.envelope
 
 
 def check_dateline(poly):


### PR DESCRIPTION
This PR fixes an "index out of range" error in the `check_dateline()` function. In some specific cases, it's possible that the input polygon does not cross the antimeridian, but it still enters the dateline check condition. For example, if the longitude range of a tile is [179, -180.5], the tile is completely contained in the left side of the antimeridian and does not cross the antimeridian line. This PR updates `check_dateline()` to handle the case in which the list of polygons obtained from the antimeridian split will have 1 element (i.e., one polygon), and not 2 as expected from the current code. 

Edit: This PR also updates the computation of min and max longitude values in `polygon_from_mgrs_tile()`. Longitude values "wrap" around the antimeridian crossing. For example, 179 degrees + 2 degrees can be represented as -179 degrees . The new logic computes min and max longitude taking into account if the vertex is as the western or easter boundary of the tile and also if there's wrapping in the comparison of longitude values.