### PR TITLE
Fix fix_get_slc_s1_dem() for antimeridian crossing

### DIFF
--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -996,6 +996,12 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         lon_min = min(lons)
         lon_max = max(lons)
 
+        # check for the antimeridian crossing:
+        if lon_max - lon_min > 180:
+            lons = [lon + (lon < 0) * 360 for lon in lons]
+            lon_min = min(lons)
+            lon_max = max(lons)
+
         bbox = [lon_min, lat_min, lon_max, lat_max]  # WSEN order
 
         logger.info(f"Derived DEM bounding box: {bbox}")


### PR DESCRIPTION
This PR fixes the function fix_get_slc_s1_dem() for S1 datasets that cross the antimeridian.

When there S1 dataset crosses the antimeridian, the western and eastern longitude boundaries cannot be computed directly using `min()` and `max()` functions because the longitude coordinates are "wrapped" by `360` degrees. This PR fixes it by first detecting the antimeridian crossing using the statement `if lon_max - lon_min > 180:` and wrapping the negative longitude values up by `360` degrees: `lons = [lon + (lon < 0) * 360 for lon in lons]`. Afterwards, the `min()` and `max()` values can be computed normally.