### PR TITLE
Issue 500 r2: Handle native-id download for HLS and SLC 

### DIFF
--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -71,7 +71,7 @@ def run_download(args, token, es_conn, netloc, username, password, job_id):
         if args.collection=='HLSL30' or args.collection=='HLSS30':
             result = es_conn.es.query(index='hls_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
-        else if args.collection == "SENTINEL-1A_SLC" or args.collection == "SENTINEL-1B_SLC":
+        elif args.collection == "SENTINEL-1A_SLC" or args.collection == "SENTINEL-1B_SLC":
             result = es_conn.es.query(index='slc_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -68,10 +68,10 @@ def run_download(args, token, es_conn, netloc, username, password, job_id):
         one_granule = args.batch_ids[0]
         logging.info(f"Downloading files for the granule {one_granule}")
 
-        if 'HLS' in one_granule:
+        if "HLS" in one_granule:
             result = es_conn.es.query(index='hls_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
-        elif 'SLC' in ond_granule:
+        elif "SLC" in ond_granule:
             result = es_conn.es.query(index='slc_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -71,7 +71,7 @@ def run_download(args, token, es_conn, netloc, username, password, job_id):
         if "HLS" in one_granule:
             result = es_conn.es.query(index='hls_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
-        elif "SLC" in ond_granule:
+        elif "SLC" in one_granule:
             result = es_conn.es.query(index='slc_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -71,7 +71,8 @@ def run_download(args, token, es_conn, netloc, username, password, job_id):
         if "HLS" in one_granule:
             result = es_conn.es.query(index='hls_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
-        elif "SLC" in one_granule:
+        #elif "SLC" in one_granule:
+        else:
             result = es_conn.es.query(index='slc_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -68,10 +68,10 @@ def run_download(args, token, es_conn, netloc, username, password, job_id):
         one_granule = args.batch_ids[0]
         logging.info(f"Downloading files for the granule {one_granule}")
 
-        if args.collection=='HLSL30' or args.collection=='HLSS30':
+        if 'HLS' in one_granule:
             result = es_conn.es.query(index='hls_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
-        elif args.collection == "SENTINEL-1A_SLC" or args.collection == "SENTINEL-1B_SLC":
+        elif 'SLC' in ond_granule:
             result = es_conn.es.query(index='slc_catalog',
                      body={"query": {"bool": {"must": [{"match": {"granule_id" : one_granule}}]}}})
 


### PR DESCRIPTION
When downloading batch id length is 1, do a direct ES query for that granule id to save resources.