### PR TITLE
RTC-S1 v2.0.0-RC.1.1 integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -384,7 +384,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -456,7 +456,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -382,7 +382,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -380,7 +380,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -382,7 +382,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -32,7 +32,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -439,7 +439,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.1.1"
-    "rtc_s1" = "2.0.0-rc.1.0"
+    "rtc_s1" = "2.0.0-rc.1.1"
   }
 }
 

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.0-rc.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-rc.1.0.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.0.0-rc.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-rc.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
This branch updates the version of the RTC-S1 PGE in PCM to v2.0.0-RC.1.1. This version fixes a bug where RTC products for certain polarization settings were not being renamed properly by the PGE.

The following SLC datasets were used to test fix in PCM:

S1A_IW_SLC__1SSH_20220411T020928_20220411T020958_042719_05190E_4B70 (single HH polarization)
S1A_IW_SLC__1SDH_20220411T193329_20220411T193344_042730_051965_CF2A (HH and HV polarizations)