### PR TITLE
Orbit time range start margin fix

### DIFF
--- a/tests/tools/test_stage_orbit_file.py
+++ b/tests/tools/test_stage_orbit_file.py
@@ -97,7 +97,7 @@ class TestStageOrbitFile(unittest.TestCase):
             <opensearch:startIndex>0</opensearch:startIndex>
             <opensearch:itemsPerPage>10</opensearch:itemsPerPage>
             <entry>
-            <title>S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942</title>
+            <title>S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T200000_20220502T005942</title>
             <id>a4c32eea-7c42-4bd7-ae4e-404151a11120</id>
             <str name="format">EOF</str>
             <str name="size">4.2 MB</str>
@@ -105,13 +105,13 @@ class TestStageOrbitFile(unittest.TestCase):
             <str name="platformshortname">S1</str>
             <str name="platformnumber">A</str>
             <str name="platformserialidentifier">1A</str>
-            <str name="filename">S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF</str>
+            <str name="filename">S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T200000_20220502T005942.EOF</str>
             <str name="producttype">AUX_POEORB</str>
             <str name="filedescription">Precise Orbit Ephemerides (POE) Orbit File</str>
             <str name="fileclass">OPER</str>
             <str name="creator">OPOD</str>
             <str name="creatorversion">1.11.6</str>
-            <str name="identifier">S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942</str>
+            <str name="identifier">S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T200000_20220502T005942</str>
             <str name="uuid">a4c32eea-7c42-4bd7-ae4e-404151a11120</str>
             </entry>
             </feed>
@@ -129,7 +129,7 @@ class TestStageOrbitFile(unittest.TestCase):
 
         # Make sure we parsed the results as expected
         self.assertEquals(
-            orbit_file_name, "S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T225942_20220502T005942.EOF"
+            orbit_file_name, "S1A_OPER_AUX_POEORB_OPOD_20220521T081912_V20220430T200000_20220502T005942.EOF"
         )
         self.assertEquals(
             orbit_file_request_id, "a4c32eea-7c42-4bd7-ae4e-404151a11120"

--- a/tools/stage_orbit_file.py
+++ b/tools/stage_orbit_file.py
@@ -46,6 +46,17 @@ ORBIT_TYPE_RES = 'RESORB'
 VALID_ORBIT_TYPES = (ORBIT_TYPE_POE, ORBIT_TYPE_RES)
 """List of the valid orbit types that this script supports querying for"""
 
+T_ORBIT = (12 * 86400.0) / 175.0
+"""
+Orbital period of Sentinel-1 in seconds: 12 days * 86400.0 seconds/day, 
+divided into 175 orbits
+"""
+
+SAFE_START_TIME_MARGIN = timedelta(seconds=T_ORBIT + 60.0)
+"""
+Temporal margin to apply to the start time of a frame to make sure that the 
+ascending node crossing is included when choosing the orbit file
+"""
 
 class NoQueryResultsException(Exception):
     """Custom exception to identify empty results from a query"""
@@ -469,6 +480,10 @@ def select_orbit_file(entry_elems, namespace_map, safe_start_time, safe_stop_tim
         safe_stop_datetime = datetime.strptime(safe_stop_time, "%Y%m%dT%H%M%S")
         orbit_start_datetime = datetime.strptime(orbit_start_time, "%Y%m%dT%H%M%S")
         orbit_stop_datetime = datetime.strptime(orbit_stop_time, "%Y%m%dT%H%M%S")
+
+        # Apply the start time margin to the beginning of the SAFE time range
+        # to ensure we select an orbit file with appropriate padding up-front
+        safe_start_datetime -= SAFE_START_TIME_MARGIN
 
         if orbit_start_datetime < safe_start_datetime and orbit_stop_datetime > safe_stop_datetime:
             logger.debug(f'orbit_file_name: {orbit_file_name}')


### PR DESCRIPTION
This branch updates stage_orbit_file.py to ensure the selected Orbit file has a start time that occurs at least 60 minutes prior to the start time of the corresponding SLC SAFE archive. This change is to bring the staging logic in line with what is expected by the s1_reader library utilized by the R2 SAS.