### PR TITLE
Issue 545: perf(slc): optimize EC2 instance types.

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -177,7 +177,7 @@ variable "lambda_role_arn" {
 
 variable "es_bucket_role_arn" {
   default = "arn:aws:iam::681612454726:role/am-es-role"
-#  default = "arn:aws:iam::271039147104:role/am-es-role"
+  #  default = "arn:aws:iam::271039147104:role/am-es-role"
 }
 
 variable "es_snapshot_bucket" {
@@ -287,125 +287,125 @@ variable "lambda_package_release" {
 variable "queues" {
   default = {
     "opera-job_worker-hls_data_ingest" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "min_size"      = 0
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "min_size"          = 0
+      "max_size"          = 10
+      "total_jobs_metric" = true
+    }
+    "opera-job_worker-sciflo-l2_cslc_s1_hist" = {
+      "instance_type"     = ["c6a.4xlarge", "c6i.4xlarge", "c6a.2xlarge", "c6i.2xlarge", "c5a.4xlarge", "c5.4xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 300
+      "max_size"          = 10
       "total_jobs_metric" = true
     }
     "opera-job_worker-sciflo-l2_cslc_s1" = {
-      "instance_type" = ["c6a.4xlarge", "c6i.4xlarge"]
-      "root_dev_size" = 50
-      "data_dev_size" = 300
-      "max_size"      = 10
+      "instance_type"     = ["c6a.4xlarge", "c6i.4xlarge", "c6a.2xlarge", "c6i.2xlarge", "c5a.4xlarge", "c5.4xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 300
+      "max_size"          = 10
       "total_jobs_metric" = true
     }
     "opera-job_worker-sciflo-l2_rtc_s1" = {
-      "instance_type" = ["c6a.2xlarge", "c6i.2xlarge"]
-      "root_dev_size" = 50
-      "data_dev_size" = 100
-      "max_size"      = 10
+      "instance_type"     = ["c6a.2xlarge", "c6i.2xlarge", "c6a.4xlarge", "c6i.4xlarge", "c5a.4xlarge", "c5.4xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "max_size"          = 10
       "total_jobs_metric" = true
     }
     "opera-job_worker-sciflo-l3_dswx_hls" = {
-      "instance_type" = ["c5a.large", "c6a.large", "c6i.large"]
-      "root_dev_size" = 50
-      "data_dev_size" = 50
-      "min_size"      = 0
-      "max_size"      = 10
+      "instance_type"     = ["c5a.large", "c6a.large", "c6i.large"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 50
+      "min_size"          = 0
+      "max_size"          = 10
       "total_jobs_metric" = true
     }
     "opera-job_worker-send_cnm_notify" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "max_size"          = 10
       "total_jobs_metric" = true
     }
     "opera-job_worker-rcv_cnm_notify" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "max_size"          = 10
       "total_jobs_metric" = true
     }
     "opera-job_worker-hls_data_query" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "min_size"      = 0
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "min_size"          = 0
+      "max_size"          = 10
       "total_jobs_metric" = false
-      "use_private_vpc" = false
+      "use_private_vpc"   = false
     }
     "opera-job_worker-hls_data_download" = {
-      "instance_type" = ["c5n.large", "m5dn.large"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "min_size"      = 0
-      "max_size"      = 80
+      "instance_type"     = ["c5n.large", "m5dn.large"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "min_size"          = 0
+      "max_size"          = 80
       "total_jobs_metric" = true
-      "use_private_vpc" = false
+      "use_private_vpc"   = false
     }
     "opera-job_worker-slc_data_query" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "min_size"      = 0
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "min_size"          = 0
+      "max_size"          = 10
       "total_jobs_metric" = false
-      "use_private_vpc" = false
+      "use_private_vpc"   = false
     }
     "opera-job_worker-slc_data_download" = {
-      "instance_type" = ["c5n.2xlarge", "m5dn.2xlarge"]
-      "root_dev_size" = 50
-      "data_dev_size" = 100
-      "min_size"      = 0
-      "max_size"      = 80
+      "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "min_size"          = 0
+      "max_size"          = 80
       "total_jobs_metric" = true
-      "use_private_vpc" = false
+      "use_private_vpc"   = false
     }
     "opera-job_worker-slc_data_download_ionosphere" = {
-      "instance_type" = ["m5a.large", "m6a.large", "m5.large", "m6a.large", "m5ad.large", "m5d.large"]
-      "root_dev_size" = 50
-      "data_dev_size" = 100
-      "min_size"      = 0
-      "max_size"      = 80
+      "instance_type"     = ["m5a.large", "m6a.large", "m5.large", "m6a.large", "m5ad.large", "m5d.large"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "min_size"          = 0
+      "max_size"          = 80
       "total_jobs_metric" = true
-      "use_private_vpc" = false
+      "use_private_vpc"   = false
     }
     "opera-job_worker-timer" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 100
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "max_size"          = 10
       "total_jobs_metric" = false
     }
     "opera-job_worker-slc_data_query_hist" = {
-      "instance_type" = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size" = 50
-      "data_dev_size" = 25
-      "min_size"      = 0
-      "max_size"      = 10
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "min_size"          = 0
+      "max_size"          = 10
       "total_jobs_metric" = false
-      "use_private_vpc" = false
+      "use_private_vpc"   = false
     }
     "opera-job_worker-slc_data_download_hist" = {
-      "instance_type" = ["c5n.2xlarge", "m5dn.2xlarge"]
-      "root_dev_size" = 50
-      "data_dev_size" = 100
-      "min_size"      = 0
-      "max_size"      = 80
+      "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "min_size"          = 0
+      "max_size"          = 80
       "total_jobs_metric" = true
-      "use_private_vpc" = false
-    }
-    "opera-job_worker-sciflo-l2_cslc_s1_hist" = {
-      "instance_type" = ["c6a.2xlarge", "c6i.2xlarge"]
-      "root_dev_size" = 50
-      "data_dev_size" = 300
-      "max_size"      = 10
-      "total_jobs_metric" = true
+      "use_private_vpc"   = false
     }
   }
 }
@@ -434,7 +434,7 @@ variable "cnm_r_sqs_arn" {
   default = {
     dev  = "arn:aws:sqs:us-west-2:681612454726:opera-dev-daac-cnm-response"
     int  = "arn:aws:sqs:us-west-2:681612454726:opera-dev-fwd-daac-cnm-response"
-    test  = "arn:aws:sqs:us-west-2:337765570207:opera-int-daac-cnm-response"
+    test = "arn:aws:sqs:us-west-2:337765570207:opera-int-daac-cnm-response"
     ops  = "arn:aws:sqs:us-west-2:907504701509:opera-ops-fwd-daac-cnm-response"
   }
 }
@@ -448,8 +448,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1"  = "2.0.0-rc.2.0"
+    "rtc_s1"   = "2.0.0-rc.2.0"
   }
 }
 
@@ -564,7 +564,7 @@ variable "pge_sim_mode" {
 
 variable "artifactory_fn_user" {
   description = "Username to use for authenticated Artifactory API calls."
-  default = ""
+  default     = ""
 }
 
 variable "artifactory_fn_api_key" {
@@ -580,6 +580,6 @@ variable "earthdata_pass" {
 }
 
 variable "clear_s3_aws_es" {
-  type = bool
+  type    = bool
   default = true
 }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -294,14 +294,14 @@ variable "queues" {
       "max_size"          = 10
       "total_jobs_metric" = true
     }
-    "opera-job_worker-sciflo-l2_cslc_s1_hist" = {
+    "opera-job_worker-sciflo-l2_cslc_s1" = {
       "instance_type"     = ["c6a.4xlarge", "c6i.4xlarge", "c6a.2xlarge", "c6i.2xlarge", "c5a.4xlarge", "c5.4xlarge"]
       "root_dev_size"     = 50
       "data_dev_size"     = 300
       "max_size"          = 10
       "total_jobs_metric" = true
     }
-    "opera-job_worker-sciflo-l2_cslc_s1" = {
+    "opera-job_worker-sciflo-l2_cslc_s1_hist" = {
       "instance_type"     = ["c6a.4xlarge", "c6i.4xlarge", "c6a.2xlarge", "c6i.2xlarge", "c5a.4xlarge", "c5.4xlarge"]
       "root_dev_size"     = 50
       "data_dev_size"     = 300
@@ -364,7 +364,25 @@ variable "queues" {
       "total_jobs_metric" = false
       "use_private_vpc"   = false
     }
+    "opera-job_worker-slc_data_query_hist" = {
+      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 25
+      "min_size"          = 0
+      "max_size"          = 10
+      "total_jobs_metric" = false
+      "use_private_vpc"   = false
+    }
     "opera-job_worker-slc_data_download" = {
+      "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "min_size"          = 0
+      "max_size"          = 80
+      "total_jobs_metric" = true
+      "use_private_vpc"   = false
+    }
+    "opera-job_worker-slc_data_download_hist" = {
       "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -388,24 +406,6 @@ variable "queues" {
       "data_dev_size"     = 100
       "max_size"          = 10
       "total_jobs_metric" = false
-    }
-    "opera-job_worker-slc_data_query_hist" = {
-      "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
-      "root_dev_size"     = 50
-      "data_dev_size"     = 25
-      "min_size"          = 0
-      "max_size"          = 10
-      "total_jobs_metric" = false
-      "use_private_vpc"   = false
-    }
-    "opera-job_worker-slc_data_download_hist" = {
-      "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
-      "root_dev_size"     = 50
-      "data_dev_size"     = 100
-      "min_size"          = 0
-      "max_size"          = 80
-      "total_jobs_metric" = true
-      "use_private_vpc"   = false
     }
   }
 }


### PR DESCRIPTION
Note: AWS price sheet updates occurred recently to make larger C5 spot machines less desirable for some OPERA workloads.

Refs #545