### PR TITLE
DSWx-S1 ER2 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -385,6 +385,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -457,6 +457,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -383,6 +383,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -175,6 +175,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -381,6 +381,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -384,6 +384,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -33,6 +33,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.1"
     "cslc_s1" = "2.0.0-rc.2.0"
     "rtc_s1" = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
+++ b/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
@@ -82,6 +82,12 @@ echo '{
             "timestamp_format": "%Y-%m-%d %H:%M:%S"
           },
           {
+            "file_path": "/data/work/jobs/**/run_sciflo_L3_DSWx_S1.log",
+            "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/run_sciflo_L3_DSWx_S1.log",
+            "timezone": "Local",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S"
+          },
+          {
             "file_path": "/data/work/jobs/**/run_sciflo_L2_CSLC_S1.log",
             "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/run_sciflo_L2_CSLC_S1.log",
             "timezone": "Local",
@@ -132,6 +138,12 @@ echo '{
           {
             "file_path": "/home/ops/verdi/log/opera-job_worker-sciflo-l3_dswx_hls.log",
             "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-sciflo-l3_dswx_hls.log",
+            "timezone": "Local",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
+          },
+          {
+            "file_path": "/home/ops/verdi/log/opera-job_worker-sciflo-l3_dswx_s1.log",
+            "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-sciflo-l3_dswx_s1.log",
             "timezone": "Local",
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
           },

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -330,6 +330,14 @@ variable "queues" {
       "max_size"          = 40
       "total_jobs_metric" = true
     }
+    "opera-job_worker-sciflo-l3_dswx_s1" = {
+      "instance_type" = ["c5a.large", "c6a.large", "c6i.large"]
+      "root_dev_size" = 50
+      "data_dev_size" = 50
+      "min_size"      = 0
+      "max_size"      = 10
+      "total_jobs_metric" = true
+    }
     "opera-job_worker-send_cnm_notify" = {
       "instance_type"     = ["t2.medium", "t3a.medium", "t3.medium"]
       "root_dev_size"     = 50

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -146,7 +146,7 @@ variable "amis" {
     #factotum  = "ami-0b988a1203b7e5a58" # factotum v4.16
     #autoscale = "ami-082d3efc94d50659f" # verdi v4.16 patchupdate - 20230525
 
-    # HySDS v5.0.0-beta.6 - July 10, 2023 
+    # HySDS v5.0.0-beta.6 - July 10, 2023
     mozart    = "ami-0d1d5539d77a6cde2" # mozart v4.21 - 230710
     metrics   = "ami-0aa63c81611c8cb2a" # metrics v4.15 - 230626
     grq       = "ami-0ab96904359fa481b" # grq v4.16 - 230605
@@ -455,8 +455,9 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1"  = "2.0.0-rc.2.0"
-    "rtc_s1"   = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.0"
+    "rtc_s1"  = "2.0.0-rc.2.0"
+    "dswx_s1" = "3.0.0-er.2.0"
   }
 }
 

--- a/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
@@ -1,0 +1,73 @@
+RunConfig:
+  Name: OPERA-DSWX-S1-PGE-CONFIG
+  Groups:
+    PGE:
+      PGENameGroup:
+        PGEName: DSWX_S1_PGE
+      InputFilesGroup:
+        InputFilePaths:
+          {%- for input in data.input_file_group.input_file_paths %}
+          - {{ input }}
+          {%- endfor %}
+      DynamicAncillaryFilesGroup:
+        AncillaryFileMap:
+          {%- for type in data.dynamic_ancillary_file_group.keys() %}
+          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- endif %}
+          {%- endfor %}
+      ProductPathGroup:
+        OutputProductPath: {{ data.product_path_group.product_path }}
+        ScratchPath: {{ data.product_path_group.scratch_path }}
+      PrimaryExecutable:
+        ProductIdentifier: DSWX_S1
+        ProductVersion: {{ data.product_path_group.product_version }}
+        ProgramPath: python3
+        ProgramOptions:
+          - /home/conda/dswx-s1-0.1.0/src/dswx_sar/dswx_s1.py
+        ErrorCodeBase: 400000
+        SchemaPath: /home/conda/opera/pge/dswx_s1/schema/dswx_s1_sas_schema.yaml
+        AlgorithmParametersSchemaPath: /home/conda/opera/pge/dswx_s1/schema/algorithm_parameters_s1_schema.yaml
+        # TODO - This template does not exist yet, so the field is left blank
+        IsoTemplatePath:
+      QAExecutable:
+        Enabled: False
+        ProgramPath:
+        ProgramOptions:
+      DebugLevelGroup:
+        DebugSwitch: False
+        ExecuteViaShell: False
+    SAS:
+      runconfig:
+        name: dswx_s1_workflow_default
+        groups:
+          pge_name_group:
+            pge_name: DSWX_S1_PGE
+          input_file_group:
+            input_file_path:
+              {%- for input in data.input_file_group.input_file_paths %}
+              - {{ input }}
+              {%- endfor %}
+          dynamic_ancillary_file_group:
+            {%- for type in data.dynamic_ancillary_file_group.keys() %}
+            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- else %}
+            {{ type }}:
+            {%- endif %}
+            {%- endfor %}
+            algorithm_parameters: {{ data.processing.algorithm_parameters }}
+            # TODO: update descriptions as necessary when new ancillary releases are available
+            dem_file_description: 'DEM'
+            worldcover_file_description: 'COPERNICUS WORLDCOVER 10m'
+            reference_water_file_description: 'PEKELs water'
+            hand_file_description: 'ASF HAND'
+            shoreline_shapefile_description: 'NOAA GSHHS Level 1 resolution f - GSHHS_f_L1'
+          primary_executable:
+            product_type: dswx_s1
+          product_path_group:
+            product_path: {{ data.product_path_group.product_path }}
+            scratch_path: {{ data.product_path_group.scratch_path }}
+            sas_output_path: {{ data.product_path_group.product_path }}
+            product_version: {{ data.product_path_group.product_version }}
+          log_file:

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -84,3 +84,24 @@ L3_DSWx_HLS:
   Missing_Metadata: {
   # "daac_product_type": "OPERA_L3_DSWX_HLS_0.0"
   }
