### PR TITLE
R2 PGE v2.0.0-rc.2.1 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -383,8 +383,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -455,8 +455,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -381,8 +381,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -173,8 +173,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -379,8 +379,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -382,8 +382,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,8 +31,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1" = "2.0.0-rc.2.0"
-    "rtc_s1" = "2.0.0-rc.2.0"
+    "cslc_s1" = "2.0.0-rc.2.1"
+    "rtc_s1" = "2.0.0-rc.2.1"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -146,7 +146,7 @@ variable "amis" {
     #factotum  = "ami-0b988a1203b7e5a58" # factotum v4.16
     #autoscale = "ami-082d3efc94d50659f" # verdi v4.16 patchupdate - 20230525
 
-    # HySDS v5.0.0-beta.6 - July 10, 2023 
+    # HySDS v5.0.0-beta.6 - July 10, 2023
     mozart    = "ami-0d1d5539d77a6cde2" # mozart v4.21 - 230710
     metrics   = "ami-0aa63c81611c8cb2a" # metrics v4.15 - 230626
     grq       = "ami-0ab96904359fa481b" # grq v4.16 - 230605
@@ -455,8 +455,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.1"
-    "cslc_s1"  = "2.0.0-rc.2.0"
-    "rtc_s1"   = "2.0.0-rc.2.0"
+    "cslc_s1"  = "2.0.0-rc.2.1"
+    "rtc_s1"   = "2.0.0-rc.2.1"
   }
 }
 

--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -38,7 +38,7 @@ RunConfig:
         ErrorCodeBase: 200000
         SchemaPath: /home/compass_user/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
         IsoTemplatePath: /home/compass_user/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
-        DataValidityStartTime: {{ data.product_path_group.data_validity_start_time }}
+        DataValidityStartDate: {{ data.product_path_group.data_validity_start_date }}
       QAExecutable:
         Enabled: False
         ProgramPath:
@@ -82,17 +82,14 @@ RunConfig:
             sas_output_file: {{ data.product_path_group.product_path }}
             product_version: "{{ data.product_path_group.product_version }}"
           primary_executable:
-            product_type: CSLC_S1
+            product_type: {{ data.processing.product_type }}
           processing:
             polarization: {{ data.processing.polarization }}
             geocoding:
               flatten: True
-              lines_per_block: 1000
               x_posting: 5
               y_posting: 10
             geo2rdr:
               lines_per_block: 1000
               threshold: 1.0e-8
               numiter: 25
-            rdr2geo:
-              enabled: {{ data.processing.enable_static_layers }}

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -39,7 +39,7 @@ RunConfig:
         ErrorCodeBase: 300000
         SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
         IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
-        DataValidityStartTime: {{ data.product_path_group.data_validity_start_time }}
+        DataValidityStartDate: {{ data.product_path_group.data_validity_start_date }}
       QAExecutable:
         Enabled: False
         ProgramPath:
@@ -84,7 +84,8 @@ RunConfig:
             product_path: {{ data.product_path_group.product_path }}
             scratch_path: {{ data.product_path_group.scratch_path }}
             output_dir: {{ data.product_path_group.product_path }}
-            product_id: OPERA_L2_RTC-S1_{burst_id}
+            product_id:
+            rtc_s1_static_validity_start_date: {{ data.product_path_group.data_validity_start_date }}
             save_bursts: True
             save_mosaics: False
             save_browse: True
@@ -94,49 +95,19 @@ RunConfig:
             save_secondary_layers_as_hdf5: False
             save_metadata: True
           primary_executable:
-            product_type: RTC_S1
+            product_type: {{ data.processing.product_type }}
           processing:
             check_ancillary_inputs_coverage: True
             polarization: {{ data.processing.polarization }}
-            geo2rdr:
-              threshold: 1.0e-7
-              numiter: 50
-            rdr2geo:
-              threshold: 1.0e-7
-              numiter: 25
-            apply_absolute_radiometric_correction: True
-            apply_thermal_noise_correction: True
-            apply_rtc: True
-            apply_bistatic_delay_correction: True
-            apply_dry_tropospheric_delay_correction: True
             rtc:
               output_type: gamma0
-              algorithm_type: area_projection
-              input_terrain_radiometry: beta0
-              rtc_min_value_db: -30
-              dem_upsampling: 2
-            num_workers: 0
+
+            num_workers: {{ data.processing.num_workers }}
+
             geocoding:
-              algorithm_type: area_projection
               memory_mode: auto
-              geogrid_upsampling: 1
 
-              save_incidence_angle: {{ data.processing.enable_static_layers }}
-              save_local_inc_angle: {{ data.processing.enable_static_layers }}
-              save_nlooks: {{ data.processing.enable_static_layers }}
-              save_rtc_anf: {{ data.processing.enable_static_layers }}
-              save_layover_shadow_mask: {{ data.processing.enable_static_layers }}
-
-              abs_rad_cal: 1
-              clip_max:
-              clip_min:
-              upsample_radargrid: False
               bursts_geogrid:
-                output_epsg:
-                x_posting: 30
-                y_posting: 30
-                x_snap: 30
-                y_snap: 30
                 top_left:
                   x:
                   y:
@@ -146,7 +117,3 @@ RunConfig:
 
             mosaicking:
               mosaic_mode: first
-
-            browse_image_group:
-              browse_image_burst_height: 1024
-              browse_image_mosaic_height: 1024

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -90,9 +90,6 @@ RunConfig:
             save_mosaics: False
             save_browse: True
             output_imagery_format: COG
-            output_imagery_compression: ZSTD
-            output_imagery_nbits: 16
-            save_secondary_layers_as_hdf5: False
             save_metadata: True
           primary_executable:
             product_type: {{ data.processing.product_type }}

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -24,16 +24,16 @@ L2_CSLC_S1:
   Outputs:
     Primary:
       # Pattern for parsing primary (per-burst) output filenames, such as:
-      # OPERA_L2_CSLC-S1A_IW_T064-135518-IW1_VV_20220501T015035Z_v1.0_20230119T195150Z.h5
-      # OPERA_L2_CSLC-S1A_IW_T064-135518-IW1_VV_20140403T000000Z_v1.0_20230119T195150Z_Static.h5
-      # OPERA_L2_CSLC-S1A_IW_T064-135518-IW1_VV_20220501T015035Z_v1.0_20230119T195150Z_BROWSE.png
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))(_Static|_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      # OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20230807T212944Z_S1A_VV_v1.0.h5
+      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_20230807T234233Z_S1A_v1.0.h5
+      # OPERA_L2_CSLC-S1_T064-135518-IW2_20220501T015035Z_20230807T212944Z_S1A_VV_v1.0_BROWSE.png
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)(-STATIC)?_(?P<burst_id>\w{4}-\w{6}-\w{3})_((?P<validity_date>\d{8})|(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z))_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV))?_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
-      # OPERA_L2_CSLC-S1A_IW_VV_v1.0_20230119T195150Z.log
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>log|qa\.log|catalog\.json)$'
+      # OPERA_L2_CSLC-S1_20230807T234233Z_S1A_VV_v1.0.log
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>log|qa\.log|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames
@@ -45,11 +45,13 @@ L2_RTC_S1:
   Outputs:
     Primary:
       # Pattern for parsing primary (per-burst) output filenames, such as:
