### PR TITLE
Ionosphere naming convention update

### DIFF
--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1066,11 +1066,10 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         # Find the available Ionosphere files staged by the download job
         ionosphere_file_objects = []
-        for ionosphere_file_type in VALID_IONOSPHERE_TYPES:
+        for ionosphere_file_type in VALID_IONOSPHERE_TYPES + ['RAP', 'FIN']:
             ionosphere_file_objects.extend(
                 list(filter(lambda s3_object: ionosphere_file_type in s3_object.key, s3_objects))
             )
-
         logger.info(f"{ionosphere_file_objects}=")
 
         # May not of found any Ionosphere files during download phase, so check now

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -29,7 +29,7 @@ def test_simulate_cslc_s1_pge():
                 "params": [
                     {
                         "name": "input_dataset_id",
-                        "value": "S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC"
+                        "value": "S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC-r1"
                     }
                 ]
             }
@@ -80,7 +80,7 @@ def test_simulate_rtc_s1_pge():
                 "params": [
                     {
                         "name": "input_dataset_id",
-                        "value": "S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F"
+                        "value": "S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F-r1"
                     }
                 ]
             }
@@ -144,7 +144,7 @@ def test_simulate_dswx_hls_pge_with_l30():
                     "params": [
                         {
                             "name": "input_dataset_id",
-                            "value": "HLS.L30.T22VEQ.2021248T143156.v2.0"
+                            "value": "HLS.L30.T22VEQ.2021248T143156.v2.0-r1"
                         }
                     ]
                 }
@@ -193,7 +193,7 @@ def test_simulate_dswx_hls_pge_with_s30():
                     "params": [
                         {
                             "name": "input_dataset_id",
-                            "value": "HLS.S30.T15SXR.2021250T163901.v2.0"
+                            "value": "HLS.S30.T15SXR.2021250T163901.v2.0-r1"
                         }
                     ]
                 }
@@ -238,7 +238,7 @@ def test_simulate_dswx_hls_pge_with_unsupported():
                         "params": [
                             {
                                 "name": "input_dataset_id",
-                                "value": "HLS.X30.T15SXR.2021250T163901.v2.0"
+                                "value": "HLS.X30.T15SXR.2021250T163901.v2.0-r1"
                             }
                         ]
                     }

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -25,7 +25,12 @@ def slc_s1_lineage_metadata(context, work_dir):
     local_dem_filepaths = glob.glob(os.path.join(work_dir, "dem*.*"))
     lineage_metadata.extend(local_dem_filepaths)
 
+    # Legacy Ionosphere files
     local_tec_filepaths = glob.glob(os.path.join(work_dir, "jp*.*i"))
+    lineage_metadata.extend(local_tec_filepaths)
+
+    # New Ionosphere files
+    local_tec_filepaths = glob.glob(os.path.join(work_dir, "JPL*.INX"))
     lineage_metadata.extend(local_tec_filepaths)
 
     local_burstdb_filepaths = glob.glob(os.path.join(work_dir, "*.sqlite3"))


### PR DESCRIPTION
This branch updates the stage_ionosphere_file.py script to support the new file naming conventions adopted after 8/12/2023 (?). The script will attempt to look for the "legacy" ionosphere file name, and if it is not available (provider returns 404 code), then it will reattempt using the "new" naming conventions. If the file still cannot be found, the `IonosphereFileNotFoundException` error will be raised.

The changes to stage_ionosphere_file.py were tested locally with the following granules:

- Legacy: `S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC`
- New: `S1A_IW_SLC__1SDV_20230812T170353_20230812T170419_049845_05FEAE_1474`
- Invalid (no ionosphere files available yet): `S1A_IW_SLC__1SDV_20230816T170353_20230816T170419_049845_05FEAE_1474`

Note that the Invalid case is a made up granule name with the start/end times set to today (8/16). Both ionosphere types were tested.

Note that this branch was **not tested** in a deployed cluster for sake of expediency.

Lastly, this branch also fixes some unrelated unit tests for PGE simulation mode where the new revision tag was not included in the sample dataset IDs used with the tests.