### PR TITLE
Issue 604: fix(grq): re-set number of shards previously set by the base ES templ…

### DIFF
--- a/conf/sds/files/elasticsearch/es_template_hls_catalog.json
+++ b/conf/sds/files/elasticsearch/es_template_hls_catalog.json
@@ -6,7 +6,8 @@
         "sort.field": "creation_timestamp",
         "sort.order": "asc"
       },
-      "index.lifecycle.name": "opera_grq_ilm_policy"
+      "index.lifecycle.name": "opera_grq_ilm_policy",
+      "number_of_shards": 8
     },
     "mappings": {
       "properties": {

--- a/conf/sds/files/elasticsearch/es_template_hls_spatial_catalog.json
+++ b/conf/sds/files/elasticsearch/es_template_hls_spatial_catalog.json
@@ -2,7 +2,8 @@
   "index_patterns": ["hls_spatial_catalog", "hls_spatial_catalog-*"],
   "template": {
     "settings": {
-      "index.lifecycle.name": "opera_grq_ilm_policy"
+      "index.lifecycle.name": "opera_grq_ilm_policy",
+      "number_of_shards": 8
     },
     "mappings": {
       "properties": {

--- a/conf/sds/files/elasticsearch/es_template_jobs_accountability_catalog.json
+++ b/conf/sds/files/elasticsearch/es_template_jobs_accountability_catalog.json
@@ -2,7 +2,8 @@
   "index_patterns": ["jobs_accountability_catalog", "jobs_accountability_catalog-*"],
   "template": {
     "settings": {
-      "index.lifecycle.name": "opera_grq_ilm_policy"
+      "index.lifecycle.name": "opera_grq_ilm_policy",
+      "number_of_shards": 8
     },
     "mappings": {
       "properties": {

--- a/conf/sds/files/elasticsearch/es_template_slc_catalog.json
+++ b/conf/sds/files/elasticsearch/es_template_slc_catalog.json
@@ -6,7 +6,8 @@
         "sort.field": "creation_timestamp",
         "sort.order": "asc"
       },
-      "index.lifecycle.name": "opera_grq_ilm_policy"
+      "index.lifecycle.name": "opera_grq_ilm_policy",
+      "number_of_shards": 8
     },
     "mappings": {
       "properties": {

--- a/conf/sds/files/elasticsearch/es_template_slc_spatial_catalog.json
+++ b/conf/sds/files/elasticsearch/es_template_slc_spatial_catalog.json
@@ -2,7 +2,8 @@
   "index_patterns": ["slc_spatial_catalog", "slc_spatial_catalog-*"],
   "template": {
     "settings": {
-      "index.lifecycle.name": "opera_grq_ilm_policy"
+      "index.lifecycle.name": "opera_grq_ilm_policy",
+      "number_of_shards": 8
     },
     "mappings": {
       "properties": {


### PR DESCRIPTION
…ate.

The base template is not inherited anymore. So explicitly set the same value it defines for number_of_shards: 8.

Refs #604

## Purpose
- to fix the number of shards per index to be consistent
## Proposed Changes
- [CHANGE] Elasticsearch index template to define number_of_shards setting
## Issues
- Example: issue-604
## Testing
- Compared with base index template