-      # OPERA_L2_RTC-S1_T069-147169-IW3_20180504T104507Z_20230109T203121Z_S1B_30_v1.0.h5
-      # OPERA_L2_RTC-S1_T069-147169-IW3_20180504T104507Z_20230109T203121Z_S1B_30_v1.0_VV.tif
-      # OPERA_L2_RTC-S1_T069-147169-IW3_20140403T000000Z_20230109T203121Z_S1B_30_v1.0_static_nlooks.tif
-      # OPERA_L2_RTC-S1_T069-147169-IW3_20180504T104507Z_20230109T203121Z_S1B_30_v1.0_BROWSE.png
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_BROWSE|_static_(?P<static_layer_name>incidence_angle|layover_shadow_mask|local_incidence_angle|nlooks|rtc_anf_gamma0_to_beta0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0.h5
+      # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_VV.tif
+      # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_mask.tif
+      # OPERA_L2_RTC-S1_T069-147175-IW1_20180504T104522Z_20230804T203850Z_S1B_30_v1.0_BROWSE.png
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0.h5
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0_incidence_angle.tif
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)(-STATIC)?_(?P<burst_id>\w{4}-\w{6}-\w{3})_((?P<validity_date>\d{8})|(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z))_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:

--- a/conf/schema/RunConfig_schema.L2_CSLC_S1.yaml
+++ b/conf/schema/RunConfig_schema.L2_CSLC_S1.yaml
@@ -26,7 +26,7 @@ RunConfig:
         SchemaPath: str(required=True)
         AlgorithmParametersSchemaPath: str(required=False)
         IsoTemplatePath: str(required=False)
-        DataValidityStartTime: regex(r'\d{8}T\d{6}', name='YYYYMMDDTHHmmss datetime', required=False)
+        DataValidityStartDate: int(min=20000101, max=21991231, required=False)
 
       QAExecutable:
         Enabled: bool(required=True)
@@ -80,7 +80,7 @@ RunConfig:
             product_specification_version: str(required=False)
 
           primary_executable:
-            product_type: enum('CSLC_S1')
+            product_type: enum('CSLC_S1', 'CSLC_S1_STATIC')
 
           # This section includes parameters to tweak the workflow
           processing: include('processing_options', required=False)
@@ -90,6 +90,9 @@ RunConfig:
 
           # Quality assurance options
           quality_assurance: include('quality_assurance_options', required=False)
+
+          # Output options for geocoded rasters (CSLC datatype, compression, chunking, shuffle filter)
+          output: include('output_options', required=False)
 ---
 # Group of processing options
 processing_options:
@@ -107,8 +110,6 @@ processing_options:
 geocoding_options:
   # Boolean flag to enable/disable flattening
   flatten: bool(required=False)
-  # Number of lines to process in batch
-  lines_per_block: int(min=1, required=False)
   # Product posting along X (same units as burst center EPSG)
   x_posting: num(min=0, required=False)
   # Product posting along Y (same units as burst center EPSG)
@@ -143,8 +144,6 @@ troposphere_options:
   delay_type: enum('dry', 'wet', 'wet_dry', required=False)
 
 rdr2geo_options:
-  # Enable/disable computation of topo layers
-  enabled: bool(required=False)
   # Convergence threshold for rdr2geo algorithm
   threshold: num(min=0, required=False)
   # Maximum number of iterations
@@ -161,14 +160,12 @@ rdr2geo_options:
   compute_height: bool(required=False)
   # Enable/disable layover shadow mask output
   compute_layover_shadow_mask: bool(required=False)
-  # Enable/disable incidence angle output
-  compute_incidence_angle: bool(required=False)
   # Enable/disable local incidence output
   compute_local_incidence_angle: bool(required=False)
-  # Enable/disable azimuth angle output
-  compute_azimuth_angle: bool(required=False)
-  # Enable/disable geocoding of the topo layers
-  geocode_metadata_layers: bool(required=False)
+  # Enable/disable ground to satellite East LOS vector
+  compute_ground_to_sat_east: bool(required=False)
+  # Enable/disable ground to satellite North LOS vector
+  compute_ground_to_sat_north: bool(required=False)
 
 worker_options:
   # To prevent downloading DEM / other data automatically. Default True
@@ -200,4 +197,17 @@ browse_image_options:
   gamma: num(min=0, required=False)
   # Enable/disable histogram equalization
   equalize: bool(required=False)
+
+output_options:
+  # Data type of CSLC raster (default complex64_zero_mantissa)
+  cslc_data_type: enum('complex32', 'complex64', 'complex64_zero_mantissa', required=False)
+  # Enable/disable gzip compression of raster (default True)
+  compression_enabled: bool(required=False)
+  # Level of compression applied to raster (default 4)
+  # 1 - least compression, 9 - best compresssion
+  compression_level: int(min=1, max=9, required=False)
+  # Chunk size of raster (default [128, 128])
+  chunk_size: list(int(min=4), min=2, max=2, required=False)
+  # Enable/disable shuffle filtering of rasters (default True)
+  shuffle: bool(required=False)
 

--- a/conf/schema/RunConfig_schema.L2_RTC_S1.yaml
+++ b/conf/schema/RunConfig_schema.L2_RTC_S1.yaml
@@ -26,7 +26,7 @@ RunConfig:
         SchemaPath: str(required=True)
         AlgorithmParametersSchemaPath: str(required=False)
         IsoTemplatePath: str(required=False)
-        DataValidityStartTime: regex(r'\d{8}T\d{6}', name='YYYYMMDDTHHmmss datetime', required=False)
+        DataValidityStartDate: int(min=20000101, max=21991231, required=False)
 
       QAExecutable:
         Enabled: bool(required=True)
@@ -42,14 +42,23 @@ RunConfig:
         name: str()
 
         groups:
+          primary_executable:
+            # Required. Output product type: "RTC_S1" or "RTC_S1_STATIC"
+            product_type: enum('RTC_S1', 'RTC_S1_STATIC')
+
           pge_name_group:
             pge_name: enum('RTC_S1_PGE')
 
           input_file_group:
             # Required. List of SAFE files (min=1)
             safe_file_path: list(str(), min=1)
+
+            # Location from where the source data can be retrieved (URL or DOI)
+            source_data_access: str(required=False)
+
             # Required. List of orbit (EOF) files
             orbit_file_path: list(str(), min=1)
+
             # Optional. Burst ID to process (empty for all bursts)
             burst_id: list(str(), min=1, required=False)
 
@@ -65,9 +74,6 @@ RunConfig:
             # burst database sqlite file
             burst_database_file: str(required=False)
 
