### PR TITLE
Enable parallelized localization/upload for PGE jobs

### DIFF
--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l2_cslc_s1"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l2_cslc_s1"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l2_cslc_s1_hist"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l2_cslc_s1_hist"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l2_rtc_s1"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l2_rtc_s1"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -19,7 +19,17 @@
     }
   ],
   "recommended-queues": [ "opera-job_worker-sciflo-l3_dswx_hls"],
-  "post": [ "hysds.triage.triage"],
+  "disable_pre_builtins": true,
+  "disable_post_builtins": true,
+  "pre": [
+    "hysds.localize.localize_urls_parallel",
+    "hysds.utils.mark_localized_datasets",
+    "hysds.utils.validate_checksum_files"
+  ],
+  "post": [
+    "hysds.dataset_ingest_bulk.publish_datasets_parallel",
+    "hysds.triage.triage"
+  ],
   "params": [
     {
       "name": "module_path",


### PR DESCRIPTION
## Purpose
- This branch modifies the job-spec files for all PGE/SCIFLO jobs to enable the Hysds pre- and post-processing functions to perform parallelized localization and upload to S3. This has shown to be a significant improvement in runtime when uploading products to rolling storage.

## Issues
- Resolves #645 

## Testing
- Branch was tested on a dev cluster using hysds-framework v5.0.0-rc.1
- All R2 PGEs (baseline and static layers) were triggered on the following granule: `S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC`
- After PGE completion, parallel upload to rolling storage was visually confirmed by watching the rolling storage bucket from the AWS console
