### PR TITLE
Orbit script query range fix

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -89,10 +89,10 @@ RTC_S1:
   ANCILLARY_MARGIN: 100
   # Estimated geometric accuracy values needed for CEOS compliance
   ESTIMATED_GEOMETRIC_ACCURACY:
-    BIAS_X: -72.0
-    BIAS_Y: -67.0
-    STDDEV_X: 70.0
-    STDDEV_Y: 62.0
+    BIAS_X: -0.72
+    BIAS_Y: -0.67
+    STDDEV_X: 0.70
+    STDDEV_Y: 0.62
 
 # End PGE Configuration section
 

--- a/tests/tools/test_stage_orbit_file.py
+++ b/tests/tools/test_stage_orbit_file.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 import unittest
+from datetime import datetime
+
 import tools.stage_orbit_file
 from tools.stage_orbit_file import (ORBIT_TYPE_POE,
                                     ORBIT_TYPE_RES,
@@ -249,3 +251,130 @@ class TestStageOrbitFile(unittest.TestCase):
 
         self.assertIn('No suitable orbit file could be found within the results of the query',
                       str(err.exception))
+
+    def test_select_orbit_file(self):
+        """Tests for the select_orbit_file() function"""
+        # Sample XML response derived from query on SLC granule
+        # S1A_IW_SLC__1SDV_20230825T185042_20230825T185110_050036_060529_C8A2
+        # for type RESORB and a query window length of 4 hours on each side of
+        # the SLC start time
+        xml_response = """<?xml version="1.0" encoding="utf-8"?>
+        <feed xmlns="http://www.w3.org/2005/Atom" xmlns:opensearch="http://a9.com/-/spec/opensearch/1.1/">
+        <title>Sentinels GNSS RINEX Hub search results for: ( beginPosition:[2023-08-25T14:50:42.000000Z TO 2023-08-25T22:51:10.000000Z] AND endPosition:[2023-08-25T14:50:42.000000Z TO 2023-08-25T22:51:10.000000Z] ) AND ( (platformname:Sentinel-1 AND filename:S1A_* AND producttype:AUX_RESORB))</title>
+        <subtitle>Displaying 3 results. Request done in 0.002 seconds.</subtitle>
+        <updated>2023-09-25T17:50:53.549Z</updated>
+        <author>
+        <name>Sentinels GNSS RINEX Hub</name>
+        </author>
+        <id>https://scihub.copernicus.eu/gnss/search?q=( beginPosition:[2023-08-25T14:50:42.000000Z TO 2023-08-25T22:51:10.000000Z] AND endPosition:[2023-08-25T14:50:42.000000Z TO 2023-08-25T22:51:10.000000Z] ) AND ( (platformname:Sentinel-1 AND filename:S1A_* AND producttype:AUX_RESORB))</id>
+        <opensearch:totalResults>3</opensearch:totalResults>
+        <opensearch:startIndex>0</opensearch:startIndex>
+        <opensearch:itemsPerPage>10</opensearch:itemsPerPage>
+        <entry>
+        <title>S1A_OPER_AUX_RESORB_OPOD_20230825T223851_V20230825T185010_20230825T220740</title>
+        <id>5ae6bb3b-0f19-41c0-ba1e-28988ed93842</id>
+        <str name="format">EOF</str>
+        <str name="size">577.01 KB</str>
+        <str name="platformname">Sentinel-1</str>
+        <str name="platformshortname">S1</str>
+        <str name="platformnumber">A</str>
+        <str name="platformserialidentifier">1A</str>
+        <str name="filename">S1A_OPER_AUX_RESORB_OPOD_20230825T223851_V20230825T185010_20230825T220740.EOF</str>
+        <str name="producttype">AUX_RESORB</str>
+        <str name="filedescription">NRT POD Restituted Orbit File</str>
+        <str name="fileclass">OPER</str>
+        <str name="creator">OPOD</str>
+        <str name="creatorversion">3.4.0</str>
+        <str name="identifier">S1A_OPER_AUX_RESORB_OPOD_20230825T223851_V20230825T185010_20230825T220740</str>
+        <str name="uuid">5ae6bb3b-0f19-41c0-ba1e-28988ed93842</str>
+        </entry>
+        <entry>
+        <title>S1A_OPER_AUX_RESORB_OPOD_20230825T205555_V20230825T171126_20230825T202856</title>
+        <id>b36a07ec-fc8a-444d-9270-dfd2b9463200</id>
+        <str name="format">EOF</str>
+        <str name="size">576.65 KB</str>
+        <str name="platformname">Sentinel-1</str>
+        <str name="platformshortname">S1</str>
+        <str name="platformnumber">A</str>
+        <str name="platformserialidentifier">1A</str>
+        <str name="filename">S1A_OPER_AUX_RESORB_OPOD_20230825T205555_V20230825T171126_20230825T202856.EOF</str>
+        <str name="producttype">AUX_RESORB</str>
+        <str name="filedescription">NRT POD Restituted Orbit File</str>
+        <str name="fileclass">OPER</str>
+        <str name="creator">OPOD</str>
+        <str name="creatorversion">3.4.0</str>
+        <str name="identifier">S1A_OPER_AUX_RESORB_OPOD_20230825T205555_V20230825T171126_20230825T202856</str>
+        <str name="uuid">b36a07ec-fc8a-444d-9270-dfd2b9463200</str>
+        </entry>
+        <entry>
+        <title>S1A_OPER_AUX_RESORB_OPOD_20230825T190955_V20230825T153241_20230825T185011</title>
+        <id>6c264b9c-6646-4e3d-92d6-862ef96ee2e8</id>
+        <str name="format">EOF</str>
+        <str name="size">576.61 KB</str>
+        <str name="platformname">Sentinel-1</str>
+        <str name="platformshortname">S1</str>
+        <str name="platformnumber">A</str>
+        <str name="platformserialidentifier">1A</str>
+        <str name="filename">S1A_OPER_AUX_RESORB_OPOD_20230825T190955_V20230825T153241_20230825T185011.EOF</str>
+        <str name="producttype">AUX_RESORB</str>
+        <str name="filedescription">NRT POD Restituted Orbit File</str>
+        <str name="fileclass">OPER</str>
+        <str name="creator">OPOD</str>
+        <str name="creatorversion">3.4.0</str>
+        <str name="identifier">S1A_OPER_AUX_RESORB_OPOD_20230825T190955_V20230825T153241_20230825T185011</str>
+        <str name="uuid">6c264b9c-6646-4e3d-92d6-862ef96ee2e8</str>
+        </entry>
+        </feed>
+        """
+
+        input_granule = "S1A_IW_SLC__1SDV_20230825T185042_20230825T185110_050036_060529_C8A2"
+
+        (mission_id,
+         safe_start_time,
+         safe_stop_time) = tools.stage_orbit_file.parse_orbit_time_range_from_safe(input_granule)
+
+        entry_elems, namespace_map = tools.stage_orbit_file.parse_orbit_file_query_xml(xml_response)
+
+        # Start with the default time range for finding a single RESORB file:
+        # [sensing_start - T_orbit - 1 min, sensing_end + 1 min]
+        sensing_start_range = datetime.strptime("20230825T171057", "%Y%m%dT%H%M%S")
+        sensing_stop_range =  datetime.strptime("20230825T185210", "%Y%m%dT%H%M%S")
+
+        # This should result in no suitable orbit file selected
+        with self.assertRaises(NoSuitableOrbitFileException):
+            tools.stage_orbit_file.select_orbit_file(
+                entry_elems, namespace_map, safe_start_time, safe_stop_time,
+                sensing_start_range, sensing_stop_range
+            )
+
+        # Now use the two ranges used to find consecutive RESORB files that
+        # the SAS will concatenate together
+        # The first range is [sensing_start - 1 min, sensing_end + 1 min]
+        sensing_start_range = datetime.strptime("20230825T184942", "%Y%m%dT%H%M%S")
+        sensing_stop_range = datetime.strptime("20230825T185210", "%Y%m%dT%H%M%S")
+
+        orbit_file_name, orbit_file_request_id = tools.stage_orbit_file.select_orbit_file(
+            entry_elems, namespace_map, safe_start_time, safe_stop_time,
+            sensing_start_range, sensing_stop_range
+        )
+
+        expected_orbit_file = "S1A_OPER_AUX_RESORB_OPOD_20230825T205555_V20230825T171126_20230825T202856.EOF"
+        expected_orbit_file_request_id = "b36a07ec-fc8a-444d-9270-dfd2b9463200"
+
+        self.assertEqual(orbit_file_name, expected_orbit_file)
+        self.assertEqual(orbit_file_request_id, expected_orbit_file_request_id)
+
+        # The second range is [sensing_start – T_orb – 1 min, sensing_start – T_orb + 1 min]
+        sensing_start_range = datetime.strptime("20230825T171057", "%Y%m%dT%H%M%S")
+        sensing_stop_range = datetime.strptime("20230825T171257", "%Y%m%dT%H%M%S")
+
+        orbit_file_name, orbit_file_request_id = tools.stage_orbit_file.select_orbit_file(
+            entry_elems, namespace_map, safe_start_time, safe_stop_time,
+            sensing_start_range, sensing_stop_range
+        )
+
+        expected_orbit_file = "S1A_OPER_AUX_RESORB_OPOD_20230825T190955_V20230825T153241_20230825T185011.EOF"
+        expected_orbit_file_request_id = "6c264b9c-6646-4e3d-92d6-862ef96ee2e8"
+
+        self.assertEqual(orbit_file_name, expected_orbit_file)
+        self.assertEqual(orbit_file_request_id, expected_orbit_file_request_id)

--- a/tests/tools/test_stage_orbit_file.py
+++ b/tests/tools/test_stage_orbit_file.py
@@ -64,8 +64,8 @@ class TestStageOrbitFile(unittest.TestCase):
 
         # Check that all portions of the query were constructed with the inputs
         # as expected
-        self.assertIn("beginPosition:[2022-04-30T00:00:00.000000Z TO 2022-05-01T00:00:00.000000Z]", query)
-        self.assertIn("endPosition:[2022-05-01T00:00:00.000000Z TO 2022-05-02T00:00:30.000000Z]", query)
+        self.assertIn("beginPosition:[2022-04-30T00:00:00.000000Z TO 2022-05-02T00:00:30.000000Z]", query)
+        self.assertIn("endPosition:[2022-04-30T00:00:00.000000Z TO 2022-05-02T00:00:30.000000Z]", query)
         self.assertIn("platformname:Sentinel-1", query)
         self.assertIn("filename:S1A_*", query)
         self.assertIn("producttype:AUX_POEORB", query)
@@ -77,8 +77,8 @@ class TestStageOrbitFile(unittest.TestCase):
             mission_id, orbit_type, safe_start_time, safe_stop_time
         )
 
