### PR TITLE
R2 PGE v2.1.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -388,8 +388,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -460,8 +460,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -386,8 +386,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -173,8 +173,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -384,8 +384,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -387,8 +387,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,8 +31,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.0.0"
-    "rtc_s1" = "2.0.1"
+    "cslc_s1" = "2.1.0"
+    "rtc_s1" = "2.1.0"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -452,8 +452,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1"  = "2.0.0"
-    "rtc_s1"   = "2.0.1"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
   }
 }
 

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -44,9 +44,9 @@ L2_CSLC_S1_STATIC:
   Outputs:
     Primary:
       # Pattern for parsing primary (per-burst) output filenames, such as:
-      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_20230807T234233Z_S1A_v1.0.h5
-      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_20230807T234233Z_S1A_v1.0_BROWSE.h5
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_S1A_v1.0.h5
+      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_S1A_v1.0_BROWSE.h5
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<sensor>S1A|S1B)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:
@@ -86,9 +86,9 @@ L2_RTC_S1_STATIC:
   Outputs:
     Primary:
       # Pattern for parsing primary (per-burst) output filenames, such as:
-      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0.h5
-      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0_incidence_angle.tif
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0.h5
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0_incidence_angle.tif
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_STATIC",
       "level": "L2",
       "type": "L2_CSLC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -316,7 +316,7 @@
       "ipath": "hysds::data/L2_RTC_S1_STATIC",
       "level": "L2",
       "type": "L2_RTC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_STATIC",
       "level": "L2",
       "type": "L2_CSLC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -316,7 +316,7 @@
       "ipath": "hysds::data/L2_RTC_S1_STATIC",
       "level": "L2",
       "type": "L2_RTC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -301,6 +301,6 @@ PRODUCT_TYPES:
 
 # Settings to enable forceful ingest of PGE outputs (a.k.a disable no-clobber errors)
 # These settings only take effect on those PGE jobs that produce datasets that get
-# pushed to object storage.
+# pushed to object storage (this should not include input product download jobs).
 FORCE_INGEST:
-    INGEST_STAGED: !!bool false
+    INGEST_STAGED: !!bool true

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -218,14 +218,14 @@ PRODUCT_TYPES:
 
     L2_CSLC_S1_STATIC:
       # Pattern for parsing output L2_CSLC-S1 static layer product filenames, such as:
-      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_20230807T234233Z_S1A_v1.0.h5
+      # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_S1A_v1.0.h5
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5|iso\.xml)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<sensor>S1A|S1B)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5|iso\.xml)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
       Configuration:
-        Date_Time_Patterns: [ '%Y%m%d', '%Y%m%dT%H%M%SZ' ]
-        Date_Time_Keys: [ 'validity_ts', 'creation_ts' ]
+        Date_Time_Patterns: [ '%Y%m%d' ]
+        Date_Time_Keys: [ 'validity_ts' ]
         # Specify the metadata key to use as the dataset version.
         #  Note: this affects the data product index name
         Dataset_Version_Key: 'product_version'
@@ -251,16 +251,16 @@ PRODUCT_TYPES:
 
     L2_RTC_S1_STATIC:
       # Pattern for parsing output L2_RTC-S1 static layer product filenames, such as:
-      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0.h5
-      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0_incidence_angle.tif
-      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_20230807T162755Z_S1B_30_v1.0_number_of_looks.tif
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0.h5
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0_incidence_angle.tif
+      # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0_number_of_looks.tif
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
       Configuration:
-        Date_Time_Patterns: [ '%Y%m%d', '%Y%m%dT%H%M%SZ' ]
-        Date_Time_Keys: [ 'validity_ts', 'creation_ts' ]
+        Date_Time_Patterns: [ '%Y%m%d' ]
+        Date_Time_Keys: [ 'validity_ts' ]
         # Specify the metadata key to use as the dataset version.
         #  Note: this affects the data product index name
         Dataset_Version_Key: 'product_version'

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.0.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.1.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.0.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.0.1.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
@@ -102,5 +102,5 @@ localize_groups:
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
     - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
