### PR TITLE
R2 PGE 2.0.0 RC 1.3 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -383,8 +383,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -455,8 +455,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -381,8 +381,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -173,8 +173,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-er.5.0"
-    "rtc_s1" = "2.0.0-er.5.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -379,8 +379,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -381,8 +381,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,8 +31,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -442,8 +442,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.1.2"
-    "rtc_s1" = "2.0.0-rc.1.1"
+    "cslc_s1" = "2.0.0-rc.1.3"
+    "rtc_s1" = "2.0.0-rc.1.3"
   }
 }
 

--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -79,7 +79,7 @@ RunConfig:
             product_path: {{ data.product_path_group.product_path }}
             scratch_path: {{ data.product_path_group.scratch_path }}
             sas_output_file: {{ data.product_path_group.product_path }}
-            product_version: {{ data.product_path_group.product_version }}
+            product_version: "{{ data.product_path_group.product_version }}"
           primary_executable:
             product_type: CSLC_S1
           processing:

--- a/conf/schema/RunConfig_schema.L2_CSLC_S1.yaml
+++ b/conf/schema/RunConfig_schema.L2_CSLC_S1.yaml
@@ -73,7 +73,9 @@ RunConfig:
             # PGE may rename the product according to file naming convention
             sas_output_file: str()
             # Product version
-            product_version: num(required=False)
+            product_version: str(required=False)
+            # Product specification document version
+            product_specification_version: str(required=False)
 
           primary_executable:
             product_type: enum('CSLC_S1')

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -47,8 +47,13 @@ URGENT_RESPONSE_LATENCY:
     # Latency period in minutes. Expiration time is calculated from when the LDF is being processed.
 #    RRST_EVALUATOR: 60
 
+
 # This area is intended to be used to set any PGE configurable settings that an operator can change
 # during production.
+
+# Time range values to use when querying for Orbit files for use with SLC-based jobs
+POE_ORBIT_TIME_RANGE: 2  # Days
+RES_ORBIT_TIME_RANGE: 3  # Hours
 
 CSLC_S1:
   # Toggle static layer generation during processing
@@ -65,6 +70,8 @@ DSWX_HLS:
 RTC_S1:
   # Toggle static layer generation during processing
   ENABLE_STATIC_LAYERS: !!bool true
+
+# End PGE Configuration section
 
 PRODUCT_TYPES:
     Observation_Accountability_Report:

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -185,6 +185,7 @@ def download_from_asf(
                 [
                     f"--output-directory={str(dataset_dir)}",
                     "--orbit-type=POEORB",
+                    f"--query-time-range={settings_cfg.get('POE_ORBIT_TIME_RANGE', stage_orbit_file.DEFAULT_POE_TIME_RANGE)}",
                     str(product_filepath)
                 ]
             )
@@ -195,6 +196,7 @@ def download_from_asf(
                 [
                     f"--output-directory={str(dataset_dir)}",
                     "--orbit-type=RESORB",
+                    f"--query-time-range={settings_cfg.get('RES_ORBIT_TIME_RANGE', stage_orbit_file.DEFAULT_RES_TIME_RANGE)}",
                     str(product_filepath)
                 ]
             )

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.2",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.2.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.3.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.1.3.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.0-rc.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-rc.1.1.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.0.0-rc.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-rc.1.3.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -1,8 +1,8 @@
 {
   "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
   "disk_usage":"70GB",
-  "soft_time_limit": 8000,
-  "time_limit": 8060,
+  "soft_time_limit": 30000,
+  "time_limit": 30060,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",


### PR DESCRIPTION
This branch integrates the v2.0.0-rc.1.3 releases of the R2 PGEs into PCM. It also updates the stage_orbit_file.py script to expose the date range used when querying as a command-line argument. This value can be set in settings.yaml so it may be adjusted without requiring a redeployment. The default for POEORB files in settings.yaml has been set to 2 days to resolve orbit file download errors for a particular time range in April 2021.

The following issues were tested with this release to ensure the processing now completes successfully:

* RTC-S1 processing fails with `KeyError: 't175_371592_iw1'` - Tested with data set S1A_IW_SLC__1SDV_20210419T162132_20210419T162200_037521_046C9E_CF36
* SLC Download fails to find an Orbit file for time range in April 2021 - Tested with data set S1A_IW_SLC__1SDV_20210214T233829_20210214T233857_036593_044C7E_8FC3
* CSLC-S1 processing fails with `ValueError: maximum value not > minimum value` during creation of the browse image - Tested with S1B_IW_SLC__1SDV_20210413T183008_20210413T183038_026452_032874_7CBB

The following issues still seem to be present with this release:
* RTC-S1 jobs that use an inordinate amount of resources, causing them to either time out or go into "offline" state - Tested with data sets S1B_IW_SLC__1SDV_20210412T042700_20210412T042727_026429_0327AA_7A06 and S1B_IW_SLC__1SDV_20210413T214536_20210413T214612_026454_032884_DCE7.

The time out for RTC-S1 jobs has been increased to try to accommodate this issue, but large memory usage can still cause these jobs to into offline state.