-          primary_executable:
-            product_type: enum('RTC_S1')
-
           product_group:
 
             processing_type: enum('NOMINAL', 'URGENT', 'CUSTOM', 'UNDEFINED', required=False)
@@ -80,9 +86,9 @@ RunConfig:
             scratch_path: str()
 
             # If option `save_bursts` is set, output bursts are saved to:
-            #     {output_dir}/{burst_id}/{product_id}_v{product_version}{suffix}.{ext}
+            #     {output_dir}/{burst_id}/{product_id}{suffix}.{ext}
             # If option `save_mosaics` is set, output mosaics are saved to:
-            #     {output_dir}/{product_id}_v{product_version}{suffix}.{ext}
+            #     {output_dir}/{product_id}{suffix}.{ext}
             #
             # If the `product_id` contains the substring "_{burst_id}", the
             # substring will be substituted by either:
@@ -93,14 +99,31 @@ RunConfig:
             # `RTC-S1_069-147170-IW1_S1B` for the burst t069-147170-IW1; and it
             # will become `RTC-S1_S1B` for the mosaic product.
             #
-            # If the field `product_id`` is left empty, the prefix
-            # "OPERA_L2_RTC-S1_{burst_id}"  will be used instead.
+            # For RTC-S1 products, if the field `product_id` is left empty,
+            # the burst product ID will follow the RTC-S1 file naming conventions:
+            # `OPERA_L2_RTC-S1_{burst_id}_{sensing_start_datetime}_
+            # {processing_datetime}_{sensor}_{pixel_spacing}
+            #  _{product_version}`.
+            #
+            # For RTC-S1-STATIC products, if the field `product_id` is left empty,
+            # the burst product ID will follow the RTC-S1-STATIC file naming
+            # conventions:
+            # `OPERA_L2_RTC-S1-STATIC_{burst_id}_{rtc_s1_static_validity_start_date}_
+            # {processing_datetime}_{sensor}_{pixel_spacing}
+            #  _{product_version}`.
+            #
             # `suffix` is only used when there are multiple output files.
             # `ext` is determined by geocoding_options.output_imagery_format.
             output_dir: str()
-            product_id: str()
+            product_id: str(required=False)
 
-            # RTC-S1 imagery
+            # Validity start date for RTC-S1-STATIC products in the format YYYYMMDD
+            rtc_s1_static_validity_start_date: int(min=20000101, max=21991231, required=False)
+
+            # Location from where the output product can be retrieved (URL or DOI)
+            product_data_access: str(required=False)
+
+            # Save RTC-S1 products
             save_bursts: bool(required=False)
 
             # Save mosaic of RTC-S1 bursts
@@ -216,10 +239,12 @@ rtc_options:
   # RTC DEM upsampling
   dem_upsampling: int(min=1, required=False)
 
+  # RTC area beta mode
+  area_beta_mode: enum('auto', 'pixel_area', 'projection_angle', required=False)
 
 geocoding_options:
 
-  # OPTIONAL - Apply RSLC metadata valid-samples sub-swath masking
+  # OPTIONAL - Apply valid-samples sub-swath masking
   apply_valid_samples_sub_swath_masking: bool(required=False)
 
   # OPTIONAL - Apply shadow masking
@@ -249,23 +274,26 @@ geocoding_options:
 
   # Save the RTC area normalization factor (ANF) computed with
   # the projection angle method
-  save_rtc_anf_psi: bool(required=False)
+  save_rtc_anf_projection_angle: bool(required=False)
 
   # Save the range slope angle
   save_range_slope: bool(required=False)
 
-  # Save the number of looks used to generate the RTC product
+  # Save the number of looks used to generate the RTC-S1 product
   save_nlooks: bool(required=False)
 
   # Save the RTC area normalization factor (ANF) used to generate
   # the RTC product
   save_rtc_anf: bool(required=False)
 
-  # Save the interpolated DEM used to generate the RTC product
+  # Save the RTC area normalization factor (ANF) gamma0 to sigma0
+  save_rtc_anf_gamma0_to_sigma0: bool(required=False)
+
+  # Save the interpolated DEM used to generate the RTC-S1 product
   save_dem: bool(required=False)
 
   # Save layover/shadow mask
-  save_layover_shadow_mask: bool(required=False)
+  save_mask: bool(required=False)
 
   # Layover/shadow mask dilation size of shadow pixels
   shadow_dilation_size: int(min=0, required=False)
@@ -324,6 +352,7 @@ output_grid_options:
   bottom_right:
     x: num(required=False)
     y: num(required=False)
+
 
 browse_image_options:
 

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -265,9 +265,9 @@
       }
     },
     {
-      "ipath": "hysds::data/L2_CSLC_S1_static_layers",
+      "ipath": "hysds::data/L2_CSLC_S1_STATIC",
       "level": "L2",
-      "type": "L2_CSLC_S1_static_layers",
+      "type": "L2_CSLC_S1_STATIC",
       "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
@@ -313,9 +313,9 @@
       }
     },
     {
-      "ipath": "hysds::data/L2_RTC_S1_static_layers",
+      "ipath": "hysds::data/L2_RTC_S1_STATIC",
       "level": "L2",
-      "type": "L2_RTC_S1_static_layers",
+      "type": "L2_RTC_S1_STATIC",
       "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -244,7 +244,7 @@
       "ipath": "hysds::data/L2_CSLC_S1",
       "level": "L2",
       "type": "L2_CSLC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_static_layers",
       "level": "L2",
       "type": "L2_CSLC_S1_static_layers",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2})T(?P<validity_hour>\\d{2})(?P<validity_minute>\\d{2})(?P<validity_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_static_layers)$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -292,7 +292,7 @@
       "ipath": "hysds::data/L2_RTC_S1",
       "level": "L2",
       "type": "L2_RTC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))(_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV))?$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))(_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)|_BROWSE|_mask)?$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -316,7 +316,7 @@
       "ipath": "hysds::data/L2_RTC_S1_static_layers",
       "level": "L2",
       "type": "L2_RTC_S1_static_layers",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2})T(?P<validity_hour>\\d{2})(?P<validity_minute>\\d{2})(?P<validity_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+)_static_layers)$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -265,9 +265,9 @@
       }
     },
     {
-      "ipath": "hysds::data/L2_CSLC_S1_static_layers",
+      "ipath": "hysds::data/L2_CSLC_S1_STATIC",
       "level": "L2",
-      "type": "L2_CSLC_S1_static_layers",
+      "type": "L2_CSLC_S1_STATIC",
       "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
@@ -313,9 +313,9 @@
       }
     },
     {
-      "ipath": "hysds::data/L2_RTC_S1_static_layers",
+      "ipath": "hysds::data/L2_RTC_S1_STATIC",
       "level": "L2",
-      "type": "L2_RTC_S1_static_layers",
+      "type": "L2_RTC_S1_STATIC",
       "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -244,7 +244,7 @@
       "ipath": "hysds::data/L2_CSLC_S1",
       "level": "L2",
       "type": "L2_CSLC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_static_layers",
       "level": "L2",
       "type": "L2_CSLC_S1_static_layers",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2})T(?P<validity_hour>\\d{2})(?P<validity_minute>\\d{2})(?P<validity_second>\\d{2})Z)_(?P<product_version>v\\d+[.]\\d+)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_static_layers)$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -292,7 +292,7 @@
       "ipath": "hysds::data/L2_RTC_S1",
       "level": "L2",
       "type": "L2_RTC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))(_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV))?$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))(_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)|_BROWSE|_mask)?$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -316,7 +316,7 @@
       "ipath": "hysds::data/L2_RTC_S1_static_layers",
       "level": "L2",
       "type": "L2_RTC_S1_static_layers",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2})T(?P<validity_hour>\\d{2})(?P<validity_minute>\\d{2})(?P<validity_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+)_static_layers)$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -31,7 +31,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.h5\"],\"metadata\":[\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.h5\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