-output_base_name: OPERA_L2_CSLC-S1-STATIC_{burst_id}_{validity_ts}_{creation_ts}Z_{sensor}_{product_version}
+output_base_name: OPERA_L2_CSLC-S1-STATIC_{burst_id}_{validity_ts}_{sensor}_{product_version}
 ancillary_base_name: OPERA_L2_CSLC-S1_{creation_ts}Z_{sensor}_{pol}_{product_version}

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
@@ -109,5 +109,5 @@ localize_groups:
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
     - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
-output_base_name: OPERA_L2_RTC-S1-STATIC_{burst_id}_{validity_ts}_{creation_ts}Z_{sensor}_30_{product_version}
+output_base_name: OPERA_L2_RTC-S1-STATIC_{burst_id}_{validity_ts}_{sensor}_30_{product_version}
 ancillary_base_name: OPERA_L2_RTC-S1_{creation_ts}Z_{sensor}_30_{product_version}

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -6,6 +6,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     FORCE_INGEST = "FORCE_INGEST"
 
+    INGEST_STAGED = "INGEST_STAGED"
+
     CNM_VERSION = "CNM_VERSION"
 
     PROCESSING_MODE_KEY = "processing_mode"

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from commons.logger import logger
 from chimera.pge_job_submitter import PgeJobSubmitter
 from opera_chimera.constants.opera_chimera_const import (
-    OperaChimeraConstants as nc_const,
+    OperaChimeraConstants as oc_const,
 )
 
 from wrapper.opera_pge_wrapper import run_pipeline
@@ -124,6 +124,7 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
                 with open(os.path.join(self._base_work_dir, "pge_metrics.json"), "r") as f:
                     old_pge_metrics = json.load(f)
                 pge_metrics.update(old_pge_metrics)
+
             # pge_metrics.json is already created in get_dems() in precondition_function.py
             with open(os.path.join(self._base_work_dir, "pge_metrics.json"), "w") as f:
                 json.dump(pge_metrics, f, indent=2)
@@ -132,20 +133,11 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
             self._context["_triage_additional_globs"] = ["output", "RunConfig.yaml", "pge_output_dir"]
 
             # set force publish (disable no-clobber)
-            if not (
-                match := re.search(
-                    r"^job-(.+):.+$", self._context["job_specification"]["id"]
-                )
-            ):
-                raise RuntimeError(
-                    "Failed to extract job type from job specification ID: "
-                    "{}".format(self._context["job_specification"]["id"])
-                )
-            job_type = match.group(1)
-            force_publish = self._settings.get(nc_const.FORCE_INGEST, {}).get(
-                job_type, False
+            force_publish = self._settings.get(oc_const.FORCE_INGEST, {}).get(
+                oc_const.INGEST_STAGED, False
             )
             if force_publish:
+                logger.info("Disabling no-clobber errors")
                 self._context["_force_ingest"] = True
 
             # sync updates to context JSON file
@@ -180,7 +172,7 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
             pge_info = {}
             with open(self._base_work_dir + "/_pid", "r+") as pid:
                 pid = int(pid.read())
-            if self._settings.get(nc_const.PGE_SIM_MODE, True):
+            if self._settings.get(oc_const.PGE_SIM_MODE, True):
                 pge_info = {
                     "time_start": datetime.utcnow().strftime(ISO_DATETIME_PATTERN)
                     + "Z",

--- a/tests/util/test_pge_util.py
+++ b/tests/util/test_pge_util.py
@@ -83,13 +83,13 @@ def test_simulate_cslc_s1_static_pge():
         output_dir='/tmp'
     )
 
-    expected_static_output_basename = 'OPERA_L2_CSLC-S1-STATIC_{burst_id}_20140403_{creation_ts}Z_S1A_v0.1'
+    expected_static_output_basename = 'OPERA_L2_CSLC-S1-STATIC_{burst_id}_20140403_S1A_v0.1'
     expected_ancillary_basename = 'OPERA_L2_CSLC-S1_{creation_ts}Z_S1A_VV_v0.1'
     creation_ts = pge_util.get_time_for_filename()
 
     try:
         for burst_id in pge_util.CSLC_BURST_IDS:
-            static_output_basename = expected_static_output_basename.format(burst_id=burst_id, creation_ts=creation_ts)
+            static_output_basename = expected_static_output_basename.format(burst_id=burst_id)
 
             assert Path(f'/tmp/{static_output_basename}.h5').exists()
             assert Path(f'/tmp/{static_output_basename}.iso.xml').exists()
@@ -177,13 +177,13 @@ def test_simulate_rtc_s1_static_pge():
         output_dir='/tmp'
     )
 