+L3_DSWx_S1:
+  Outputs:
+    Primary:
+      # Pattern for parsing output image filenames, such as:
+      # * "OPERA_L3_DSWx-S1_T18MVA_20200702T231843Z_20230317T190549Z_v0.1_B01_WTR.tif"
+      # TODO: update once full file name conventions are implemented
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>S1)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+))(_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF))?[.](?P<ext>tif|tiff|iso\.xml)$'
+        verify: true
+        hash: md5
+    Secondary:
+      # Patterns for parsing aux filenames, such as:
+      # * "OPERA_L3_DSWx_20230317T190549.catalog.json"
+      # TODO: update once full file name conventions are implemented
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})))[.](?P<ext>log|qa\.log|catalog\.json)$'
+        verify: false
+    Optional: []
+      # Pattern for optional output product filenames
+
+  Missing_Metadata: {
+  # "daac_product_type": "OPERA_L3_DSWX_HLS_0.0"
+  }

--- a/conf/schema/RunConfig_schema.L3_DSWx_S1.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_S1.yaml
@@ -1,0 +1,104 @@
+RunConfig:
+  Name: str()
+
+  Groups:
+    PGE:
+      PGENameGroup:
+        PGEName: str(required=True)
+
+      InputFilesGroup:
+        InputFilePaths: list(str(), min=1, required=True)
+
+      DynamicAncillaryFilesGroup:
+        AncillaryFileMap: map(str(), key=str(), min=0)
+
+      ProductPathGroup:
+        OutputProductPath: str(required=True)
+        ScratchPath: str(required=True)
+
+      PrimaryExecutable:
+        ProductIdentifier: str(required=False)
+        ProductVersion: num(required=False)
+        CompositeReleaseID: str(required=False)
+        ProgramPath: str(required=True)
+        ProgramOptions: list(str(), min=0, required=False)
+        ErrorCodeBase: int(required=True)
+        SchemaPath: str(required=True)
+        AlgorithmParametersSchemaPath: str(required=False)
+        IsoTemplatePath: str(required=False)
+        DataValidityStartTime: regex(r'\d{8}T\d{6}', name='YYYYMMDDTHHmmss datetime', required=False)
+
+      QAExecutable:
+        Enabled: bool(required=True)
+        ProgramPath: str(required=False)
+        ProgramOptions: list(str(), min=0, required=False)
+
+      DebugLevelGroup:
+        DebugSwitch: bool(required=False)
+        ExecuteViaShell: bool(required=False)
+
+    SAS:
+      runconfig:
+        name: str()
+
+        groups:
+          pge_name_group:
+            pge_name: enum('DSWX_S1_PGE')
+
+          input_file_group:
+            # REQUIRED - list of RTC products (directory or files)
+            input_file_path: list(str(), min=1)
+
+          dynamic_ancillary_file_group:
+            # Digital elevation model
+            dem_file: str(required=True)
+
+            # Digital elevation model description
+            dem_file_description: str(required=False)
+
+            # Reference water body map (Required)
+            # https://global-surface-water.appspot.com/download
+            reference_water_file: str(required=True)
+
+            # Pekel's water description
+            reference_water_file_description: str(required=False)
+
+            # Height Above Nearest Drainage (optional)
+            hand_file: str(required=True)
+
+            # HAND description
+            hand_file_description: str(required=False)
+
+            # ESA WorldCover map file
+            worldcover_file: str(required=False)
+
+            # ESA WorldCover map description
+            worldcover_file_description: str(required=False)
+
+            # NOAA GSHHS shapefile
+            shoreline_shapefile: str(required=False)
+
+            # NOAA GSHHS shapefile description
+            shoreline_shapefile_description: str(required=False)
+
+            # algorithm parameter
+            algorithm_parameters: str(required=True)
+
+          primary_executable:
+            product_type: enum('dswx_s1', 'twele')
+
+          product_path_group:
+            # Directory where PGE will place results
+            product_path: str()
+
+            # Directory where SAS can write temporary data
+            scratch_path: str()
+
+            # Intermediate file name.  SAS writes the output product to the following file.
+            # After the SAS completes, the PGE wrapper renames the product file
+            # according to proper file naming conventions.
+            sas_output_path: str()
+
+            product_version: num(required=False)
+
+          log_file: str(required=False)

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -359,6 +359,30 @@
           "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/browse/DSWx_HLS/{id}"
         ]
       }
+    },
+    {
+      "ipath": "hysds::data/L3_DSWx_S1",
+      "level": "L3",
+      "type": "L3_DSWx_S1",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>S1)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+))$",
+      "alt_match_pattern": null,
+      "extractor": null,
+      "publish": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/products/DSWx_S1/{id}",
+        "urls": [
+          "http://{{ DATASET_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/products/DSWx_S1/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/products/DSWx_S1/{id}"
+        ]
+      },
+      "browse": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/browse/DSWx_S1/{id}",
+        "urls": [
+          "http://{{ DATASET_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/browse/DSWx_S1/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/browse/DSWx_S1/{id}"
+        ]
+      }
     }
   ]
 }

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -359,6 +359,30 @@
           "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/browse/DSWx_HLS/{id}"
         ]
       }
+    },
+    {
+      "ipath": "hysds::data/L3_DSWx_S1",
+      "level": "L3",
+      "type": "L3_DSWx_S1",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>S1)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+))$",
+      "alt_match_pattern": null,
+      "extractor": null,
+      "publish": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/products/DSWx_S1/{id}",
+        "urls": [
+          "http://{{ DATASET_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/products/DSWx_S1/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/products/DSWx_S1/{id}"
+        ]
+      },
+      "browse": {
+        "s3-profile-name": "default",
+        "location": "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/browse/DSWx_S1/{id}",
+        "urls": [
+          "http://{{ DATASET_BUCKET }}.{{ DATASET_S3_WEBSITE_ENDPOINT }}/browse/DSWx_S1/{id}",
+          "s3://{{ DATASET_S3_ENDPOINT }}:80/{{ DATASET_BUCKET }}/browse/DSWx_S1/{id}"
+        ]
+      }
     }
   ]
 }

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -17,6 +17,20 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ PO_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ PO_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ PO_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\"],\"browse\":[],\"metadata\":[\"*.log\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "passthru_query": false,
+      "priority": 0,
+      "query_all": false,
+      "query_string": "{\n \"bool\": {\n \"must\": [\n {\n \"term\": {\n \"dataset.keyword\": \"L3_DSWx_S1\"\n }\n }\n ],\n \"must_not\": [\n {\n \"term\": {\n \"metadata.restaged\": \"true\"\n }\n }\n ]\n }\n}",
+      "queue": "opera-job_worker-send_cnm_notify",
+      "rule_name": "trigger-send_cnm_notify_msg_L3_DSWX_S1",
+      "username": "hysdsops",
+      "workflow": "hysds-io-send_notify_msg:__TAG__",
+      "job_spec": "job-send_notify_msg:__TAG__"
+    },
+    {
+      "enabled": true,
+      "job_type": "hysds-io-send_notify_msg:__TAG__",
       "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.h5\"],\"browse\":[\"*.png\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,

--- a/conf/sds/rules/user_rules.json
+++ b/conf/sds/rules/user_rules.json
@@ -69,6 +69,20 @@
       "username": "hysdsops",
       "workflow": "hysds-io-SCIFLO_L3_DSWx_HLS:__TAG__",
       "job_spec": "job-SCIFLO_L3_DSWx_HLS:__TAG__"
+    },
+    {
+      "enabled": true,
+      "job_type": "hysds-io-SCIFLO_L3_DSWx_S1:__TAG__",
+      "kwargs": "{}",
+      "passthru_query": false,
+      "priority": 0,
+      "query_all": false,
+      "query_string": "{\"bool\": {\"should\": [{\"terms\": {\"dataset_type.keyword\": [\"L2_RTC_S1_tile_group\"]}}]}}",
+      "queue": "opera-job_worker-sciflo-l3_dswx_s1",
+      "rule_name": "trigger-SCIFLO_L3_DSWx_S1",
+      "username": "hysdsops",
+      "workflow": "hysds-io-SCIFLO_L3_DSWx_S1:__TAG__",
+      "job_spec": "job-SCIFLO_L3_DSWx_S1:__TAG__"
     }
   ],
   "mozart": []

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -285,6 +285,34 @@ PRODUCT_TYPES:
             Dataset_Version_Key: 'product_version'
         Dataset_Keys: {}
 