@@ -59,7 +59,7 @@
     {
       "enabled": true,
       "job_type": "hysds-io-send_notify_msg:__TAG__",
-      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\"],\"metadata\":[\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
+      "kwargs": "{\"provider_name\":\"JPL-OPERA\",\"checksum_type\":\"md5\",\"publisher_arn\":\"{{ ASF_DAAC_PROXY }}\",\"sqs_queue_url\":\"{{ ASF_DAAC_SQS_URL }}\",\"sqs_endpoint_url\":\"{{ ASF_DAAC_ENDPOINT_URL }}\",\"staged_data_types\":{\"data\":[\"*.tif\", \"*.h5\"],\"browse\":[\"*.png\"],\"metadata\":[\"*.log\",\"*.catalog.json\",\"*.iso.xml\",\"*.md5\"]},\"use_s3_uri_structure\": \"{{ USE_S3_URI }}\",\"product_type_key\": \"CollectionName\",\"data_version\":\"0.0\",\"schema_version\":\"1.5\"}",
       "passthru_query": false,
       "priority": 0,
       "query_all": false,

--- a/conf/sds/rules/user_rules-cnm.json.tmpl
+++ b/conf/sds/rules/user_rules-cnm.json.tmpl
@@ -35,9 +35,9 @@
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
-      "query_string": "{\n \"bool\": {\n \"must\": [\n {\n \"term\": {\n \"dataset.keyword\": \"L2_CSLC_S1_static_layers\"\n }\n }\n ],\n \"must_not\": [\n {\n \"term\": {\n \"metadata.restaged\": \"true\"\n }\n }\n ]\n }\n}",
+      "query_string": "{\n \"bool\": {\n \"must\": [\n {\n \"term\": {\n \"dataset.keyword\": \"L2_CSLC_S1_STATIC\"\n }\n }\n ],\n \"must_not\": [\n {\n \"term\": {\n \"metadata.restaged\": \"true\"\n }\n }\n ]\n }\n}",
       "queue": "opera-job_worker-send_cnm_notify",
-      "rule_name": "trigger-send_cnm_notify_msg_L2_CSLC_S1_static_layers",
+      "rule_name": "trigger-send_cnm_notify_msg_L2_CSLC_S1_STATIC",
       "username": "hysdsops",
       "workflow": "hysds-io-send_notify_msg:__TAG__",
       "job_spec": "job-send_notify_msg:__TAG__"
@@ -63,9 +63,9 @@
       "passthru_query": false,
       "priority": 0,
       "query_all": false,
-      "query_string": "{\n \"bool\": {\n \"must\": [\n {\n \"term\": {\n \"dataset.keyword\": \"L2_RTC_S1_static_layers\"\n }\n }\n ],\n \"must_not\": [\n {\n \"term\": {\n \"metadata.restaged\": \"true\"\n }\n }\n ]\n }\n}",
+      "query_string": "{\n \"bool\": {\n \"must\": [\n {\n \"term\": {\n \"dataset.keyword\": \"L2_RTC_S1_STATIC\"\n }\n }\n ],\n \"must_not\": [\n {\n \"term\": {\n \"metadata.restaged\": \"true\"\n }\n }\n ]\n }\n}",
       "queue": "opera-job_worker-send_cnm_notify",
-      "rule_name": "trigger-send_cnm_notify_msg_L2_RTC_S1_static_layers",
+      "rule_name": "trigger-send_cnm_notify_msg_L2_RTC_S1_STATIC",
       "username": "hysdsops",
       "workflow": "hysds-io-send_notify_msg:__TAG__",
       "job_spec": "job-send_notify_msg:__TAG__"

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -62,8 +62,8 @@ RES_ORBIT_TIME_RANGE: 3  # Hours
 CSLC_S1:
   # Toggle static layer generation during processing
   ENABLE_STATIC_LAYERS: !!bool false
-  # Validity start time used to tag static layer products
-  DATA_VALIDITY_START_TIME: 20140403T000000
+  # Validity start date used to tag static layer products
+  DATA_VALIDITY_START_DATE: 20140403
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 100
 
@@ -78,8 +78,8 @@ DSWX_HLS:
 RTC_S1:
   # Toggle static layer generation during processing
   ENABLE_STATIC_LAYERS: !!bool false
-  # Validity start time used to tag static layer products
-  DATA_VALIDITY_START_TIME: 20140403T000000
+  # Validity start date used to tag static layer products
+  DATA_VALIDITY_START_DATE: 20140403
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 100
 

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -61,7 +61,7 @@ RES_ORBIT_TIME_RANGE: 3  # Hours
 
 CSLC_S1:
   # Toggle static layer generation during processing
-  ENABLE_STATIC_LAYERS: !!bool true
+  ENABLE_STATIC_LAYERS: !!bool false
   # Validity start time used to tag static layer products
   DATA_VALIDITY_START_TIME: 20140403T000000
   # Amount of margin in km to apply to staged ancillaries (DEM)
@@ -77,7 +77,7 @@ DSWX_HLS:
 
 RTC_S1:
   # Toggle static layer generation during processing
-  ENABLE_STATIC_LAYERS: !!bool true
+  ENABLE_STATIC_LAYERS: !!bool false
   # Validity start time used to tag static layer products
   DATA_VALIDITY_START_TIME: 20140403T000000
   # Amount of margin in km to apply to staged ancillaries (DEM)
@@ -183,10 +183,9 @@ PRODUCT_TYPES:
 
     L2_CSLC_S1:
         # Pattern for parsing output L2_CSLC-S1 product filenames, such as:
-        # OPERA_L2_CSLC-S1A_IW_T064-135518-IW1_VV_20220501T015035Z_v1.0_20230119T195150Z.h5
-        # OPERA_L2_CSLC-S1A_IW_T064-135518-IW1_VV_20220501T015035Z_v1.0_20230119T195150Z.h5
+        # OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20230807T212944Z_S1A_VV_v1.0.h5
         # This pattern groups the metadata information in the filename using named groups.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:
@@ -199,14 +198,13 @@ PRODUCT_TYPES:
 
     L2_CSLC_S1_static_layers:
       # Pattern for parsing output L2_CSLC-S1 static layer product filenames, such as:
-      # OPERA_L2_CSLC-S1A_IW_T064-135518-IW1_VV_20140403T000000Z_v1.0_20230119T195150Z_Static.h5
+      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_20230807T234233Z_S1A_v1.0.h5
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<sensor>S1A|S1B)_(?P<mode>IW)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2})T(?P<validity_hour>\d{2})(?P<validity_minute>\d{2})(?P<validity_second>\d{2})Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))_Static[.](?P<ext>h5)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5|iso\.xml)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
-      Suffix: '_static_layers'
       Configuration:
-        Date_Time_Patterns: [ '%Y%m%dT%H%M%SZ' ]
+        Date_Time_Patterns: [ '%Y%m%d', '%Y%m%dT%H%M%SZ' ]
         Date_Time_Keys: [ 'validity_ts', 'creation_ts' ]
         # Specify the metadata key to use as the dataset version.
         #  Note: this affects the data product index name
@@ -215,11 +213,12 @@ PRODUCT_TYPES:
 
     L2_RTC_S1:
         # Pattern for parsing output L2_RTC-S1 product filenames, such as:
-        # OPERA_L2_RTC-S1_T069-147169-IW3_20180504T104507Z_20230109T203121Z_S1B_30_v1.0.h5
-        # OPERA_L2_RTC-S1_T069-147169-IW3_20180504T104507Z_20230109T203121Z_S1B_30_v1.0_VV.tif
-        # OPERA_L2_RTC-S1_T069-147169-IW3_20180504T104507Z_20230109T203121Z_S1B_30_v1.0_BROWSE.png
+        # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0.h5
+        # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_VV.tif
+        # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_mask.tif
+        # OPERA_L2_RTC-S1_T069-147175-IW1_20180504T104522Z_20230804T203850Z_S1B_30_v1.0_BROWSE.png
         # This pattern groups the metadata information in the filename using named groups.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV))?(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_BROWSE|_mask)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:
@@ -232,15 +231,15 @@ PRODUCT_TYPES:
 
     L2_RTC_S1_static_layers:
       # Pattern for parsing output L2_RTC-S1 static layer product filenames, such as:
-      # OPERA_L2_RTC-S1_T069-147169-IW3_20140403T000000Z_20230109T203121Z_S1B_30_v1.0_static_nlooks.tif
-      # OPERA_L2_RTC-S1_T069-147169-IW3_20140403T000000Z_20230109T203121Z_S1B_30_v1.0_static_layover_shadow_mask.tif
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0.h5
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0_incidence_angle.tif
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0_number_of_looks.tif
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2})T(?P<validity_hour>\d{2})(?P<validity_minute>\d{2})(?P<validity_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_static_(?P<static_layer_name>incidence_angle|layover_shadow_mask|local_incidence_angle|nlooks|rtc_anf_gamma0_to_beta0)[.](?P<ext>tif|tiff)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
-      Suffix: '_static_layers'
       Configuration:
-        Date_Time_Patterns: [ '%Y%m%dT%H%M%SZ' ]
+        Date_Time_Patterns: [ '%Y%m%d', '%Y%m%dT%H%M%SZ' ]
         Date_Time_Keys: [ 'validity_ts', 'creation_ts' ]
         # Specify the metadata key to use as the dataset version.
         #  Note: this affects the data product index name

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.2.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.2.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.2.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.2.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.2.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.2.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.0.0-rc.2.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0-rc.2.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.0-rc.2.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-rc.2.0.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.0.0-rc.2.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0-rc.2.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -25,17 +25,17 @@ runconfig:
     product_version: __CHIMERA_VAL__
     product_path: /home/compass_user/output_dir
     scratch_path: /home/compass_user/scratch
-    data_validity_start_time: __CHIMERA_VAL__
+    data_validity_start_date: __CHIMERA_VAL__
   processing:
     # TODO: set to __CHIMERA_VAL__ once dual-pol mode is supported by the CSLC-S1 SAS
     polarization: co-pol
-    enable_static_layers: __CHIMERA_VAL__
+    product_type: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
   - get_product_version
-  - get_data_validity_start_time
+  - get_data_validity_start_date
   # TODO uncomment once dual-pol mode is supported by the CSLC-S1 SAS
   # - get_slc_polarization
   - get_slc_static_layers_enabled
@@ -61,7 +61,7 @@ get_slc_s1_dem:
 get_slc_s1_burst_database:
   # The s3 location of the burst database file to use with each job
   s3_bucket: "opera-burstdb"
-  s3_key: "opera_burst_database_deploy_2022_1212.sqlite3"
+  s3_key: "burst_db_20230713-bbox-only.sqlite"
 
 set_daac_product_type:
   template: OPERA_L2_CSLC_S1_{cnm_version}
@@ -105,5 +105,6 @@ localize_groups:
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
     - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})$'
-output_base_name: OPERA_L2_CSLC-S1A_IW_{burst_id}_{pol}_{acquisition_ts}Z_{product_version}_{creation_ts}Z
-ancillary_base_name: OPERA_L2_CSLC-S1A_IW_{pol}_{product_version}_{creation_ts}Z
+output_base_name: OPERA_L2_CSLC-S1_{burst_id}_{acquisition_ts}Z_{creation_ts}Z_{sensor}_{pol}_{product_version}
+static_output_base_name: OPERA_L2_CSLC-S1-STATIC_{burst_id}_{validity_ts}_{creation_ts}Z_{sensor}_{product_version}
+ancillary_base_name: OPERA_L2_CSLC-S1_{creation_ts}Z_{sensor}_{pol}_{product_version}

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
@@ -25,16 +25,18 @@ runconfig:
     product_path: /home/rtc_user/output_dir
     # Scratch path is defined relative to output_dir to avoid file system permission issues
     scratch_path: /home/rtc_user/output_dir/scratch_dir
-    data_validity_start_time: __CHIMERA_VAL__
+    data_validity_start_date: __CHIMERA_VAL__
   processing:
     polarization: __CHIMERA_VAL__
-    enable_static_layers: __CHIMERA_VAL__
+    product_type: __CHIMERA_VAL__
+    num_workers: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
   - get_product_version
-  - get_data_validity_start_time
+  - get_data_validity_start_date
+  - get_rtc_s1_num_workers
   - get_slc_polarization
   - get_slc_static_layers_enabled
   - get_slc_s1_safe_file
@@ -58,7 +60,7 @@ get_slc_s1_dem:
 get_slc_s1_burst_database:
   # The s3 location of the burst database file to use with each job
   s3_bucket: "opera-burstdb"
-  s3_key: "opera_burst_database_deploy_2022_1212.sqlite3"
+  s3_key: "burst_db_20230713-bbox-only.sqlite"
 
 set_daac_product_type:
   template: OPERA_L2_CSLC_S1_{cnm_version}
