### PR TITLE
Fix for Worldcover translation failure

### DIFF
--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -105,7 +105,7 @@ def determine_polygon(tile_code, bbox=None, margin_in_km=50):
     return poly
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=8, max_value=32)
+@backoff.on_exception(backoff.expo, Exception, max_time=600, max_value=32)
 def translate_dem(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     """
     Translate a DEM from S3 to a region matching the provided boundaries.

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -103,7 +103,7 @@ def determine_polygon(tile_code, bbox=None, margin_in_km=50):
     return poly
 
 
-@backoff.on_exception(backoff.expo, Exception, max_tries=8, max_value=32)
+@backoff.on_exception(backoff.expo, Exception, max_time=600, max_value=32)
 def translate_worldcover(vrt_filename, output_path, x_min, x_max, y_min, y_max):
     """
     Translate a Worldcover map from the esa-worldcover bucket.


### PR DESCRIPTION
## Purpose
- This branch addresses the crashes reported in #684, where the Worldcover ancillary input would fail to stage for specific MGRS tiles. The stage_worldcover.py script now catches such errors, and falls back to using an "unadjusted" projection window, which has been shown to not cause the failure when called with `gdal.Translate()`. This was done to ensure that we use the same staging logic for all DSWx-HLS jobs that had previously worked, and only use this new logic for the very few tiles that exhibit this behavior.
- This branch also attempts to address #685. The root cause of this bug was a transient outtage of S3 availability, so to mitigate going forward, the `backoff` decorators used in `stage_dem.py` and `stage_worldcover.py` have been adjusted to wait a maximum of 10 minutes before giving up. With the previous logic (max 8 retries, max 32 seconds between each retry), the wait time was less than half this.

## Issues
- Fixes #684 
- Addresses #685 

## Testing
- This branch was tested on a development cluster by submitting the following granules to kick off DSWx-HLS processing:
  - `HLS.S30.T15DXD.2023320T145229.v2.0` To test fix for #684 
  - `HLS.S30.T15DWD.2023320T145229.v2.0` To test fix for #684
  - `HLS.L30.T35SLA.2023317T085907.v2.0` To test that error in #685 was transient

In all cases DSWx-HLS processing completed successfully.
The cluster was also run in forward production mode for about 4 hours, during which time there were no failures.