### PR TITLE
issue 617: chore(terraform): update python runtime for harikiri lambda

### DIFF
--- a/cluster_provisioning/modules/common/main.tf
+++ b/cluster_provisioning/modules/common/main.tf
@@ -326,7 +326,7 @@ resource "aws_lambda_function" "harikiri_lambda" {
   function_name = "${var.project}-${var.venue}-${local.counter}-harikiri-autoscaling"
   role          = var.lambda_role_arn
   handler       = "lambda_function.lambda_handler"
-  runtime       = "python3.7"
+  runtime       = "python3.8"
   timeout       = 600
 }
 


### PR DESCRIPTION
update runtime ahead of deprecation scheduled for 1/2024 by AWS

## Purpose
- update runtime ahead of deprecation. 
## Proposed Changes
- [CHANGE] runtime used by harikiri lambda
## Issues
- issue-617
## Testing
- tested on int environment
