### PR TITLE
Issue 500 batch id 1

### DIFF
--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -80,11 +80,7 @@ class DaacDownload:
         if args.batch_ids and len(args.batch_ids) == 1:
             one_granule = args.batch_ids[0]
             logger.info(f"Downloading files for the granule {one_granule}")
-
-            result = es_conn.es.query(index=es_conn.ES_INDEX_PATTERNS,
-                                  body={"query": {"bool": {"must": [{"match": {"id": one_granule}}]}}})
-
-            downloads = es_conn.filter_query_result(result)
+            downloads = es_conn.get_download_granule_revision(one_granule)
 
         else:
             download_timerange = self.get_download_timerange(args)

--- a/data_subscriber/hls/hls_catalog.py
+++ b/data_subscriber/hls/hls_catalog.py
@@ -31,13 +31,20 @@ class HLSProductCatalog:
     def generate_es_index_name(self):
         return "hls_catalog-{date}".format(date=datetime.utcnow().strftime("%Y.%m"))
 
-    def get_all_between(self, start_dt: datetime, end_dt: datetime, use_temporal: bool):
-        hls_catalog = self._query_catalog(start_dt, end_dt, use_temporal)
+    def filter_query_result(self, query_result):
         return [{"_id": catalog_entry["_id"], "granule_id": catalog_entry["_source"].get("granule_id"),
                  "revision_id": catalog_entry["_source"].get("revision_id"),
                  "s3_url": catalog_entry["_source"].get("s3_url"),
                  "https_url": catalog_entry["_source"].get("https_url")}
-                for catalog_entry in (hls_catalog or [])]
+                for catalog_entry in (query_result or [])]
+    def get_download_by_id(self, id):
+        downloads = self.es.query(index=self.ES_INDEX_PATTERNS,
+                                  body={"query": {"bool": {"must": [{"match": {"id": id}}]}}})
+        return self.filter_query_result(downloads)
+
+    def get_all_between(self, start_dt: datetime, end_dt: datetime, use_temporal: bool):
+        downloads = self._query_catalog(start_dt, end_dt, use_temporal)
+        return self.filter_query_result(downloads)
 
     def process_url(
             self,

--- a/data_subscriber/hls/hls_catalog.py
+++ b/data_subscriber/hls/hls_catalog.py
@@ -37,9 +37,16 @@ class HLSProductCatalog:
                  "s3_url": catalog_entry["_source"].get("s3_url"),
                  "https_url": catalog_entry["_source"].get("https_url")}
                 for catalog_entry in (query_result or [])]
-    def get_download_by_id(self, id):
+
+    def granule_and_revision(self, es_id):
+        '''For HLS.S30.T56MPU.2022152T000741.v2.0-r1 returns:
+        HLS.S30.T56MPU.2022152T000741.v2.0 and 1 '''
+        return es_id.split('-')[0], es_id.split('-r')[1]
+    def get_download_granule_revision(self, id):
+        granule, revision = self.granule_and_revision(id)
         downloads = self.es.query(index=self.ES_INDEX_PATTERNS,
-                                  body={"query": {"bool": {"must": [{"match": {"id": id}}]}}})
+                                  body={"query": {"bool": {"must": [{"match": {"granule_id": granule}},
+                                                                    {"term": {"revision_id": revision}}]}}})
         return self.filter_query_result(downloads)
 
     def get_all_between(self, start_dt: datetime, end_dt: datetime, use_temporal: bool):

--- a/data_subscriber/slc/slc_catalog.py
+++ b/data_subscriber/slc/slc_catalog.py
@@ -27,14 +27,8 @@ class SLCProductCatalog(HLSProductCatalog):
         super().__init__(logger=logger)
         self.ES_INDEX_PATTERNS = "slc_catalog*"
 
-    def get_all_between(self, start_dt: datetime, end_dt: datetime, use_temporal: bool):
-        undownloaded = self._query_catalog(start_dt, end_dt, use_temporal)
-
-        return [result['_source'] for result in (undownloaded or [])]
-
     def generate_es_index_name(self):
         return "slc_catalog-{date}".format(date=datetime.utcnow().strftime("%Y.%m"))
 
-    def get_all_between(self, start_dt: datetime, end_dt: datetime, use_temporal: bool):
-        undownloaded = self._query_catalog(start_dt, end_dt, use_temporal)
-        return [result['_source'] for result in (undownloaded or [])]
+    def filter_query_result(self, query_result):
+        return [result['_source'] for result in (query_result or [])]

--- a/data_subscriber/slc/slc_catalog.py
+++ b/data_subscriber/slc/slc_catalog.py
@@ -26,6 +26,10 @@ class SLCProductCatalog(HLSProductCatalog):
     def __init__(self, /, logger=None):
         super().__init__(logger=logger)
         self.ES_INDEX_PATTERNS = "slc_catalog*"
+    def granule_and_revision(self, es_id):
+        '''For S1A_IW_SLC__1SDV_20220601T000522_20220601T000549_043462_05308F_86F3.zip-r5 returns:
+                S1A_IW_SLC__1SDV_20220601T000522_20220601T000549_043462_05308F_86F3-SLC and 5 '''
+        return es_id.split('.zip')[0]+'-SLC', es_id.split('-r')[1]
 
     def generate_es_index_name(self):
         return "slc_catalog-{date}".format(date=datetime.utcnow().strftime("%Y.%m"))


### PR DESCRIPTION
## Purpose
- When downloading just one granule by native-id, this changes makes it much for efficient
## Proposed Changes
- [CHANGE] In download code 
## Issues
- https://github.com/nasa/opera-sds-pcm/issues/500
## Testing
- Tested both HLS and SLC download and SCIFLO execution for both native-id and traditional date range queries. All passed.