@@ -104,4 +106,5 @@ localize_groups:
 input_file_base_name_regexes: # regexes taken from settings.yaml
     - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})$'
 output_base_name: OPERA_L2_RTC-S1_{burst_id}_{acquisition_ts}Z_{creation_ts}Z_{sensor}_30_{product_version}
+static_output_base_name: OPERA_L2_RTC-S1-STATIC_{burst_id}_{validity_ts}_{creation_ts}Z_{sensor}_30_{product_version}
 ancillary_base_name: OPERA_L2_RTC-S1_{creation_ts}Z_{sensor}_30_{product_version}

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1147,19 +1147,19 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
-    def get_data_validity_start_time(self):
-        """Gets the setting for the data_validity_start_time flag from settings.yaml"""
+    def get_data_validity_start_date(self):
+        """Gets the setting for the data_validity_start_date flag from settings.yaml"""
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 
         pge_name = self._pge_config.get('pge_name')
         pge_shortname = pge_name[3:].upper()
 
-        logger.info(f'Getting DATA_VALIDITY_START_TIME setting for PGE {pge_shortname}')
+        logger.info(f'Getting DATA_VALIDITY_START_DATE setting for PGE {pge_shortname}')
 
-        data_validity_start_time = self._settings.get(pge_shortname).get("DATA_VALIDITY_START_TIME")
+        data_validity_start_time = self._settings.get(pge_shortname).get("DATA_VALIDITY_START_DATE")
 
         rc_params = {
-            "data_validity_start_time": data_validity_start_time
+            "data_validity_start_date": data_validity_start_time
         }
 
         logger.info(f"rc_params : {rc_params}")

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -714,6 +714,29 @@ class OperaPreConditionFunctions(PreConditionFunctions):
                 )
             )
 
+    def get_rtc_s1_num_workers(self):
+        """
+        Determines the number of workers/cores to assign to an RTC-S1 as a
+        fraction of the total available.
+
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        available_cores = os.cpu_count()
+
+        # Use 3/4th of the available cores
+        num_workers = max(int(round((available_cores * 3) / 4)), 1)
+
+        logger.info(f"Allocating {num_workers} core(s) out of {available_cores} available")
+
+        rc_params = {
+            "num_workers": str(num_workers)
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def get_slc_polarization(self):
         """
         Determines the polarization setting for the CSLC-S1 or RTC-S1 job based
@@ -776,7 +799,9 @@ class OperaPreConditionFunctions(PreConditionFunctions):
             enable_static_layers = False
 
         rc_params = {
-            "enable_static_layers": enable_static_layers
+            "product_type": (
+                f"{pge_shortname}_STATIC" if enable_static_layers else f"{pge_shortname}"
+            )
         }
 
         logger.info(f"rc_params : {rc_params}")

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -269,8 +269,8 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
 
         self.assertIsNotNone(rc_params)
         self.assertIsInstance(rc_params, dict)
-        self.assertIn('enable_static_layers', rc_params)
-        self.assertTrue(rc_params['enable_static_layers'])
+        self.assertIn('product_type', rc_params)
+        self.assertEqual(rc_params['product_type'], 'RTC_S1_STATIC')
 
         # Make sure static layer generation is disabled when in "historical" mode
         context = {
@@ -300,8 +300,8 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
 
         self.assertIsNotNone(rc_params)
         self.assertIsInstance(rc_params, dict)
-        self.assertIn('enable_static_layers', rc_params)
-        self.assertFalse(rc_params['enable_static_layers'])
+        self.assertIn('product_type', rc_params)
+        self.assertEqual(rc_params['product_type'], 'CSLC_S1')
 
         # Check that we logged the flag being set to False
         self.assertIn('INFO:opera_pcm:Processing mode for L2_CSLC_S1 is set to historical, '

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -37,19 +37,27 @@ def test_simulate_cslc_s1_pge():
         output_dir='/tmp'
     )
 
-    expected_output_basename = 'OPERA_L2_CSLC-S1A_IW_{burst_id}_VV_20220501T015035Z_v0.1_20220501T015102Z'
-    expected_ancillary_basename = 'OPERA_L2_CSLC-S1A_IW_VV_v0.1_20220501T015102Z'
+    expected_output_basename = 'OPERA_L2_CSLC-S1_{burst_id}_20220501T015035Z_{creation_ts}Z_S1A_VV_v0.1'
+    expected_static_output_basename = 'OPERA_L2_CSLC-S1-STATIC_{burst_id}_20140403_{creation_ts}Z_S1A_v0.1'
+    expected_ancillary_basename = 'OPERA_L2_CSLC-S1_{creation_ts}Z_S1A_VV_v0.1'
+    creation_ts = pge_util.get_time_for_filename()
 
     try:
         for burst_id in pge_util.CSLC_BURST_IDS:
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}.h5').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_Static.h5').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_BROWSE.png').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}.iso.xml').exists()
+            output_basename = expected_output_basename.format(burst_id=burst_id, creation_ts=creation_ts)
+            static_output_basename = expected_static_output_basename.format(burst_id=burst_id, creation_ts=creation_ts)
 
-        assert Path(f'/tmp/{expected_ancillary_basename}.catalog.json').exists()
-        assert Path(f'/tmp/{expected_ancillary_basename}.log').exists()
-        assert Path(f'/tmp/{expected_ancillary_basename}.qa.log').exists()
+            assert Path(f'/tmp/{output_basename}.h5').exists()
+            assert Path(f'/tmp/{output_basename}_BROWSE.png').exists()
+            assert Path(f'/tmp/{output_basename}.iso.xml').exists()
+
+            assert Path(f'/tmp/{static_output_basename}.h5').exists()
+            assert Path(f'/tmp/{static_output_basename}.iso.xml').exists()
+
+        ancillary_basename = expected_ancillary_basename.format(creation_ts=creation_ts)
+        assert Path(f'/tmp/{ancillary_basename}.catalog.json').exists()
+        assert Path(f'/tmp/{ancillary_basename}.log').exists()
+        assert Path(f'/tmp/{ancillary_basename}.qa.log').exists()
     finally:
         for path in glob.iglob('/tmp/OPERA_L2_CSLC-S1*.*'):
             Path(path).unlink(missing_ok=True)
@@ -80,33 +88,45 @@ def test_simulate_rtc_s1_pge():
         output_dir='/tmp'
     )
 
-    expected_output_basename = 'OPERA_L2_RTC-S1_{burst_id}_20180504T104507Z_20180504T104535Z_S1B_30_v0.1'
-    expected_ancillary_basename = 'OPERA_L2_RTC-S1_20180504T104535Z_S1B_30_v0.1'
+    expected_output_basename = 'OPERA_L2_RTC-S1_{burst_id}_20180504T104507Z_{creation_ts}Z_S1B_30_v0.1'
+    expected_static_output_basename = 'OPERA_L2_RTC-S1-STATIC_{burst_id}_20140403_{creation_ts}Z_S1B_30_v0.1'
+    expected_ancillary_basename = 'OPERA_L2_RTC-S1_{creation_ts}Z_S1B_30_v0.1'
+    creation_ts = pge_util.get_time_for_filename()
 
     try:
         for burst_id in pge_util.RTC_BURST_IDS:
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_VV.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_VH.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_static_incidence_angle.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_static_layover_shadow_mask.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_static_local_incidence_angle.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_static_nlooks.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}_static_rtc_anf_gamma0_to_beta0.tif').exists()
-            assert Path(f'/tmp/{expected_output_basename.format(burst_id=burst_id)}.iso.xml').exists()
+            output_basename = expected_output_basename.format(burst_id=burst_id, creation_ts=creation_ts)
+            static_output_basename = expected_static_output_basename.format(burst_id=burst_id, creation_ts=creation_ts)
 
