### PR TITLE
Ionosphere workflow corrections

### DIFF
--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -190,7 +190,7 @@ def download_from_asf(
             )
             stage_orbit_file.main(stage_orbit_file_args)
         except NoQueryResultsException:
-            logging.warning("No POEORB file could be found, querying for Restituted Orbit (ROEORB) file")
+            logging.warning("POEORB file could not be found, querying for Restituted Orbit (ROEORB) file")
             stage_orbit_file_args = stage_orbit_file.get_parser().parse_args(
                 [
                     f"--output-directory={str(dataset_dir)}",
@@ -207,18 +207,29 @@ def download_from_asf(
         try:
             stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
                 [
+                    f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPLG}"
                     f"--output-directory={str(dataset_dir)}",
                     str(product_filepath)
                 ]
             )
             stage_ionosphere_file.main(stage_ionosphere_file_args)
-
-            logging.info("Added Ionosphere correction file to dataset")
+            logging.info("Added JPLG Ionosphere correction file to dataset")
         except IonosphereFileNotFoundException:
-            # TODO: check toggle to see if job should fail or not based on this
-            raise RuntimeError(
-                f"Could not find an Ionosphere Correction file for product {product_filepath}"
-            )
+            logging.warning("JPLG file type could not be found, querying for JPRG file type")
+            try:
+                stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
+                    [
+                        f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPRG}"
+                        f"--output-directory={str(dataset_dir)}",
+                        str(product_filepath)
+                    ]
+                )
+                stage_ionosphere_file.main(stage_ionosphere_file_args)
+                logging.info("Added JPRG Ionosphere correction file to dataset")
+            except IonosphereFileNotFoundException:
+                logging.warning(
+                    f"Could not find any Ionosphere Correction file for product {product_filepath}"
+                )
 
         logging.info(f"Removing {product_filepath}")
         product_filepath.unlink(missing_ok=True)

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -202,34 +202,34 @@ def download_from_asf(
 
         logging.info("Added orbit file to dataset")
 
-        logging.info("Downloading associated Ionosphere Correction file")
-
-        try:
-            stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
-                [
-                    f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPLG}"
-                    f"--output-directory={str(dataset_dir)}",
-                    str(product_filepath)
-                ]
-            )
-            stage_ionosphere_file.main(stage_ionosphere_file_args)
-            logging.info("Added JPLG Ionosphere correction file to dataset")
-        except IonosphereFileNotFoundException:
-            logging.warning("JPLG file type could not be found, querying for JPRG file type")
+        if additional_metadata.get("intersects_north_america", False):
+            logging.info("Downloading associated Ionosphere Correction file")
             try:
                 stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
                     [
-                        f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPRG}"
+                        f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPLG}",
                         f"--output-directory={str(dataset_dir)}",
                         str(product_filepath)
                     ]
                 )
                 stage_ionosphere_file.main(stage_ionosphere_file_args)
-                logging.info("Added JPRG Ionosphere correction file to dataset")
+                logging.info("Added JPLG Ionosphere correction file to dataset")
             except IonosphereFileNotFoundException:
-                logging.warning(
-                    f"Could not find any Ionosphere Correction file for product {product_filepath}"
-                )
+                logging.warning("JPLG file type could not be found, querying for JPRG file type")
+                try:
+                    stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
+                        [
+                            f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPRG}",
+                            f"--output-directory={str(dataset_dir)}",
+                            str(product_filepath)
+                        ]
+                    )
+                    stage_ionosphere_file.main(stage_ionosphere_file_args)
+                    logging.info("Added JPRG Ionosphere correction file to dataset")
+                except IonosphereFileNotFoundException:
+                    logging.warning(
+                        f"Could not find any Ionosphere Correction file for product {product_filepath}"
+                    )
 
         logging.info(f"Removing {product_filepath}")
         product_filepath.unlink(missing_ok=True)

--- a/tests/data_subscriber/test_daac_data_subscriber.py
+++ b/tests/data_subscriber/test_daac_data_subscriber.py
@@ -507,7 +507,17 @@ def test_download_from_asf(monkeypatch):
     )
 
     # ACT
-    download.download_from_asf(session=MagicMock(), es_conn=MagicMock(), downloads=[{"https_url": "https://www.example.com/dummy_slc_product.zip"}], args=Args(), token=None, job_id=None)
+    download.download_from_asf(session=MagicMock(),
+                               es_conn=MagicMock(),
+                               downloads=[
+                                   {
+                                       "https_url": "https://www.example.com/dummy_slc_product.zip",
+                                       "intersects_north_america": True
+                                   }
+                               ],
+                               args=Args(),
+                               token=None,
+                               job_id=None)
 
     # ASSERT
     mock_extract_one_to_one.assert_called_once()

