### PR TITLE
Anti-meridian crossing fix for SLC bounding boxes

### DIFF
--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -996,6 +996,12 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         lon_min = min(lons)
         lon_max = max(lons)
 
+        # check for the antimeridian crossing:
+        if lon_max - lon_min > 180:
+            lons = [lon + (lon < 0) * 360 for lon in lons]
+            lon_min = min(lons)
+            lon_max = max(lons)
+
         bbox = [lon_min, lat_min, lon_max, lat_max]  # WSEN order
 
         logger.info(f"Derived DEM bounding box: {bbox}")

--- a/tests/geo/test_geo_util.py
+++ b/tests/geo/test_geo_util.py
@@ -27,7 +27,8 @@ def test_bbox_in_north_america():
     ]
     assert does_bbox_intersect_north_america(bbox)
 
-def test_polygon_from_bounding_box():
+def test_polygon_from_bounding_box_nominal():
+    """Test application of margin to bounding box which does not cross anti-meridian"""
     # bbox obtained from S1A_IW_SLC__1SDH_20230628T122459_20230628T122529_049186_05EA1E_AD77
     bounding_box = [-77.210869, 81.085464, -55.746243, 83.767433]
     poly = polygon_from_bounding_box(bounding_box, margin_in_km=100)
@@ -37,7 +38,32 @@ def test_polygon_from_bounding_box():
                                         xmax=-85.48536002006186,
                                         ymax=84.6657482770715)
 
-    assert poly == expected_poly
+    assert poly.bounds == expected_poly.bounds
+
+def test_polygon_from_bounding_box_antimeridian():
+    """Test application of margin to bounding box which crosses the anti-meridian"""
+    # Raw bbox obtained from S1B_IW_SLC__1SDV_20210730T183014_20210730T183044_028027_0357ED_4B46
+    bounding_box = [-176.387039, 67.454239, 178.635727, 69.701736]
+    poly = polygon_from_bounding_box(bounding_box, margin_in_km=100)
+
+    expected_poly = Polygon.from_bounds(xmin=-173.79754190105595,
+                                        ymin=66.5559237229285,
+                                        xmax=176.04622990105597,
+                                        ymax=70.6000512770715)
+
+    assert poly.bounds == expected_poly.bounds
+
+    # "Unwrapped" bbox from S1B_IW_SLC__1SDV_20210730T183014_20210730T183044_028027_0357ED_4B46,
+    # as would be returned from geo_util.bounding_box_from_slc_granule()
+    bounding_box = [177.793381, 67.454239, 184.918289, 69.701736]
+    poly = polygon_from_bounding_box(bounding_box, margin_in_km=100)
+
+    expected_poly = Polygon.from_bounds(xmin=175.20388390105597,
+                                        ymin=66.5559237229285,
+                                        xmax=187.50778609894402,
+                                        ymax=70.6000512770715)
+
+    assert poly.bounds == expected_poly.bounds
 
 def test_polygon_from_mgrs_tile_nominal():
     """Reproduce ADT results from values provided with code"""
@@ -48,9 +74,9 @@ def test_polygon_from_mgrs_tile_nominal():
                                         xmax=-91.99766472766642,
                                         ymax=32.577473659397235)
 
-    assert poly == expected_poly
+    assert poly.bounds == expected_poly.bounds
 
-def test_polygon_from_mgrs_tile_nominal_antimeridian():
+def test_polygon_from_mgrs_tile_antimeridian():
     """Test MGRS tile code conversion with a tile that crosses the anti-meridian"""
     poly = polygon_from_mgrs_tile('T60VXQ', margin_in_km=0)
 
@@ -59,4 +85,4 @@ def test_polygon_from_mgrs_tile_nominal_antimeridian():
                                         xmax= 178.82637550795243,
                                         ymax=63.16076767648831)
 
-    assert poly == expected_poly
+    assert poly.bounds == expected_poly.bounds

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -103,8 +103,14 @@ def polygon_from_bounding_box(bounding_box, margin_in_km):
     lat_margin = margin_km_to_deg(margin_in_km)
     lon_margin = margin_km_to_longitude_deg(margin_in_km, lat=lat_worst_case)
 
-    poly = box(lon_min - lon_margin, max([lat_min - lat_margin, -90]),
-               lon_max + lon_margin, min([lat_max + lat_margin, 90]))
+    # Check if the bbox crosses the antimeridian and apply the margin accordingly
+    # so that any resultant DEM is split properly by check_dateline
+    if lon_max - lon_min > 180:
+        poly = box(lon_min + lon_margin, max([lat_min - lat_margin, -90]),
+                   lon_max - lon_margin, min([lat_max + lat_margin, 90]))
+    else:
+        poly = box(lon_min - lon_margin, max([lat_min - lat_margin, -90]),
+                   lon_max + lon_margin, min([lat_max + lat_margin, 90]))
 
     return poly
 


### PR DESCRIPTION
This branch introduces two fixes to address the issue when an SLC bounding box crosses the anti-meridian. 

One fix (provided by @gshiroma) is to the code that derives the bounding box from an SLC granule which ensures that if the bbox crosses the anti-meridian the coordinates are "unwrapped" before selecting the min/max longitude values.

The other fix (provided by @vbrancat) is to the `geo_util.polygon_from_bounding_box` function to ensure that margin is applied correctly when the input bounding box crosses the anti-merdian. This fix was added to account for cases where the bounding box is not derived from an SLC granule (and hence is not already "unwrapped"), as could be the case for future bounding box regions derived for R3 processing.

Note that these fixes should address the specific failures reported in #593 for all listed datasets, but issues within the SAS itself still result in about 11 out of 29 job failures. These should be addressed in the final delivery for RTC-S1.