-        assert Path(f'/tmp/{expected_ancillary_basename}.catalog.json').exists()
-        assert Path(f'/tmp/{expected_ancillary_basename}.log').exists()
-        assert Path(f'/tmp/{expected_ancillary_basename}.qa.log').exists()
+            assert Path(f'/tmp/{output_basename}.h5').exists()
+            assert Path(f'/tmp/{output_basename}_VV.tif').exists()
+            assert Path(f'/tmp/{output_basename}_VH.tif').exists()
+            assert Path(f'/tmp/{output_basename}_mask.tif').exists()
+            assert Path(f'/tmp/{output_basename}_BROWSE.png').exists()
+            assert Path(f'/tmp/{output_basename}.iso.xml').exists()
+
+            assert Path(f'/tmp/{static_output_basename}.h5').exists()
+            assert Path(f'/tmp/{static_output_basename}_BROWSE.png').exists()
+            assert Path(f'/tmp/{static_output_basename}_incidence_angle.tif').exists()
+            assert Path(f'/tmp/{static_output_basename}_mask.tif').exists()
+            assert Path(f'/tmp/{static_output_basename}_local_incidence_angle.tif').exists()
+            assert Path(f'/tmp/{static_output_basename}_number_of_looks.tif').exists()
+            assert Path(f'/tmp/{static_output_basename}_rtc_anf_gamma0_to_beta0.tif').exists()
+            assert Path(f'/tmp/{static_output_basename}_rtc_anf_gamma0_to_sigma0.tif').exists()
+            assert Path(f'/tmp/{static_output_basename}.iso.xml').exists()
+
+        ancillary_basename = expected_ancillary_basename.format(creation_ts=creation_ts)
+        assert Path(f'/tmp/{ancillary_basename}.catalog.json').exists()
+        assert Path(f'/tmp/{ancillary_basename}.log').exists()
+        assert Path(f'/tmp/{ancillary_basename}.qa.log').exists()
     finally:
         for path in glob.iglob('/tmp/OPERA_L2_RTC-S1*.*'):
             Path(path).unlink(missing_ok=True)
 
 
 def test_simulate_dswx_hls_pge_with_l30():
-    expected_output_base_name = "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20210905T143156Z_L8_30_v2.0"
-
     # before
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
+    for path in glob.iglob(f'/tmp/OPERA_L3_DSWx-HLS*'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml')
@@ -132,6 +152,9 @@ def test_simulate_dswx_hls_pge_with_l30():
             output_dir='/tmp'
         )
 
+    creation_ts = pge_util.get_time_for_filename()
+    expected_output_base_name = f"OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_{creation_ts}Z_L8_30_v2.0"
+
     # ASSERT
     for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
         assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tif').exists()
@@ -144,15 +167,15 @@ def test_simulate_dswx_hls_pge_with_l30():
     assert Path(f'/tmp/{expected_output_base_name}.iso.xml').exists()
 
     # after
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
+    for path in glob.iglob(f'/tmp/OPERA_L3_DSWx-HLS*'):
         Path(path).unlink(missing_ok=True)
 
 
 def test_simulate_dswx_hls_pge_with_s30():
-    expected_output_base_name = "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20210907T163901Z_S2A_30_v2.0"
+
 
     # before
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
+    for path in glob.iglob(f'/tmp/OPERA_L3_DSWx-HLS*'):
         Path(path).unlink(missing_ok=True)
 
     pge_config_file_path = join(REPO_DIR, 'opera_chimera/configs/pge_configs/PGE_L3_DSWx_HLS.yaml')
@@ -178,6 +201,9 @@ def test_simulate_dswx_hls_pge_with_s30():
             output_dir='/tmp'
         )
 
+    creation_ts = pge_util.get_time_for_filename()
+    expected_output_base_name = f"OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_{creation_ts}Z_S2A_30_v2.0"
+
     # ASSERT
     for band_idx, band_name in enumerate(pge_util.DSWX_BAND_NAMES, start=1):
         assert Path(f'/tmp/{expected_output_base_name}_B{band_idx:02}_{band_name}.tif').exists()
@@ -190,7 +216,7 @@ def test_simulate_dswx_hls_pge_with_s30():
     assert Path(f'/tmp/{expected_output_base_name}.iso.xml').exists()
 
     # after
-    for path in glob.iglob(f'/tmp/{expected_output_base_name}*'):
+    for path in glob.iglob(f'/tmp/OPERA_L3_DSWx-HLS*'):
         Path(path).unlink(missing_ok=False)
 
 

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -148,47 +148,47 @@ def get_cslc_s1_simulated_output_filenames(dataset_match, pge_config, extension)
     output_filenames = []
 
     base_name_template: str = pge_config['output_base_name']
+    static_name_template: str = pge_config['static_output_base_name']
     ancillary_name_template: str = pge_config['ancillary_base_name']
+    creation_time = get_time_for_filename()
 
-    if extension.endswith('h5'):
+    if extension.endswith('h5') or extension.endswith('iso.xml'):
         for burst_id in CSLC_BURST_IDS:
             base_name = base_name_template.format(
                 burst_id=burst_id,
-                pol='VV',
                 acquisition_ts=dataset_match.groupdict()['start_ts'],
-                product_version='v0.1',
-                creation_ts=dataset_match.groupdict()['stop_ts']
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
+                pol='VV',
+                product_version='v0.1'
             )
-
             output_filenames.append(f'{base_name}.{extension}')
-            output_filenames.append(f'{base_name}_Static.{extension}')
+
+            static_base_name = static_name_template.format(
+                burst_id=burst_id,
+                validity_ts='20140403',
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
+                product_version='v0.1',
+            )
+            output_filenames.append(f'{static_base_name}.{extension}')
     elif extension.endswith('png'):
         for burst_id in CSLC_BURST_IDS:
             base_name = base_name_template.format(
                 burst_id=burst_id,
-                pol='VV',
                 acquisition_ts=dataset_match.groupdict()['start_ts'],
-                product_version='v0.1',
-                creation_ts=dataset_match.groupdict()['stop_ts']
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
+                pol='VV',
+                product_version='v0.1'
             )
-
             output_filenames.append(f'{base_name}_BROWSE.{extension}')
