### PR TITLE
issue 543: fix(logging): remove unused log groups. refactor terraform cloudwatch…

### DIFF
--- a/cluster_provisioning/modules/common/autoscaling_groups.tf
+++ b/cluster_provisioning/modules/common/autoscaling_groups.tf
@@ -1,17 +1,51 @@
-resource "aws_cloudwatch_log_group" "autoscaling-log-groups_run" {
-  for_each = var.queues
-  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_${substr(each.key, 17, 100)}.log"
+resource "aws_cloudwatch_log_group" "amazon-cloudwatch-agent" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/amazon-cloudwatch-agent.log"
   retention_in_days = var.lambda_log_retention_in_days
 }
 
 resource "aws_cloudwatch_log_group" "autoscaling-log-groups-job-worker" {
-  for_each = var.queues
-  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/${each.key}.log"
+  for_each          = var.queues
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/${lower(each.key)}.log"
   retention_in_days = var.lambda_log_retention_in_days
 }
 
-resource "aws_cloudwatch_log_group" "amazon-cloudwatch-agent" {
-  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/amazon-cloudwatch-agent.log"
+resource "aws_cloudwatch_log_group" "run_hlsl30_query" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_hlsl30_query.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_hlss30_query" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_hlss30_query.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_hls_download" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_hls_download.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_slcs1a_query" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slcs1b_query.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_slcs1a_query" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slcs1b_query.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_slc_download" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slc_download.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_ionosphere_download" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_ionosphere_download.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}
+
+resource "aws_cloudwatch_log_group" "run_ionosphere_download" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_ionosphere_download.log"
   retention_in_days = var.lambda_log_retention_in_days
 }
 
@@ -40,3 +74,7 @@ resource "aws_cloudwatch_log_group" "run_sciflo_L2_CSLC_S1" {
   retention_in_days = var.lambda_log_retention_in_days
 }
 
+resource "aws_cloudwatch_log_group" "run_sciflo_L2_RTC_S1" {
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_sciflo_L2_RTC_S1.log"
+  retention_in_days = var.lambda_log_retention_in_days
+}

--- a/cluster_provisioning/modules/common/autoscaling_groups.tf
+++ b/cluster_provisioning/modules/common/autoscaling_groups.tf
@@ -25,22 +25,17 @@ resource "aws_cloudwatch_log_group" "run_hls_download" {
 }
 
 resource "aws_cloudwatch_log_group" "run_slcs1a_query" {
-  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slcs1b_query.log"
+  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slcs1a_query.log"
   retention_in_days = var.lambda_log_retention_in_days
 }
 
-resource "aws_cloudwatch_log_group" "run_slcs1a_query" {
+resource "aws_cloudwatch_log_group" "run_slcs1b_query" {
   name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slcs1b_query.log"
   retention_in_days = var.lambda_log_retention_in_days
 }
 
 resource "aws_cloudwatch_log_group" "run_slc_download" {
   name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_slc_download.log"
-  retention_in_days = var.lambda_log_retention_in_days
-}
-
-resource "aws_cloudwatch_log_group" "run_ionosphere_download" {
-  name              = "/opera/sds/${var.project}-${var.venue}-${local.counter}/run_ionosphere_download.log"
   retention_in_days = var.lambda_log_retention_in_days
 }
 

--- a/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
+++ b/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
@@ -88,6 +88,12 @@ echo '{
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
+            "file_path": "/data/work/jobs/**/run_sciflo_L2_RTC_S1.log",
+            "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/run_sciflo_L2_RTC_S1.log",
+            "timezone": "Local",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+          },
+          {
             "file_path": "/home/ops/verdi/log/opera-job_worker-hls_data_query.log",
             "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-hls_data_query.log",
             "timezone": "Local",


### PR DESCRIPTION
… resources. added missing log group to launch template user data.

for-loop for worker logs kept, as script works as intended since log group is named after queue/ASG. for-loop for job logs removed and replaced because job log files are not coupled to queue/ASG.

Refs #543