### PR TITLE
Static layer toggle for historical processing

### DIFF
--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -20,6 +20,12 @@ class OperaChimeraConstants(ChimeraConstants):
 
     PROCESSING_MODE_KEY = "processing_mode"
 
+    PROCESSING_MODE_FORWARD = "forward"
+
+    PROCESSING_MODE_HISTORICAL = "historical"
+
+    PROCESSING_MODE_REPROCESSING = "reprocessing"
+
     GET_PRODUCT_METADATA = "get_product_metadata"
 
     GET_METADATA = "get_metadata"
@@ -190,7 +196,15 @@ class OperaChimeraConstants(ChimeraConstants):
     S3_KEYS = "s3_keys"
 
     # PGE names
-    #L3_DSWX_HLS = "L3_DSWX_HLS"
+    L3_DSWX_HLS = "L3_DSWX_HLS"
+
+    L2_RTC_S1 = "L2_RTC_S1"
+
+    L2_CSLC_S1 = "L2_CSLC_S1"
+
+    L3_DSWx_S1 = "L3_DSWx_S1"
+
+    L3_DISP_S1 = "L3_DISP_S1"
 
     # Other Constants
     JOB_ACCOUNTABILITY_INDEX = job_accountability_index

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -756,7 +756,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         return rc_params
 
     def get_slc_static_layers_enabled(self):
-        """Gets the setting for the static_layers_enabled flag from settings.yaml"""
+        """Gets the setting for the enable_static_layers flag from settings.yaml"""
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 
         pge_name = self._pge_config.get('pge_name')
@@ -765,6 +765,15 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         logger.info(f'Getting ENABLE_STATIC_LAYERS setting for PGE {pge_shortname}')
 
         enable_static_layers = self._settings.get(pge_shortname).get("ENABLE_STATIC_LAYERS")
+
+        metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
+        processing_mode = metadata[oc_const.PROCESSING_MODE_KEY]
+
+        # Static layer generation should always be disabled for historical processing mode
+        if processing_mode == oc_const.PROCESSING_MODE_HISTORICAL:
+            logger.info(f"Processing mode for {pge_name} is set to {processing_mode}, "
+                        f"static layer generation will be DISABLED.")
+            enable_static_layers = False
 
         rc_params = {
             "enable_static_layers": enable_static_layers

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -235,6 +235,78 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
         expected_s3_path = "s3://opera-bucket/fake/key/to/S1A_OPER_AUX_RESORB_OPOD.EOF"
         self.assertEqual(rc_params[oc_const.ORBIT_FILE_PATH], expected_s3_path)
 
+    def test_get_slc_static_layers_enabled(self):
+        """Unit tests for the get_slc_static_layers_enabled function"""
+        # Set up the arguments to OperaPreConditionFunctions
+        context = {
+            "product_metadata": {
+                "metadata": {
+                    "processing_mode": oc_const.PROCESSING_MODE_FORWARD
+                }
+            }
+        }
+
+        pge_config = {
+            'pge_name': oc_const.L2_RTC_S1
+        }
+
+        settings = {
+            'RTC_S1':  {
+                'ENABLE_STATIC_LAYERS': True
+            }
+        }
+
+        # These are not used by get_slc_s1_orbit_file
+        job_params = None
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        # For standard case (forward processing) we should get the value assigned
+        # in settings.yaml
+        rc_params = precondition_functions.get_slc_static_layers_enabled()
+
+        self.assertIsNotNone(rc_params)
+        self.assertIsInstance(rc_params, dict)
+        self.assertIn('enable_static_layers', rc_params)
+        self.assertTrue(rc_params['enable_static_layers'])
+
+        # Make sure static layer generation is disabled when in "historical" mode
+        context = {
+            "product_metadata": {
+                "metadata": {
+                    "processing_mode": oc_const.PROCESSING_MODE_HISTORICAL
+                }
+            }
+        }
+
+        pge_config = {
+            'pge_name': oc_const.L2_CSLC_S1
+        }
+
+        settings = {
+            'CSLC_S1': {
+                'ENABLE_STATIC_LAYERS': True
+            }
+        }
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        with self.assertLogs() as cm:
+            rc_params = precondition_functions.get_slc_static_layers_enabled()
+
+        self.assertIsNotNone(rc_params)
+        self.assertIsInstance(rc_params, dict)
+        self.assertIn('enable_static_layers', rc_params)
+        self.assertFalse(rc_params['enable_static_layers'])
+
+        # Check that we logged the flag being set to False
+        self.assertIn('INFO:opera_pcm:Processing mode for L2_CSLC_S1 is set to historical, '
+                      'static layer generation will be DISABLED.', cm.output)
+
     @patch.object(tools.stage_dem, "check_aws_connection", _check_aws_connection_patch)
     @patch.object(tools.stage_dem, "gdal", MockGdal)
     def test_get_slc_s1_dem(self):


### PR DESCRIPTION
This branch adds a feature to automatically disable static layer generation for the R2 PGE's whenever the processing mode is not set to "forward". This ensures that static layers are never generated when in "historical" or "reprocessing" mode.

This branch was tested by using the daac_data_subscriber.py script with the `--processing-mode=historical` option, and with static layers enabled for CSLC-S1 in settings.yaml. Within the `run_sciflo_L2_CSLC_S1.log` file for the job, the following should appear near the top of the log:

```
2023-07-20 21:38:19 opera_pcm:INFO [precondition_functions.py:765] Getting ENABLE_STATIC_LAYERS setting for PGE CSLC_S1
2023-07-20 21:38:19 opera_pcm:INFO [precondition_functions.py:773] Processing mode for L2_CSLC_S1 is set to historical, static layer generation will be DISABLED.
```