--- a/tools/stage_ionosphere_file.py
+++ b/tools/stage_ionosphere_file.py
@@ -201,6 +201,9 @@ def safe_start_date_to_julian_day(safe_start_date):
     year = time_tuple.tm_year
     doy = time_tuple.tm_yday
 
+    # Make sure the DOY is zero-padded
+    doy = f"{int(doy):03d}"
+
     logger.debug(f'year: {year} doy: {doy}')
 
     return str(year), str(doy)
@@ -344,7 +347,7 @@ def main(args):
 
     # Formulate the archive name and URL location based on the file type and
     # the Julian date of the SLC archive
-    archive_name = f"{args.type}{int(doy):03d}0.{year[2:]}i.Z"
+    archive_name = f"{args.type}{doy}0.{year[2:]}i.Z"
     request_url = join(args.download_endpoint, year, doy, archive_name)
 
     # If user request the URL only, print it to standard out and the log

--- a/tools/stage_ionosphere_file.py
+++ b/tools/stage_ionosphere_file.py
@@ -31,6 +31,11 @@ DEFAULT_DOWNLOAD_ENDPOINT = "https://cddis.nasa.gov/archive/gnss/products/ionex"
 DEFAULT_EDL_ENDPOINT = "urs.earthdata.nasa.gov"
 """Default endpoint for authenticating with EarthData Login"""
 
+IONOSPHERE_TYPE_JPLG = "jplg"
+IONOSPHERE_TYPE_JPRG = "jprg"
+VALID_IONOSPHERE_TYPES = [IONOSPHERE_TYPE_JPLG, IONOSPHERE_TYPE_JPRG]
+"""The valid Ionosphere file types that this script can download"""
+
 class IonosphereFileNotFoundException(Exception):
     """Exception to identify no result found (404) for a requested Ionosphere archive"""
     pass
@@ -59,6 +64,10 @@ def get_parser():
                         help="Specify the EarthData Login password to use with "
                              "the download request. If a password is not provided, "
                              "it is obtained from the local .netrc file.")
+    parser.add_argument("-t", "--type", type=str.lower, choices=VALID_IONOSPHERE_TYPES,
+                        default=IONOSPHERE_TYPE_JPLG,
+                        help=f"Specify the type of Ionosphere file to download. "
+                             f"Must be one of {VALID_IONOSPHERE_TYPES}")
     parser.add_argument("--url-only", action="store_true",
                         help="Only output the URL from where the resulting Ionosphere "
                              "file may be downloaded from.")
@@ -320,7 +329,7 @@ def main(args):
         )
 
     # Get username/password from netrc file if neither were provided via command-line
-    if args.username is None and args.password is None:
+    if args.username is None and args.password is None and not args.url_only:
         args.username, _, args.password = netrc.netrc().authenticators(DEFAULT_EDL_ENDPOINT)
 
     logger.info(f"Determining Ionosphere file for input SAFE file {args.input_safe_file}")
@@ -333,9 +342,9 @@ def main(args):
     # Convert start date to Year and Day of Year (Julian date)
     year, doy = safe_start_date_to_julian_day(safe_start_date)
 
-    # formulate the archive name and URL location based on the Julian date of the SLC archive
-    # TODO: add support for the "jprg" version of the file
-    archive_name = f"jplg{int(doy):03d}0.{year[2:]}i.Z"
+    # Formulate the archive name and URL location based on the file type and
+    # the Julian date of the SLC archive
+    archive_name = f"{args.type}{int(doy):03d}0.{year[2:]}i.Z"
     request_url = join(args.download_endpoint, year, doy, archive_name)
 
     # If user request the URL only, print it to standard out and the log


### PR DESCRIPTION
This branch makes the following corrections to the workflow for downloading an Ionosphere correction file for use with CSLC-S1 jobs:

- The Ionosphere staging script now supports downloading both the "jplg" (latency 48 hours) and the "jprg" (latency 24-36 hours) types.
- The DAAC download script will now attempt to download a "jplg" file type, and if is not found then it will try to download the "jprg" type.
- If neither Ionosphere type can be found by the DAAC download script, then only a warning will be logged, rather than failing the entire SLC download job. This means only the CLSC-S1 jobs will now fail if no Ionosphere file was downloaded. RTC-S1 jobs will be unaffected.
- The DAAC download script only downloads Ionosphere files for SLC archives that intersect North America (meaning that a CSLC-S1 job would be triggered).
- Fixes a bug where the DOY value used to formulate the download URL for Ionosphere files was not zero padded.