### PR TITLE
DEM from bounding box margin fix

### DIFF
--- a/tests/geo/test_geo_util.py
+++ b/tests/geo/test_geo_util.py
@@ -1,5 +1,7 @@
 from geo.geo_util import does_bbox_intersect_north_america, Coordinate
+from util.geo_util import polygon_from_bounding_box, polygon_from_mgrs_tile
 
+from shapely.geometry import Polygon
 
 def test_bbox_not_in_north_america():
     # random bbox from CMR
@@ -24,3 +26,37 @@ def test_bbox_in_north_america():
         {"lon": -109.060253, "lat": 36.992426}
     ]
     assert does_bbox_intersect_north_america(bbox)
+
+def test_polygon_from_bounding_box():
+    # bbox obtained from S1A_IW_SLC__1SDH_20230628T122459_20230628T122529_049186_05EA1E_AD77
+    bounding_box = [-77.210869, 81.085464, -55.746243, 83.767433]
+    poly = polygon_from_bounding_box(bounding_box, margin_in_km=100)
+
+    expected_poly = Polygon.from_bounds(xmin=-47.47175197993814,
+                                        ymin=80.1871487229285,
+                                        xmax=-85.48536002006186,
+                                        ymax=84.6657482770715)
+
+    assert poly == expected_poly
+
+def test_polygon_from_mgrs_tile_nominal():
+    """Reproduce ADT results from values provided with code"""
+    poly = polygon_from_mgrs_tile('15SXR', margin_in_km=0)
+
+    expected_poly = Polygon.from_bounds(xmin=-90.81751155385777,
+                                        ymin=31.572733739486036,
+                                        xmax=-91.99766472766642,
+                                        ymax=32.577473659397235)
+
+    assert poly == expected_poly
+
+def test_polygon_from_mgrs_tile_nominal_antimeridian():
+    """Test MGRS tile code conversion with a tile that crosses the anti-meridian"""
+    poly = polygon_from_mgrs_tile('T60VXQ', margin_in_km=0)
+
+    expected_poly = Polygon.from_bounds(xmin=-178.93677941363356,
+                                        ymin=62.13198085489144,
+                                        xmax= 178.82637550795243,
+                                        ymax=63.16076767648831)
+
+    assert poly == expected_poly

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -10,14 +10,14 @@ import boto3
 import shapely.wkt
 
 from osgeo import gdal
-from shapely.geometry import Polygon, box
+from shapely.geometry import Polygon
 
 from commons.logger import logger
 from commons.logger import LogLevels
 from util.geo_util import (check_dateline,
                            epsg_from_polygon,
+                           polygon_from_bounding_box,
                            polygon_from_mgrs_tile,
-                           margin_km_to_deg,
                            transform_polygon_coords_to_epsg)
 
 # Enable exceptions
@@ -88,12 +88,7 @@ def determine_polygon(tile_code, bbox=None, margin_in_km=50):
     """
     if bbox:
         logger.info('Determining polygon from bounding box')
-        poly = box(bbox[0], bbox[1], bbox[2], bbox[3])
-
-        # convert margin to degree
-        margin_in_deg = margin_km_to_deg(margin_in_km)
-
-        poly = poly.buffer(margin_in_deg)
+        poly = polygon_from_bounding_box(bbox, margin_in_km)
     else:
         logger.info(f'Determining polygon from MGRS tile code {tile_code}')
         poly = polygon_from_mgrs_tile(tile_code, margin_in_km)

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -10,6 +10,7 @@ from shapely.geometry import box, LinearRing, Point, Polygon
 
 
 EARTH_APPROX_CIRCUMFERENCE = 40075017.
+EARTH_RADIUS = EARTH_APPROX_CIRCUMFERENCE / (2 * np.pi)
 
 def margin_km_to_deg(margin_in_km):
     """Converts a margin value from kilometers to degrees"""
@@ -17,6 +18,50 @@ def margin_km_to_deg(margin_in_km):
     margin_in_deg = margin_in_km * km_to_deg_at_equator
 
     return margin_in_deg
+
+def margin_km_to_longitude_deg(margin_in_km, lat=0):
+    """Converts a margin value from kilometers to degrees as a function of latitude"""
+    delta_lon = (180 * 1000 * margin_in_km /
+                 (np.pi * EARTH_RADIUS * np.cos(np.pi * lat / 180)))
+
+    return delta_lon
+
+def polygon_from_bounding_box(bounding_box, margin_in_km):
+    """
+    Create a polygon (EPSG:4326) from the lat/lon coordinates corresponding to
+    a provided bounding box.
+
+    Parameters
+    -----------
+    bounding_box : list
+        Bounding box with lat/lon coordinates (decimal degrees) in the form of
+        [West, South, East, North].
+    margin_in_km : float
+        Margin in kilometers to be added to the resultant polygon.
+
+    Returns
+    -------
+    poly: shapely.Geometry.Polygon
+        Bounding polygon corresponding to the provided bounding box with
+        margin applied.
+
+    """
+    lon_min = bounding_box[0]
+    lat_min = bounding_box[1]
+    lon_max = bounding_box[2]
+    lat_max = bounding_box[3]
+
+    # note we can also use the center lat here
+    lat_worst_case = max([lat_min, lat_max])
+
+    # convert margin to degree
+    lat_margin = margin_km_to_deg(margin_in_km)
+    lon_margin = margin_km_to_longitude_deg(margin_in_km, lat=lat_worst_case)
+
+    poly = box(lon_min - lon_margin, max([lat_min - lat_margin, -90]),
+               lon_max + lon_margin, min([lat_max + lat_margin, 90]))
+
+    return poly
 
 def polygon_from_mgrs_tile(mgrs_tile_code, margin_in_km,
                            flag_use_m_to_deg_conversion_at_equator=True):
@@ -55,8 +100,6 @@ def polygon_from_mgrs_tile(mgrs_tile_code, margin_in_km,
     -------
     poly: shapely.Geometry.Polygon
         Bounding polygon corresponding to the provided MGRS tile code.
-    margin_in_km: float, optional
-        Margin in kilometers to be added to MGRS bounding box
 
     """
     mgrs_obj = mgrs.MGRS()


### PR DESCRIPTION
This branch fixes an issue in stage_dem.py where a provided bounding box was not padded with margin properly for regions at high latitudes. A new function named polygon_from_bounding_box() has been added to geo_util.py to handle application of margin to the bounding box used to obtain the corresponding DEM.

This branch was tested on a dev cluster using the following input SLC's which exhibit the high latitude behavior:

-   S1A_IW_SLC__1SDH_20230628T122459_20230628T122529_049186_05EA1E_AD77
-   S1A_IW_SLC__1SDH_20230628T122527_20230628T122546_049186_05EA1E_4B0C
-   S1A_IW_SLC__1SDH_20230628T122652_20230628T122722_049186_05EA20_0BC9

For all cases, the DEM staged with 100km of margin were now sufficient for the RTC-S1 jobs to run to completion.

@gshiroma If you could review the changes to make sure I captured the expected updates it would be appreciated, thanks!
