### PR TITLE
RTC-S1 PGE v2.0.1 integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -384,7 +384,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -456,7 +456,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -382,7 +382,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -174,7 +174,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -380,7 +380,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -383,7 +383,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -32,7 +32,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.2"
     "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.0"
+    "rtc_s1" = "2.0.1"
   }
 }
 

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.0.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.0.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
## Purpose
- This branch integrates v2.0.1 of the RTC-S1 PGE into PCM. This version incorporates the v1.0.1 point delivery of the RTC-S1 SAS to correct some metadata fields in the GeoTIFF

## Issues
- Resolves #623 

## Testing
- This branch was tested in a dev cluster configured to run only RTC-S1 PGE baseline workflow (not static layers). The granule used was S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC. Individual output products were inspected to ensure metadata fields such as static layer access URL and the estimated geometric accuracy values were set correctly.