+    L3_DSWx_S1:
+      # Pattern for parsing filenames such as:
+      # * "OPERA_L3_DSWx-S1_T18MVA_20200702T231843Z_20230317T190549Z_v0.1_B01_WTR.tif"
+      # This pattern groups the metadata information in the filename using named groups.
+      #
+      # Note: POSIX character class "[[:alnum:]]" is not supported in python's re, and so has been replaced with "[^\W_]" here.
+      # TODO: update once full file name conventions are implemented
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>S1)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+))(_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF))?[.](?P<ext>tif|tiff|iso\.xml)$'
+      Strip_File_Extension: !!bool true
+      Extractor: extractor.FilenameRegexMetExtractor
+      Configuration:
+        # Custom Pattern for dates like "<year><month><day>T<hour><minute><second>"
+        # For example, "20210211T163901":
+        #   year: 2021
+        #   month: 02 (February)
+        #   day of month: 11 (the 11th)
+        #   hour (24hr): 16
+        #   minute: 39
+        #   second: 01
+        Date_Time_Patterns: [ '%Y%m%dT%H%M%SZ' ]
+
+        # Specify the metadata key to convert to a start and end time for the dataset times
+        Date_Time_Keys: [ 'acquisition_ts', 'creation_ts' ]
+        # Specify the metadata key to use as the dataset version.
+        #  Note: this affects the data product index name
+        Dataset_Version_Key: 'product_version'
+      Dataset_Keys: { }
+
 
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 # WARNING: ONLY MODIFY THE SETTINGS BELOW IF YOU KNOW WHAT YOU'RE DOING !!!!!!!!!!!!!!

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -3,11 +3,11 @@ PGE_SIMULATION_MODE: !!bool true
 CRID: '{{ CRID }}'
 
 # for PST (CalVal products)
-#DSWX_COLLECTION_NAME: "OPERA_L3_DSWX-HLS_PROVISIONAL_V0"
+#DSWX_HLS_COLLECTION_NAME: "OPERA_L3_DSWX-HLS_PROVISIONAL_V0"
 #DSWX_HLS_PRODUCT_VERSION: "0.0"
 
 # uncomment out for OPS in R1
-DSWX_COLLECTION_NAME: "OPERA_L3_DSWX-HLS_PROVISIONAL_V1"
+DSWX_HLS_COLLECTION_NAME: "OPERA_L3_DSWX-HLS_PROVISIONAL_V1"
 DSWX_HLS_PRODUCT_VERSION: "1.0"
 
 # CSLC & RTC in R2
@@ -19,6 +19,10 @@ CSLC_S1_PRODUCT_VERSION: "0.1"
 RTC_S1_PRODUCT_VERSION: "0.4"
 CSLC_S1_STATIC_PRODUCT_VERSION: "0.1"
 RTC_S1_STATIC_PRODUCT_VERSION: "0.4"
+
+# DSWx-S1 & DISP-S1 in R3
+DSWX_S1_COLLECTION_NAME: "OPERA_L3_DSWX-S1_PROVISIONAL_V0"
+DSWX_S1_PRODUCT_VERSION: "0.1"
 
 # Shortname filtering on input product types. RegEx strings ('.' == any single character)
 SHORTNAME_FILTERS:
@@ -72,7 +76,7 @@ DSWX_HLS:
   CHECK_ANCILLARY_INPUTS_COVERAGE: !!bool true
   # Toggle application of ocean/shoreline masking during processing
   APPLY_OCEAN_MASKING: !!bool false
-  # Amount of margin in km to apply to staged ancillaries (DEM/worldcover)
+  # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)
   ANCILLARY_MARGIN: 200
 
 RTC_S1:
@@ -82,6 +86,12 @@ RTC_S1:
   DATA_VALIDITY_START_TIME: 20140403T000000
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 100
+
+DSWX_S1:
+  # Toggle application of ocean/shoreline masking during processing
+  APPLY_OCEAN_MASKING: !!bool false
+  # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)
+  ANCILLARY_MARGIN: 50
 
 # End PGE Configuration section
 

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
@@ -1,0 +1,85 @@
+{
+  "label": "SCIFLO_L3_DSWx_S1",
+  "allowed_accounts": [ "ops" ],
+  "enable_dedup": true,
+  "params": [
+    {
+      "name": "module_path",
+      "from": "value",
+      "type": "text",
+      "value": "/home/ops/verdi/ops/opera-pcm"
+    },
+    {
+      "name": "wf_dir",
+      "from": "value",
+      "type": "text",
+      "value": "/home/ops/verdi/ops/opera-pcm/opera_chimera/wf_xml"
+    },
+    {
+      "name": "wf_name",
+      "from": "value",
+      "type": "text",
+      "value": "L3_DSWx_S1"
+    },
+    {
+      "name":"dataset_type",
+      "from": "value",
+      "type":"text",
+      "value":"L2_RTC_S1"
+    },
+    {
+      "name":"input_dataset_id",
+      "type":"text",
+      "from":"value",
+      "value": "OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1"
+    },
+    {
+     "name": "product_metadata",
+     "from": "value",
+     "type": "object",
+     "value" : "{ \"metadata\": { \"FileName\": \"OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1_VV.tif\", \"id\": \"OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1\" } }"
+    },
+    {
+      "name": "accountability_module_path",
+      "from": "value",
+      "type": "text",
+      "value": "opera_chimera.accountability"
+    },
+    {
+      "name": "accountability_class",
+      "from": "value",
+      "type": "text",
+      "value": "OperaAccountability"
+    },
+    {
+      "name": "pge_runconfig_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_runconfig_dir"
+    },
+    {
+      "name": "pge_input_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_input_dir"
+    },
+    {
+      "name": "pge_output_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_output_dir"
+    },
+    {
+      "name": "container_home",
+      "from": "value",
+      "type": "text",
+      "value": "/home/conda"
+    },
+    {
+      "name": "container_working_dir",
+      "from": "value",
+      "type": "text",
+      "value": "/home/conda"
+    }
+  ]
+}

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -1,0 +1,77 @@
+{
+  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "disk_usage":"25GB",
+  "soft_time_limit": 3600,
+  "time_limit": 3660,
+  "imported_worker_files": {
+    "$HOME/.netrc": "/home/ops/.netrc",
+    "$HOME/.aws": "/home/ops/.aws",
+    "$HOME/verdi/etc/settings.yaml": "/home/ops/verdi/ops/opera-pcm/conf/settings.yaml"
+  },
+  "dependency_images": [
+    {
+      "container_image_name": "opera_pge/dswx_s1:3.0.0-er.2.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0-er.2.0.tar.gz",
+      "container_mappings": {
+        "$HOME/.netrc": ["/root/.netrc"],
+        "$HOME/.aws": ["/root/.aws", "ro"]
+      }
+    }
+  ],
+  "recommended-queues": [ "opera-job_worker-sciflo-l3_dswx_s1"],
+  "post": [ "hysds.triage.triage"],
+  "params": [
+    {
+      "name": "module_path",
+      "destination": "positional"
+    },
+    {
+      "name": "wf_dir",
+      "destination": "positional"
+    },
+    {
+      "name": "wf_name",
+      "destination": "positional"
+    },
+    {
+      "name": "dataset_type",
+      "destination": "context"
+    },
+    {
+      "name":"input_dataset_id",
+      "destination": "context"
+    },
+    {
+      "name": "product_metadata",
+      "destination": "context"
+    },
+    {
+      "name": "accountability_module_path",
+      "destination": "context"
+    },
+    {
+      "name": "accountability_class",
+      "destination": "context"
+    },
+    {
+      "name": "pge_runconfig_dir",
+      "destination": "context"
+    },
+    {
+      "name": "pge_input_dir",
+      "destination": "context"
+    },
+    {
+      "name": "pge_output_dir",
+      "destination": "context"
+    },
+    {
+      "name": "container_home",
+      "destination": "context"
+    },
+    {
+      "name": "container_working_dir",
+      "destination": "context"
+    }
+  ]
+}