-    expected_static_output_basename = 'OPERA_L2_RTC-S1-STATIC_{burst_id}_20140403_{creation_ts}Z_S1B_30_v0.1'
+    expected_static_output_basename = 'OPERA_L2_RTC-S1-STATIC_{burst_id}_20140403_S1B_30_v0.1'
     expected_ancillary_basename = 'OPERA_L2_RTC-S1_{creation_ts}Z_S1B_30_v0.1'
     creation_ts = pge_util.get_time_for_filename()
 
     try:
         for burst_id in pge_util.RTC_BURST_IDS:
-            static_output_basename = expected_static_output_basename.format(burst_id=burst_id, creation_ts=creation_ts)
+            static_output_basename = expected_static_output_basename.format(burst_id=burst_id)
 
             assert Path(f'/tmp/{static_output_basename}.h5').exists()
             assert Path(f'/tmp/{static_output_basename}_BROWSE.png').exists()

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -198,7 +198,6 @@ def get_cslc_s1_static_simulated_output_filenames(dataset_match, pge_config, ext
             static_base_name = base_name_template.format(
                 burst_id=burst_id,
                 validity_ts='20140403',
-                creation_ts=creation_time,
                 sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
             )
@@ -289,7 +288,6 @@ def get_rtc_s1_static_simulated_output_filenames(dataset_match, pge_config, exte
             static_base_name = base_name_template.format(
                 burst_id=burst_id,
                 validity_ts='20140403',
-                creation_ts=creation_time,
                 sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
             )
@@ -306,7 +304,6 @@ def get_rtc_s1_static_simulated_output_filenames(dataset_match, pge_config, exte
             static_base_name = base_name_template.format(
                 burst_id=burst_id,
                 validity_ts='20140403',
-                creation_ts=creation_time,
                 sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
             )
@@ -317,7 +314,6 @@ def get_rtc_s1_static_simulated_output_filenames(dataset_match, pge_config, exte
             static_base_name = base_name_template.format(
                 burst_id=burst_id,
                 validity_ts='20140403',
-                creation_ts=creation_time,
                 sensor=dataset_match.groupdict()['mission_id'],
                 product_version='v0.1',
             )

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -49,6 +49,11 @@ def main(job_json_file: str, workdir: str):
 
     # set additional files to triage
     jc.set('_triage_additional_globs', ["output", "RunConfig.yaml", "pge_output_dir"])
+
+    # Disable no-clobber errors for published files. Either the file naming conventions
+    # will guarantee uniqueness, or we want certain files to be overwritten to avoid
+    # redundant copies (such as static layer products)
+    jc.set('_force_ingest', True)
     jc.save()
 
     run_pipeline(job_json_dict=job_context, work_dir=workdir)


### PR DESCRIPTION
## Purpose
- This branch integrates v2.1.0 of the R2 PGEs into PCM. This version incorporates the CSLC-S1 v0.5.4 Final SAS delivery, and removes the production datetime from the filenames of output static layer products.
- Additionally, this branch fixes an issue where the `INGEST_STAGED` flag in settings.yaml did not actually affect the use of no-clobber errors when uploading PGE outputs. Since we want redundant static layer products to be overwritten in S3, the default for `INGEST_STAGED` is now set to `True`

## Issues
- Resolves #639 

## Testing
- Branch was tested with a dev cluster by submitting the following granule for ingest: S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC
- Both R2 PGEs were run with both workflows (baseline and static)
- After all jobs completed successfully, the static layer jobs were resubmitted to ensure that no-clobber errors were not raised.
