### PR TITLE
Removing blank defaults for some credentials

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -492,19 +492,15 @@ variable "artifactory_fn_user" {
 }
 
 variable "dataspace_user" {
-  default = ""
 }
 
 variable "dataspace_pass" {
-  default = ""
 }
 
 variable "earthdata_user" {
-  default = ""
 }
 
 variable "earthdata_pass" {
-  default = ""
 }
 
 # ami vars


### PR DESCRIPTION
## Purpose
- Remove blank default creds from variables.tf. These will let deployments success without necessary creds - and the system will fail while running. Better to catch these errors at deployment time.