--- a/extractor/extract.py
+++ b/extractor/extract.py
@@ -37,7 +37,8 @@ MULTI_OUTPUT_PRODUCT_TYPES = ['L3_DSWx_HLS',
                               'L2_CSLC_S1',
                               'L2_RTC_S1',
                               'L2_CSLC_S1_static_layers',
-                              'L2_RTC_S1_static_layers']
+                              'L2_RTC_S1_static_layers',
+                              'L3_DSWx_S1']
 """
 List of the product types (from settings.yaml) which produce multiple output files
 which should all be bundled in the same dataset.

--- a/opera_chimera/accountability.py
+++ b/opera_chimera/accountability.py
@@ -70,7 +70,17 @@ class OperaAccountability(Accountability):
         self.trigger_dataset_id = self.context[oc_const.INPUT_DATASET_ID]
         self.input_files_type = self.trigger_dataset_type
 
-        metadata: Dict[str, str] = self.context["product_metadata"]["metadata"]
+        product_metadata = self.context["product_metadata"]
+
+        # TODO: kludge to support providing dummy metadata as a hardcoded string
+        #       within the hysds-io.json file for DSWx-S1, remove when appropriate
+        try:
+            metadata = product_metadata["metadata"]
+        except Exception as err:
+            if isinstance(product_metadata, str):
+                metadata = json.loads(product_metadata)["metadata"]
+            else:
+                raise err
 
         input_metadata = {}
         if self.input_files_type in ('L2_HLS_L30', 'L2_HLS_S30'):
@@ -80,9 +90,8 @@ class OperaAccountability(Accountability):
         elif self.input_files_type in ('L1_S1_SLC',):
             self.product_paths = [os.path.join(metadata['FileLocation'], metadata['FileName'])]
         elif self.input_files_type in ('L2_RTC_S1',):
-            # TODO: unsure about this
-            self.product_paths = [os.path.join(metadata['FileLocation'], metadata['FileName'])]
-            input_metadata["filenames"] = [nested_product["FileName"] for nested_product in metadata["Files"]]
+            # TODO: unsure about this, revisit once input staging/trigger logic are implemented
+            self.product_paths = [os.path.join(metadata['FileName'])]
         else:
             raise RuntimeError(f'Unknown input file type "{self.input_files_type}"')
 

--- a/opera_chimera/accountability.py
+++ b/opera_chimera/accountability.py
@@ -79,6 +79,10 @@ class OperaAccountability(Accountability):
             input_metadata["filenames"] = [nested_product["FileName"] for nested_product in metadata["Files"]]
         elif self.input_files_type in ('L1_S1_SLC',):
             self.product_paths = [os.path.join(metadata['FileLocation'], metadata['FileName'])]
+        elif self.input_files_type in ('L2_RTC_S1',):
+            # TODO: unsure about this
+            self.product_paths = [os.path.join(metadata['FileLocation'], metadata['FileName'])]
+            input_metadata["filenames"] = [nested_product["FileName"] for nested_product in metadata["Files"]]
         else:
             raise RuntimeError(f'Unknown input file type "{self.input_files_type}"')
 

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -1,0 +1,97 @@
+#######################################################################
+# PGE configuration for L3_DSWx_S1.
+#######################################################################
+
+# The runconfig section is intended to be used for dynamically generating the runconfig file used
+# when running the OPERA PGEs. Any values set with a "__CHIMERA_VAL__" should be filled in by the input
+# preprocessor. Otherwise, a precondition evaluation error will be raised by chimera.
+#
+# The runconfig section is also used as the data dict for the RunConfig jinja2 template.
+# Accordingly, the schema here does NOT need to match the final RunConfig.yaml schema.
+#
+# * See RunConfig_schema.<label>.yaml for RunConfig.yaml documentation.
+# * See related `RunConfig.yaml.<label>.jinja2.tmpl` file
+#  and `util.conf_util.RunConfig.__init__()` for jinja2 usage.
+runconfig:
+  input_file_group:
+    input_file_paths: __CHIMERA_VAL__
+  dynamic_ancillary_file_group:
+    dem_file:  __CHIMERA_VAL__
+    hand_file: __CHIMERA_VAL__
+    worldcover_file: __CHIMERA_VAL__
+    reference_water_file: __CHIMERA_VAL__
+  product_path_group:
+    product_version: __CHIMERA_VAL__
+    product_path: output_dir
+    # Scratch path is defined relative to output_dir to avoid file system permission issues
+    scratch_path: output_dir/scratch_dir
+  processing:
+    algorithm_parameters: __CHIMERA_VAL__
+  cnm_version: "__CHIMERA_VAL__"
+
+# This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
+preconditions:
+  - get_product_version
+  - get_cnm_version
+  - set_daac_product_type
+  - get_dswx_s1_sample_inputs
+  # TODO: to be implemented with further releases
+  #- get_dswx_s1_input_filepaths
+  #- get_dswx_s1_dem
+  #- get_hand_file
+  #- get_worldcover
+  #- get_reference_water_file
+  #- get_shoreline_shapefiles
+
+# This lists all the postprocessor steps that this PGE will run after running the PGE.
+postprocess:
+  - update_product_accountability
+
+get_product_version:
+  version_key: "DSWX_S1_PRODUCT_VERSION"
+
+set_daac_product_type:
+  template: OPERA_L3_DSWX_S1_{cnm_version}
+
+# This function will add to the PGE output metadata when product to dataset conversion is performed
+set_extra_pge_output_metadata:
+   daac_product_type: daac_product_type
+
+# List the extensions that the PGE generates
+output_types:
+  L3_DSWx_S1:
+    - tif
+#    - png
+    - catalog.json
+    - iso.xml
+    - log
+    - qa.log
+
+# The PGE name
+# This must MATCH the corresponding entry in pge_outputs.yaml
+pge_name: "L3_DSWx_S1"
+
+# Set the primary input/output types here
+primary_input: "L2_RTC_S1"
+primary_output: "L3_DSWx_S1"
+
+# List the groups that Chimera will need to localize
+# The entries MUST reference a property of `$.runconfig` of this YAML.
+# The referenced properties MUST be maps.
+localize_groups:
+  - product_paths
+  - dynamic_ancillary_file_group
+
+
+#######################################################################
+# PGE Simulation Mode
+#
+# * See PGE_SIMULATION_MODE in settings.yaml and it's usage
+# * See SIMULATE_OUTPUTS usage in opera_pge_wrapper.py and chimera.precondition_evaluator.py
+#######################################################################
+input_file_base_name_regexes:
+    - '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))$'
+sample_input_dataset_id: "OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1"
+# TODO: update once full file name conventions are implemented
+output_base_name: OPERA_L3_DSWx-S1_{tile_id}_{acquisition_ts}_{creation_ts}_{product_version}
+ancillary_base_name: OPERA_L3_DSWx_{creation_ts}

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1421,6 +1421,56 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_dswx_s1_sample_inputs(self):
+        """
+        Temporary function to stage the "golden" inputs for use with the DSWx-S1
+        PGE.
+
+        TODO: this function will eventually be phased out as functions to
+              acquire the appropriate input files are implemented with future
+              releases
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        # get the working directory
+        working_dir = get_working_dir()
+
+        s3_bucket = "opera-dev-lts-fwd-collinss"
+        s3_key = "dswx_s1_sample_input_data.zip"
+
+        output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
+
+        pge_metrics = download_object_from_s3(
+            s3_bucket, s3_key, output_filepath, filetype="DSWx-S1 Inputs"
+        )
+
+        with zipfile.ZipFile(output_filepath) as myzip:
+            zip_contents = myzip.namelist()
+            zip_contents = list(filter(lambda x: not x.startswith('__'), zip_contents))
+            zip_contents = list(filter(lambda x: not x.endswith('.DS_Store'), zip_contents))
+            myzip.extractall(path=working_dir, members=zip_contents)
+
+        rtc_data_dir = os.path.join(working_dir, 'dswx_s1_sample_input_data', 'rtc_data')
+        ancillary_data_dir = os.path.join(working_dir, 'dswx_s1_sample_input_data', 'ancillary_data')
+
+        rtc_dirs = os.listdir(rtc_data_dir)
+
+        rtc_file_list = [os.path.join(rtc_data_dir, rtc_dir) for rtc_dir in rtc_dirs]
+
+        rc_params = {
+            'input_file_paths': rtc_file_list,
+            'dem_file': os.path.join(ancillary_data_dir, 'dem.tif'),
+            'hand_file': os.path.join(ancillary_data_dir, 'hand.tif'),
+            'worldcover_file': os.path.join(ancillary_data_dir, 'worldcover.tif'),
+            'reference_water_file': os.path.join(ancillary_data_dir, 'reference_water.tif'),
+            'algorithm_parameters': os.path.join(ancillary_data_dir, 'algorithm_parameter_s1.yaml')
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
+
     def get_opera_ancillary(self, ancillary_type, output_filepath, staging_func, staging_func_args):
         """
         Handles common operations for obtaining ancillary data used with OPERA

--- a/opera_chimera/wf_xml/L3_DSWx_S1.sf.xml
+++ b/opera_chimera/wf_xml/L3_DSWx_S1.sf.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<sf:sciflo xmlns:sf="http://sciflo.jpl.nasa.gov/2006v1/sf"
+        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+        xmlns:py="http://sciflo.jpl.nasa.gov/2006v1/py">
+  <sf:flow id="L3_DSWx_S1">
+    <sf:title>L3_DSWx_S1</sf:title>
+    <sf:icon>http://sciflo.jpl.nasa.gov/smap_sciflo/web/thumbnails/merged_data.png</sf:icon>
+    <sf:description>Run the L3_DSWx_S1 PGE workflow</sf:description>
+    <sf:inputs>
+        <sf_context>_context.json</sf_context>
+    </sf:inputs>
+    <sf:outputs>
+      <job_id_L3_DSWx_HLS from="@#L3_DSWx_S1_PGE"/>
+    </sf:outputs>
+
+    <sf:processes>
+      <!-- input preprocessor -->
+      <sf:process id="input_preprocessor_L3_DSWx_S1">
+        <sf:inputs>
+          <sf_context/>
+          <chimera_config_file>/home/ops/verdi/ops/opera-pcm/opera_chimera/configs/chimera_config.yaml</chimera_config_file>
+          <pge_config_file>/home/ops/verdi/ops/opera-pcm/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml</pge_config_file>
+          <settings_file>/home/ops/verdi/ops/opera-pcm/conf/settings.yaml</settings_file>
+        </sf:inputs>
+        <sf:outputs>
+          <PGE_L3_DSWx_HLS_job_params />
+        </sf:outputs>
+        <sf:operator>
+          <sf:description>Pre-processing steps for L3_DSWx_S1 PGE</sf:description>
+          <sf:op>
+            <sf:binding>python:/home/ops/verdi/ops/chimera/chimera/input_preprocessor.py?input_preprocessor.process</sf:binding>
+          </sf:op>
+        </sf:operator>
+      </sf:process>
+
+      <sf:process id="L3_DSWx_S1_PGE">
+        <sf:inputs>
+          <sf_context/>
+          <PGE_L3_DSWx_HLS_job_params from="@#input_preprocessor_L3_DSWx_S1"/>
+          <pge_config_file>/home/ops/verdi/ops/opera-pcm/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml</pge_config_file>
+          <settings_file>/home/ops/verdi/ops/opera-pcm/conf/settings.yaml</settings_file>
+          <chimera_config_file>/home/ops/verdi/ops/opera-pcm/opera_chimera/configs/chimera_config.yaml</chimera_config_file>
+        </sf:inputs>
+        <sf:outputs>
+          <job_id_L3_DSWx_S1 />
+        </sf:outputs>
+        <sf:operator>
+          <sf:description>Run the L3_DSWx_S1 PGE on an EC2 worker</sf:description>
+          <sf:op>
+            <sf:binding>python:/home/ops/verdi/ops/chimera/chimera/run_pge_docker.py?run_pge_docker.submit_pge_job</sf:binding>
+          </sf:op>
+        </sf:operator>
+      </sf:process>
+
+      <sf:process id="post_L3_DSWx_S1">
+        <sf:inputs>
+          <sf_context/>
+          <job_id_L3_DSWx_HLS from="@#previous"/>
+          <chimera_config_file>/home/ops/verdi/ops/opera-pcm/opera_chimera/configs/chimera_config.yaml</chimera_config_file>
+          <pge_config_file>/home/ops/verdi/ops/opera-pcm/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml</pge_config_file>
+          <settings_file>/home/ops/verdi/ops/opera-pcm/conf/settings.yaml</settings_file>
+        </sf:inputs>
+        <sf:outputs/>
+        <sf:operator>
+          <sf:description>Post-processing steps for the L3_DSWx_S1 PGE</sf:description>
+          <sf:op>
+            <sf:binding>python:/home/ops/verdi/ops/chimera/chimera/post_processor.py?post_processor.post_process</sf:binding>
+          </sf:op>
+        </sf:operator>
+      </sf:process>
+    </sf:processes>
+  </sf:flow>
+</sf:sciflo>

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -160,6 +160,9 @@ def convert(
         elif pge_name == "L2_CSLC_S1" or pge_name == "L2_RTC_S1":
             dataset_met_json["input_granule_id"] = product_metadata["id"]
             dataset_met_json["orbit_file"] = PurePath(extra_met["runconfig"]["localize"][0]).name
+        elif pge_name == "L3_DSWx_S1":
+            # TODO: this is probably insufficient, as there will be multiple input granule ID's for each DSWx-S1 job
+            dataset_met_json["input_granule_id"] = product_metadata["id"]
 
         dataset_met_json["pcm_version"] = job_json_util.get_pcm_version(job_json_dict)
 
@@ -214,6 +217,9 @@ def get_collection_info(dataset_id: str, settings: dict):
         else:
             collection_name = settings.get("RTC_COLLECTION_NAME")
             product_version = settings.get("RTC_S1_PRODUCT_VERSION")
+    elif "dswx-s1" in dataset_id.lower():
+        collection_name = settings.get("DSWX_S1_COLLECTION_NAME")
+        product_version = settings.get("DSWX_S1_PRODUCT_VERSION")
     else:
         collection_name = "Unknown"
         product_version = "Unknown"

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -198,7 +198,7 @@ def get_collection_info(dataset_id: str, settings: dict):
     """Returns the appropriate collection name and version for the provided dataset ID"""
 
     if "dswx-hls" in dataset_id.lower():
-        collection_name = settings.get("DSWX_COLLECTION_NAME")
+        collection_name = settings.get("DSWX_HLS_COLLECTION_NAME")
         product_version = settings.get("DSWX_HLS_PRODUCT_VERSION")
     elif "cslc-s1" in dataset_id.lower():
         if "static" in dataset_id.lower():

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -133,7 +133,7 @@ def test_simulate_dswx_hls_pge_with_l30():
         )
 
     # ASSERT
-    for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
+    for band_idx, band_name in enumerate(pge_util.DSWX_HLS_BAND_NAMES, start=1):
         assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tif').exists()
 
     assert Path(f'/tmp/{expected_output_base_name}.log').exists()
@@ -179,7 +179,7 @@ def test_simulate_dswx_hls_pge_with_s30():
         )
 
     # ASSERT
-    for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
+    for band_idx, band_name in enumerate(pge_util.DSWX_HLS_BAND_NAMES, start=1):
         assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tif').exists()
 
     assert Path(f'/tmp/{expected_output_base_name}.log').exists()
@@ -219,3 +219,40 @@ def test_simulate_dswx_hls_pge_with_unsupported():
                 },
                 output_dir='/tmp'
             )
+
+def test_simulate_dswx_s1_pge():
+    for path in glob.iglob('/tmp/OPERA_L3_DSWx*.*'):
+        Path(path).unlink(missing_ok=True)
+
+    pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml')
+
+    with open(pge_config_file_path) as pge_config_file:
+        pge_config = yaml.load(pge_config_file)
+
+    pge_util.simulate_run_pge(
+        pge_config['runconfig'],
+        pge_config,
+        context={
+            "job_specification": {
+                "params": []
+            }
+        },
+        output_dir='/tmp'
+    )
+
+    expected_output_basename = 'OPERA_L3_DSWx-S1_{tile_id}_20200702T231843Z_20200702T231843Z_v0.1'
+    expected_ancillary_basename = 'OPERA_L3_DSWx_20200702T231843Z'
+
+    try:
+        for tile_id in pge_util.DSWX_S1_TILES:
+            for band_idx, band_name in enumerate(pge_util.DSWX_S1_BAND_NAMES, start=1):
+                assert Path(f'/tmp/{expected_output_basename.format(tile_id=tile_id)}_B{band_idx:02}_{band_name}.tif').exists()
+
+            assert Path(f'/tmp/{expected_output_basename.format(tile_id=tile_id)}.iso.xml').exists()
+
+        assert Path(f'/tmp/{expected_ancillary_basename}.catalog.json').exists()
+        assert Path(f'/tmp/{expected_ancillary_basename}.log').exists()
+        assert Path(f'/tmp/{expected_ancillary_basename}.qa.log').exists()
+    finally:
+        for path in glob.iglob('/tmp/OPERA_L3_DSWx*.*'):
+            Path(path).unlink(missing_ok=True)

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -59,7 +59,16 @@ def get_product_metadata(job_json_dict: Dict) -> Dict:
     params = job_json_dict['job_specification']['params']
     for param in params:
         if param['name'] == 'product_metadata':
-            return param['value']['metadata']
+            metadata = param['value']
+
+            if isinstance(metadata, dict):
+                metadata = metadata['metadata']
+            elif isinstance(metadata, str):
+                metadata = json.loads(param['value'])['metadata']
+            else:
+                raise ValueError(f'Unknown product_metadata format: {metadata}')
+
+            return metadata
 
     raise
 

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -21,10 +21,16 @@ from hysds.utils import get_disk_usage
 
 from opera_chimera.constants.opera_chimera_const import OperaChimeraConstants as oc_const
 
-DSWX_BAND_NAMES = ['WTR', 'BWTR', 'CONF', 'DIAG', 'WTR-1',
-                   'WTR-2', 'LAND', 'SHAD', 'CLOUD', 'DEM']
+DSWX_HLS_BAND_NAMES = ['WTR', 'BWTR', 'CONF', 'DIAG', 'WTR-1',
+                       'WTR-2', 'LAND', 'SHAD', 'CLOUD', 'DEM']
 """
 List of band identifiers for the multiple tif outputs produced by the DSWx-HLS
+PGE.
+"""
+
+DSWX_S1_BAND_NAMES = ['WTR', 'BWTR', 'CONF']
+"""
+List of band identifiers for the multiple tif outputs produced by the DSWx-S1
 PGE.
 """
 
@@ -38,6 +44,9 @@ RTC_BURST_IDS = ['T069-147170-IW1', 'T069-147170-IW3', 'T069-147171-IW1',
                  'T069-147172-IW2', 'T069-147172-IW3', 'T069-147173-IW1']
 """List of sample burst ID's to simulate RTC-S1 multi-product output"""
 
+DSWX_S1_TILES = ['T18MVA', 'T18MVT', 'T18MVU', 'T18MVV', 'T18MWA', 'T18MWT',
+                 'T18MWU', 'T18MWV', 'T18MXA', 'T18MXT', 'T18MXU', 'T18MXV']
+"""List of sample MGRS tile ID's to simulate DSWx-S1 multi-product output"""
 
 def get_input_hls_dataset_tile_code(context: Dict) -> str:
     product_metadata = context["product_metadata"]["metadata"]
@@ -116,9 +125,14 @@ def simulate_run_pge(runconfig: Dict, pge_config: Dict, context: Dict, output_di
     pge_name: str = pge_config['pge_name']
     input_file_base_name_regexes: List[str] = pge_config['input_file_base_name_regexes']
 
+    input_dataset_id = get_input_dataset_id(context)
+
+    if not input_dataset_id:
+        input_dataset_id = pge_config.get('sample_input_dataset_id')
+
     for input_file_base_name_regex in input_file_base_name_regexes:
         pattern = re.compile(input_file_base_name_regex)
-        match = pattern.match(get_input_dataset_id(context))
+        match = pattern.match(input_dataset_id)
         if match:
             break
     else:
@@ -140,7 +154,8 @@ def get_input_dataset_id(context: Dict) -> str:
     for param in params:
         if param['name'] == 'input_dataset_id':
             return param['value']
-    raise
+    else:
+        return ""
 
 
 def get_cslc_s1_simulated_output_filenames(dataset_match, pge_config, extension):
@@ -289,7 +304,7 @@ def get_dswx_hls_simulated_output_filenames(dataset_match, pge_config, extension
 
     # Simulate the multiple output tif files created by this PGE
     if extension.endswith('tiff') or extension.endswith('tif'):
-        for band_idx, band_name in enumerate(DSWX_BAND_NAMES, start=1):
+        for band_idx, band_name in enumerate(DSWX_HLS_BAND_NAMES, start=1):
             output_filenames.append(f'{base_name}_B{band_idx:02}_{band_name}.tif')
     elif extension.endswith('png'):
         output_filenames.append(f'{base_name}_BROWSE.png')
@@ -300,13 +315,50 @@ def get_dswx_hls_simulated_output_filenames(dataset_match, pge_config, extension
     return output_filenames
 
 
+def get_dswx_s1_simulated_output_filenames(dataset_match, pge_config, extension):
+    """Generates the output basename for simulated DSWx-S1 PGE runs"""
+    output_filenames = []
+
+    base_name_template: str = pge_config['output_base_name']
+    ancillary_name_template: str = pge_config['ancillary_base_name']
+
+    acq_time = dataset_match.groupdict()['acquisition_ts']
+
+    for tile_id in DSWX_S1_TILES:
+        base_name = base_name_template.format(
+            tile_id=tile_id,
+            acquisition_ts=acq_time,
+            # make creation time a duplicate of the acquisition time for ease of testing
+            creation_ts=acq_time,
+            product_version=dataset_match.groupdict()['product_version']
+        )
+
+        # Simulate the multiple output tif files created by this PGE
+        if extension.endswith('tiff') or extension.endswith('tif'):
+            for band_idx, band_name in enumerate(DSWX_S1_BAND_NAMES, start=1):
+                output_filenames.append(f'{base_name}_B{band_idx:02}_{band_name}.tif')
+        elif extension.endswith('iso.xml'):
+            output_filenames.append(f'{base_name}.iso.xml')
+        # Ancillary output product pattern, no burst ID, acquisition time or polarization
+        else:
+            base_name = ancillary_name_template.format(creation_ts=acq_time)
+
+            ancillary_file_name = f'{base_name}.{extension}'
+
+            # Should only be one of these files per simulated run
+            if ancillary_file_name not in output_filenames:
+                output_filenames.append(ancillary_file_name)
+
+    return output_filenames
+
 def simulate_output(pge_name: str, pge_config: dict, dataset_match: re.Match, output_dir: str, extensions: str):
     for extension in extensions:
         # Generate the output file name(s) specific to the PGE to be simulated
         base_name_map = {
             'L2_CSLC_S1': get_cslc_s1_simulated_output_filenames,
             'L2_RTC_S1': get_rtc_s1_simulated_output_filenames,
-            'L3_DSWx_HLS': get_dswx_hls_simulated_output_filenames
+            'L3_DSWx_HLS': get_dswx_hls_simulated_output_filenames,
+            'L3_DSWx_S1': get_dswx_s1_simulated_output_filenames
         }
 
         try:

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -11,8 +11,10 @@ from typing import Dict, Tuple, List, Union
 
 from .pge_functions import (slc_s1_lineage_metadata,
                             dswx_hls_lineage_metadata,
+                            dswx_s1_lineage_metadata,
                             update_slc_s1_runconfig,
-                            update_dswx_hls_runconfig)
+                            update_dswx_hls_runconfig,
+                            update_dswx_s1_runconfig)
 from commons.logger import logger
 from opera_chimera.constants.opera_chimera_const import OperaChimeraConstants as opera_chimera_const
 from product2dataset import product2dataset
@@ -26,14 +28,16 @@ to_json = partial(json.dumps, indent=2)
 lineage_metadata_functions = {
     'L2_CSLC_S1': slc_s1_lineage_metadata,
     'L2_RTC_S1': slc_s1_lineage_metadata,
-    'L3_DSWx_HLS': dswx_hls_lineage_metadata
+    'L3_DSWx_HLS': dswx_hls_lineage_metadata,
+    'L3_DSWx_S1': dswx_s1_lineage_metadata
 }
 """Maps PGE Name to a specific function used to gather lineage metadata for that PGE"""
 
 runconfig_update_functions = {
     'L2_CSLC_S1': update_slc_s1_runconfig,
     'L2_RTC_S1': update_slc_s1_runconfig,
-    'L3_DSWx_HLS': update_dswx_hls_runconfig
+    'L3_DSWx_HLS': update_dswx_hls_runconfig,
+    'L3_DSWx_S1': update_dswx_s1_runconfig
 }
 """Maps PGE Name to a specific function used to perform last-minute updates to the RunConfig for that PGE"""
 
@@ -73,6 +77,8 @@ def run_pipeline(job_json_dict: Dict, work_dir: str) -> List[Union[bytes, str]]:
         lineage_metadata = lineage_metadata_functions[pge_name](job_json_dict, work_dir)
     except KeyError as err:
         raise RuntimeError(f'No lineage metadata function available for PGE {str(err)}')
+
+    logger.info(f'Derived lineage metadata: {lineage_metadata}')
 
     logger.info("Moving input files to input directories.")
     for local_input_filepath in lineage_metadata:

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -63,6 +63,28 @@ def dswx_hls_lineage_metadata(context, work_dir):
     return lineage_metadata
 
 
+def dswx_s1_lineage_metadata(context, work_dir):
+    """Gathers the lineage metadata for the DSWx-S1 PGE"""
+    lineage_metadata = []
+
+    rtc_data_dir = os.path.join(work_dir, 'dswx_s1_sample_input_data', 'rtc_data')
+
+    # TODO: update paths as necessary as sample inputs are phased out
+    lineage_metadata.extend(
+        [os.path.join(rtc_data_dir, rtc_dir)
+         for rtc_dir in os.listdir(rtc_data_dir)]
+    )
+
+    ancillary_data_dir = os.path.join(work_dir, 'dswx_s1_sample_input_data', 'ancillary_data')
+
+    lineage_metadata.extend(
+        [os.path.join(ancillary_data_dir, ancillary)
+         for ancillary in os.listdir(ancillary_data_dir)]
+    )
+
+    return lineage_metadata
+
+
 def update_slc_s1_runconfig(context, work_dir):
     """Updates a runconfig for use with the CSLC-S1 and RTC-S1 PGEs"""
     run_config: Dict = context.get("run_config")
@@ -114,5 +136,33 @@ def update_dswx_hls_runconfig(context, work_dir):
 
     shoreline_shape_filename = basename(run_config["dynamic_ancillary_file_group"]["shoreline_shapefile"])
     run_config["dynamic_ancillary_file_group"]["shoreline_shapefile"] = f'{container_home}/input_dir/{shoreline_shape_filename}'
+
+    return run_config
+
+
+def update_dswx_s1_runconfig(context, work_dir):
+    """Updates a runconfig for use with the DSWx-S1 PGE"""
+    run_config: Dict = context.get("run_config")
+    job_spec: Dict = context.get("job_specification")
+
+    container_home_param = list(
+        filter(lambda param: param['name'] == 'container_home', job_spec['params'])
+    )[0]
+
+    container_home: str = container_home_param['value']
+    container_home_prefix = f'{container_home}/input_dir'
+    rtc_data_prefix = os.path.join(work_dir, 'dswx_s1_sample_input_data', 'rtc_data')
+
+    input_file_paths = run_config["input_file_group"]["input_file_paths"]
+    input_file_paths = list(map(lambda x: x.replace(rtc_data_prefix, container_home_prefix), input_file_paths))
+
+    run_config["input_file_group"]["input_file_paths"] = input_file_paths
+
+    run_config["dynamic_ancillary_file_group"]["dem_file"] = f'{container_home_prefix}/dem.tif'
+    run_config["dynamic_ancillary_file_group"]["hand_file"] = f'{container_home_prefix}/hand.tif'
+    run_config["dynamic_ancillary_file_group"]["worldcover_file"] = f'{container_home_prefix}/worldcover.tif'
+    run_config["dynamic_ancillary_file_group"]["reference_water_file"] = f'{container_home_prefix}/reference_water.tif'
+
+    run_config["processing"]["algorithm_parameters"] = f'{container_home_prefix}/algorithm_parameter_s1.yaml'
 
     return run_config


### PR DESCRIPTION
This branch adds the initial integration of the DSWx-S1 PGE v3.0.0-er.2.0. Currently, the PGE can only be triggered manually through an on-demand Tosca job:

<img width="766" alt="Screenshot 2023-07-27 at 8 58 22 AM" src="https://github.com/nasa/opera-sds-pcm/assets/72415379/ff971063-db66-4243-a5f6-5a6b522f8589">

The current PGE job is configured to download and run with a set of sample inputs from S3 (from the collinss long term storage bucket). Simulation mode is also supported.