-        self.assertIn("beginPosition:[2022-04-30T21:00:00.000000Z TO 2022-05-01T00:00:00.000000Z]", query)
-        self.assertIn("endPosition:[2022-05-01T00:00:00.000000Z TO 2022-05-01T03:00:30.000000Z]", query)
+        self.assertIn("beginPosition:[2022-04-30T21:00:00.000000Z TO 2022-05-01T03:00:30.000000Z]", query)
+        self.assertIn("endPosition:[2022-04-30T21:00:00.000000Z TO 2022-05-01T03:00:30.000000Z]", query)
         self.assertIn("platformname:Sentinel-1", query)
         self.assertIn("filename:S1A_*", query)
         self.assertIn("producttype:AUX_RESORB", query)

--- a/tools/stage_orbit_file.py
+++ b/tools/stage_orbit_file.py
@@ -282,22 +282,16 @@ def construct_orbit_file_query(mission_id, orbit_type, safe_start_time, safe_sto
         "( (platformname:Sentinel-1 AND filename:{mission_id}_* AND producttype:AUX_{orbit_type}))"
     )
 
-    # Format the query templates using the values we were provided
-    query_start_range = time_range_template.format(
+    # Format the query template using the values we were provided
+    query_range = time_range_template.format(
         start_date=query_start_date.strftime("%Y-%m-%dT%H:%M:%S.%f"),
-        stop_date=safe_start_date.strftime("%Y-%m-%dT%H:%M:%S.%f")
-    )
-
-    query_stop_range = time_range_template.format(
-        start_date=safe_start_date.strftime("%Y-%m-%dT%H:%M:%S.%f"),
         stop_date=query_stop_date.strftime("%Y-%m-%dT%H:%M:%S.%f")
     )
 
-    logger.debug(f'query_start_range: {query_start_range}')
-    logger.debug(f'query_stop_range: {query_stop_range}')
+    logger.debug(f'query_range: {query_range}')
 
-    query = query_template.format(start_range=query_start_range,
-                                  stop_range=query_stop_range,
+    query = query_template.format(start_range=query_range,
+                                  stop_range=query_range,
                                   mission_id=mission_id,
                                   orbit_type=orbit_type)
 


### PR DESCRIPTION
## Purpose
- This branch addresses an issue in the stage_orbit_file.py script where the initial query time range was set up incorrectly, leading to potential orbit file candidates being missed.
- This branch also corrects the estimated geometric accuracy values defined in settings.yaml
## Issues
- Fixes #620 
- Fixes #621 
## Testing
- The fix to stage_orbit_file.py was tested with the following SLC granules that require concatenated RESORB files:
```
  S1A_IW_SLC__1SDV_20230823T154843_20230823T154910_050004_060418_D30E.zip
  S1A_IW_SLC__1SDV_20230823T154908_20230823T154935_050004_060418_521B.zip
  S1A_IW_SLC__1SDV_20230823T154933_20230823T155000_050005_060418_42A5.zip
  S1A_IW_SLC__1SDV_20230823T154958_20230823T155034_050005_060418_8D51.zip
  S1A_IW_SLC__1SDV_20230823T172819_20230823T172849_050006_060423_EEC4.zip
  S1A_IW_SLC__1SDV_20230823T172846_20230823T172914_050006_060423_0024.zip
  S1A_IW_SLC__1SDV_20230823T190658_20230823T190728_050007_060430_EBCA.zip
  S1A_IW_SLC__1SDV_20230823T190725_20230823T190753_050007_060430_CAA4.zip
  S1A_IW_SLC__1SDV_20230825T171155_20230825T171224_050035_060520_103F.zip
  S1A_IW_SLC__1SDV_20230825T171222_20230825T171250_050035_060520_6E64.zip
  S1A_IW_SLC__1SDV_20230825T185014_20230825T185044_050035_060529_D666.zip
  S1A_IW_SLC__1SDV_20230825T185042_20230825T185110_050036_060529_C8A2.zip
  S1A_IW_SLC__1SDV_20230825T185108_20230825T185135_050036_060529_5BB4.zip
```
In all cases, the expected RESORB files were both downloaded, and the subsequent RTC-S1 jobs ran to completion.

Note however, that for these granules the Precise orbit file (POEORB) is now available, which means the multiple RESORB selection logic will not be run unless the POEORB query is explicitly disabled.