-    elif extension.endswith('iso.xml'):
-        for burst_id in CSLC_BURST_IDS:
-            base_name = base_name_template.format(
-                burst_id=burst_id,
-                pol='VV',
-                acquisition_ts=dataset_match.groupdict()['start_ts'],
-                product_version='v0.1',
-                creation_ts=dataset_match.groupdict()['stop_ts']
-            )
-
-            output_filenames.append(f'{base_name}.{extension}')
     else:
         base_name = ancillary_name_template.format(
+            creation_ts=creation_time,
+            sensor=dataset_match.groupdict()['mission_id'],
             pol='VV',
             product_version='v0.1',
-            creation_ts=dataset_match.groupdict()['stop_ts']
         )
 
         output_filenames.append(f'{base_name}.{extension}')
@@ -201,9 +201,9 @@ def get_rtc_s1_simulated_output_filenames(dataset_match, pge_config, extension):
     output_filenames = []
 
     base_name_template: str = pge_config['output_base_name']
+    static_name_template: str = pge_config['static_output_base_name']
     ancillary_name_template: str = pge_config['ancillary_base_name']
-
-    sensor = dataset_match.groupdict()['mission_id']
+    creation_time = get_time_for_filename()
 
     # Primary output image product pattern, includes burst ID, acquisition time
     # and polarization values/static layer name
@@ -212,48 +212,75 @@ def get_rtc_s1_simulated_output_filenames(dataset_match, pge_config, extension):
             base_name = base_name_template.format(
                 burst_id=burst_id,
                 acquisition_ts=dataset_match.groupdict()['start_ts'],
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
-                creation_ts=dataset_match.groupdict()['stop_ts'],
-                sensor=sensor
             )
 
             output_filenames.append(f'{base_name}_VV.{extension}')
             output_filenames.append(f'{base_name}_VH.{extension}')
-            output_filenames.append(f'{base_name}_static_incidence_angle.{extension}')
-            output_filenames.append(f'{base_name}_static_layover_shadow_mask.{extension}')
-            output_filenames.append(f'{base_name}_static_local_incidence_angle.{extension}')
-            output_filenames.append(f'{base_name}_static_nlooks.{extension}')
-            output_filenames.append(f'{base_name}_static_rtc_anf_gamma0_to_beta0.{extension}')
+            output_filenames.append(f'{base_name}_mask.{extension}')
+
+            static_base_name = static_name_template.format(
+                burst_id=burst_id,
+                validity_ts='20140403',
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
+                product_version='v0.1',
+            )
+
+            output_filenames.append(f'{static_base_name}_incidence_angle.{extension}')
+            output_filenames.append(f'{static_base_name}_mask.{extension}')
+            output_filenames.append(f'{static_base_name}_local_incidence_angle.{extension}')
+            output_filenames.append(f'{static_base_name}_number_of_looks.{extension}')
+            output_filenames.append(f'{static_base_name}_rtc_anf_gamma0_to_beta0.{extension}')
+            output_filenames.append(f'{static_base_name}_rtc_anf_gamma0_to_sigma0.{extension}')
     # Primary metadata product, like image product but no polarization field
     elif extension.endswith('h5') or extension.endswith('iso.xml'):
         for burst_id in RTC_BURST_IDS:
             base_name = base_name_template.format(
                 burst_id=burst_id,
                 acquisition_ts=dataset_match.groupdict()['start_ts'],
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
-                creation_ts=dataset_match.groupdict()['stop_ts'],
-                sensor=sensor
             )
-
             output_filenames.append(f'{base_name}.{extension}')
+
+            static_base_name = static_name_template.format(
+                burst_id=burst_id,
+                validity_ts='20140403',
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
+                product_version='v0.1',
+            )
+            output_filenames.append(f'{static_base_name}.{extension}')
     # PNG browse product, like image product but appended with "_BROWSE"
     elif extension.endswith('png'):
         for burst_id in RTC_BURST_IDS:
             base_name = base_name_template.format(
                 burst_id=burst_id,
                 acquisition_ts=dataset_match.groupdict()['start_ts'],
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
-                creation_ts=dataset_match.groupdict()['stop_ts'],
-                sensor=sensor
             )
-
             output_filenames.append(f'{base_name}_BROWSE.{extension}')
+
+            static_base_name = static_name_template.format(
+                burst_id=burst_id,
+                validity_ts='20140403',
+                creation_ts=creation_time,
+                sensor=dataset_match.groupdict()['mission_id'],
+                product_version='v0.1',
+            )
+            output_filenames.append(f'{static_base_name}_BROWSE.{extension}')
     # Ancillary output product pattern, no burst ID, acquisition time or polarization
     else:
         base_name = ancillary_name_template.format(
+            creation_ts=creation_time,
+            sensor=dataset_match.groupdict()['mission_id'],
             product_version='v0.1',
-            creation_ts=dataset_match.groupdict()['stop_ts'],
-            sensor=sensor
         )
 
         output_filenames.append(f'{base_name}.{extension}')
@@ -278,11 +305,12 @@ def get_dswx_hls_simulated_output_filenames(dataset_match, pge_config, extension
     acq_time = datetime.strptime(
         dataset_match.groupdict()['acquisition_ts'], '%Y%jT%H%M%S').strftime('%Y%m%dT%H%M%S')
 
+    creation_time = get_time_for_filename()
+
     base_name = base_name_template.format(
         tile_id=dataset_match.groupdict()['tile_id'],
         acquisition_ts=acq_time,
-        # make creation time a duplicate of the acquisition time for ease of testing
-        creation_ts=acq_time,
+        creation_ts=creation_time,
         sensor=sensor,
         product_version=dataset_match.groupdict()['collection_version']
     )
@@ -299,6 +327,18 @@ def get_dswx_hls_simulated_output_filenames(dataset_match, pge_config, extension
 
     return output_filenames
 
+PRODUCTION_TIME = None
+def get_time_for_filename():
+    """
+    Creates o a time-tag string suitable for use with PGE output filenames.
+    The time-tag string is cached after the first call to this function.
+    """
+    global PRODUCTION_TIME
+
+    if PRODUCTION_TIME is None:
+        PRODUCTION_TIME = datetime.now().strftime('%Y%m%dT%H%M%S')
+
+    return PRODUCTION_TIME
 
 def simulate_output(pge_name: str, pge_config: dict, dataset_match: re.Match, output_dir: str, extensions: str):
     for extension in extensions:


### PR DESCRIPTION
This branch updates PCM to incorporate v2.0.0-rc.2.1 of the R2 PGEs (CSLC-S1 and RTC-S1). Major changes with this release include updates to the file naming conventions for both baseline and static layer products, as well as changes to the workflow such that only the baseline products or static layer products can be produced at a time.

This branch was tested with the R2 PGEs both in simulation and real mode using the following input SLC archive:

     S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC

For real mode, both the baseline and static layer workflows were tested by setting the `enable_static_layers` flag appropriately in settings.yaml.

Lastly, this branch also introduces a fix for #574 so that simulation mode products always use the current time for the production time field.