### PR TITLE
Fix GDAL translate cropping coordinates to avoid the removal of the last pixel in X or Y directions

### DIFF
--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -996,12 +996,6 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         lon_min = min(lons)
         lon_max = max(lons)
 
-        # check for the antimeridian crossing:
-        if lon_max - lon_min > 180:
-            lons = [lon + (lon < 0) * 360 for lon in lons]
-            lon_min = min(lons)
-            lon_max = max(lons)
-
         bbox = [lon_min, lat_min, lon_max, lat_max]  # WSEN order
 
         logger.info(f"Derived DEM bounding box: {bbox}")

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -996,6 +996,12 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         lon_min = min(lons)
         lon_max = max(lons)
 
+        # check for the antimeridian crossing:
+        if lon_max - lon_min > 180:
+            lons = [lon + (lon < 0) * 360 for lon in lons]
+            lon_min = min(lons)
+            lon_max = max(lons)
+
         bbox = [lon_min, lat_min, lon_max, lat_max]  # WSEN order
 
         logger.info(f"Derived DEM bounding box: {bbox}")

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -134,8 +134,13 @@ def translate_dem(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     input_x_min, xres, _, input_y_max, _, yres = ds.GetGeoTransform()
     length = ds.GetRasterBand(1).YSize
     width = ds.GetRasterBand(1).XSize
-    input_y_min = input_y_max + (length * yres)
-    input_x_max = input_x_min + (width * xres)
+
+    # GDAL translate will snap `projWin` coordinates to the map grid
+    # of the input dataset. We add `0.4` to the maximum length and
+    # width to make sure that GDAL Translate will not round down the ending
+    # coordinates and remove the last pixel in X or Y directions
+    input_y_min = input_y_max + ((length + 0.4) * yres)
+    input_x_max = input_x_min + ((width + 0.4) * xres)
 
     x_min = max(x_min, input_x_min)
     x_max = min(x_max, input_x_max)

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -135,7 +135,7 @@ def translate_dem(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     length = ds.GetRasterBand(1).YSize
     width = ds.GetRasterBand(1).XSize
 
-    # GDAL translate will snap `projWin` coordinates to the map grid
+    # GDAL translate snaps `projWin` coordinates to the map grid
     # of the input dataset. We add `0.4` to the maximum length and
     # width to make sure that GDAL Translate will not round down the ending
     # coordinates and remove the last pixel in X or Y directions

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -20,6 +20,8 @@ from util.geo_util import (check_dateline,
                            polygon_from_mgrs_tile,
                            transform_polygon_coords_to_epsg)
 
+import numpy as np
+
 # Enable exceptions
 gdal.UseExceptions()
 
@@ -135,12 +137,23 @@ def translate_dem(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     length = ds.GetRasterBand(1).YSize
     width = ds.GetRasterBand(1).XSize
 
-    # GDAL translate snaps `projWin` coordinates to the map grid
-    # of the input dataset. We add `0.4` to the maximum length and
-    # width to make sure that GDAL Translate will not round down the ending
-    # coordinates and remove the last pixel in X or Y directions
-    input_y_min = input_y_max + ((length + 0.4) * yres)
-    input_x_max = input_x_min + ((width + 0.4) * xres)
+    # declare lambda function to snap min/max X and Y coordinates over the
+    # DEM grid
+    snap_coord = \
+        lambda val, snap, offset, round_func: round_func(
+            float(val - offset) / snap) * snap + offset
+
+    # Snap edge coordinates using the DEM pixel spacing
+    # (xres and yres) and starting coordinates (input_x_min and
+    # input_x_max). Maximum values are rounded using np.ceil
+    # and minimum values are rounded using np.floor
+    x_min = snap_coord(x_min, xres, input_x_min, np.floor)
+    x_max = snap_coord(x_max, xres, input_x_min, np.ceil)
+    y_min = snap_coord(y_min, yres, input_y_max, np.floor)
+    y_max = snap_coord(y_max, yres, input_y_max, np.ceil)
+
+    input_y_min = input_y_max + length * yres
+    input_x_max = input_x_min + width * xres
 
     x_min = max(x_min, input_x_min)
     x_max = min(x_max, input_x_max)


### PR DESCRIPTION
This PR updates the cropping coordinates that are passed to GDAL translate to crop the DEM and avoid the removal of the last pixel of the dataset (DEM). 

This update is relevant to the antimeridian crossing case, in which the last (east-most) DEM pixels will be located in the middle of the staged DEM as longitude coordinates are usually wrapped around +/- 180.

GDAL translate snaps `projWin` coordinates to the map grid of the input dataset. 

~* We add `0.4` to the maximum length and width to make sure that GDAL Translate will not round down the ending coordinates and remove the last pixel in X or Y directions. The value `0.4` less than `0.5` to avoid that GDAL translate adds an extra pixel to the input extents. *~

UPDATE: We snap the minimum and maximum coordinates using the DEM grid. This is done using a lambda function called `snap_coord` and the snap value from the DEM pixel sizes `xres` and `yres` and offset from the starting coordinates `input_x_min` and `input_y_max`.