### PR TITLE
CSLC-S1 v2.0.0 RC.1.2 integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -383,7 +383,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -455,7 +455,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -381,7 +381,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -379,7 +379,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -381,7 +381,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,7 +31,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -438,7 +438,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.2"
     "rtc_s1" = "2.0.0-rc.1.1"
   }
 }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -319,7 +319,7 @@ variable "queues" {
       "total_jobs_metric" = true
     }
     "opera-job_worker-sciflo-l2_cslc_s1" = {
-      "instance_type" = ["c6a.2xlarge", "c6i.2xlarge"]
+      "instance_type" = ["c6a.4xlarge", "c6i.4xlarge"]
       "root_dev_size" = 50
       "data_dev_size" = 150
       "max_size"      = 10

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -52,7 +52,7 @@ URGENT_RESPONSE_LATENCY:
 
 CSLC_S1:
   # Toggle static layer generation during processing
-  ENABLE_STATIC_LAYERS: !!bool false
+  ENABLE_STATIC_LAYERS: !!bool true
 
 DSWX_HLS:
   # Toggle ancillary overlap coverage check during processing

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.1.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.2",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.2.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
This branch integrates v2.0.0-rc.1.2 of the CSLC-S1 PGE into PCM. This version resolves the long runtime issue for generation of CSLC-S1 static layers. Static layer generation for CSLC-S1 has been re-enabled in settings.yaml.

This branch was tested with a single SLC archive on both c6[a/i].2xlarge and c6[a/i].4xlarge instances. The runtimes were:

**c6a.2xlarge/c6i.2xlarge**
SAS runtime: 2:44:03 (hr:min:sec)
PGE/SAS runtime: 10348.026279071
PCM runtime (PGE/SAS runtime + upload time to S3 rolling storage): 11355.594818s

**c6a.4xlarge/c6i.4xlarge**
SAS runtime: 1:38:33 (hr:min:sec)
PGE/SAS runtime: 6230.522144275 sec
PCM runtime (PGE/SAS runtime + upload time to S3 rolling storage): 7147.259063 sec

The instance types for the CSLC-S1 workers have been updated to the c6[a/i].4xlarge instances based on these metrics.

