### PR TITLE
CSLC v2.0.0-RC.1.1 integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -383,7 +383,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -455,7 +455,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -307,7 +307,7 @@ variable "po_daac_endpoint_url" {
 
 #The value of asf_daac_delivery_proxy can be
 # for DEV: arn:aws:sqs:us-west-2:871271927522:asf-cumulus-dev-opera-cnm-ingest-queue
-# for dev-int: 
+# for dev-int:
 variable "asf_daac_delivery_proxy" {
   #default = "arn:aws:sqs:us-west-2:681612454726:daac-proxy-for-opera"
   default = "arn:aws:sqs:us-west-2:156214815904:asf-cumulus-int-opera-cnm-ingest-queue"
@@ -381,7 +381,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -379,7 +379,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -381,7 +381,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,7 +31,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -438,7 +438,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.0"
+    "cslc_s1" = "2.0.0-rc.1.1"
     "rtc_s1" = "2.0.0-rc.1.0"
   }
 }

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
This branch updates the version of the CSLC-S1 PGE in PCM to v2.0.0-RC.1.1. This version fixes a bug that prevented CSLC-S1 jobs from running from any other year than 2022.