### PR TITLE
DSWx-S1 ER5.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e-event-misfire/variables.tf
+++ b/cluster_provisioning/dev-e2e-event-misfire/variables.tf
@@ -388,10 +388,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e-pge/variables.tf
+++ b/cluster_provisioning/dev-e2e-pge/variables.tf
@@ -460,10 +460,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -386,10 +386,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -173,10 +173,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev-restore-snapshot/variables.tf
+++ b/cluster_provisioning/dev-restore-snapshot/variables.tf
@@ -384,10 +384,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -386,10 +386,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,10 +31,10 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1" = "2.1.0"
-    "rtc_s1" = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "cslc_s1"  = "2.1.0"
+    "rtc_s1"   = "2.1.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -469,8 +469,8 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.0"
     "rtc_s1"   = "2.1.0"
-    "dswx_s1" = "3.0.0-er.4.0"
-    "disp_s1" = "3.0.0-er.4.0"
+    "dswx_s1"  = "3.0.0-er.5.0"
+    "disp_s1"  = "3.0.0-er.4.0"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -323,7 +323,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_dswx_s1" = {
       "instance_type" = ["c5a.large", "c6a.large", "c6i.large"]
       "root_dev_size" = 50
-      "data_dev_size" = 50
+      "data_dev_size" = 100
       "min_size"      = 0
       "max_size"      = 10
       "total_jobs_metric" = true

--- a/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
@@ -21,14 +21,14 @@ RunConfig:
         ScratchPath: {{ data.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DSWX_S1
-        ProductVersion: {{ data.product_path_group.product_version }}
+        ProductVersion: "{{ data.product_path_group.product_version }}"
         ProgramPath: python3
         ProgramOptions:
-          - /home/conda/dswx-s1-0.1.0/src/dswx_sar/dswx_s1.py
+          - /home/dswx_user/OPERA/DSWX-SAR/src/dswx_sar/dswx_s1.py
         ErrorCodeBase: 400000
-        SchemaPath: /home/conda/opera/pge/dswx_s1/schema/dswx_s1_sas_schema.yaml
-        AlgorithmParametersSchemaPath: /home/conda/opera/pge/dswx_s1/schema/algorithm_parameters_s1_schema.yaml
-        IsoTemplatePath: /home/conda/opera/pge/dswx_s1/templates/OPERA_ISO_metadata_L3_DSWx_S1_template.xml.jinja2
+        SchemaPath: /home/dswx_user/opera/pge/dswx_s1/schema/dswx_s1_sas_schema.yaml
+        AlgorithmParametersSchemaPath: /home/dswx_user/opera/pge/dswx_s1/schema/algorithm_parameters_s1_schema.yaml
+        IsoTemplatePath: /home/dswx_user/opera/pge/dswx_s1/templates/OPERA_ISO_metadata_L3_DSWx_S1_template.xml.jinja2
       QAExecutable:
         Enabled: False
         ProgramPath:
@@ -57,11 +57,20 @@ RunConfig:
             {%- endfor %}
             algorithm_parameters: {{ data.processing.algorithm_parameters }}
             # TODO: update descriptions as necessary when new ancillary releases are available
-            dem_file_description: 'DEM'
-            worldcover_file_description: 'COPERNICUS WORLDCOVER 10m'
-            reference_water_file_description: 'PEKELs water'
-            hand_file_description: 'ASF HAND'
+            dem_file_description: 'Copernicus DEM GLO-30 2021 WGS84'
+            worldcover_file_description: 'ESA WorldCover 10m 2020 v1.0'
+            reference_water_file_description: 'JRC Global Surface Water - collection from 1984 to 2021'
+            hand_file_description: 'ASF HAND GLO30'
             shoreline_shapefile_description: 'NOAA GSHHS Level 1 resolution f - GSHHS_f_L1'
+          static_ancillary_file_group:
+            static_ancillary_inputs_flag: True
+            {%- for type in data.static_ancillary_file_group.keys() %}
+            {%- if data.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- else %}
+            {{ type }}:
+            {%- endif %}
+            {%- endfor %}
           primary_executable:
             product_type: dswx_s1
           product_path_group:
@@ -69,4 +78,5 @@ RunConfig:
             scratch_path: {{ data.product_path_group.scratch_path }}
             sas_output_path: {{ data.product_path_group.product_path }}
             product_version: {{ data.product_path_group.product_version }}
+            output_imagery_format: 'COG'
           log_file:

--- a/conf/schema/RunConfig_schema.L3_DSWx_S1.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_S1.yaml
@@ -10,7 +10,7 @@ RunConfig:
         InputFilePaths: list(str(), min=1, required=True)
 
       DynamicAncillaryFilesGroup:
-        AncillaryFileMap: map(str(), key=str(), min=0)
+        AncillaryFileMap: map(key=str(), min=0)
 
       ProductPathGroup:
         OutputProductPath: str(required=True)
@@ -84,6 +84,15 @@ RunConfig:
             # algorithm parameter
             algorithm_parameters: str(required=True)
 
+          static_ancillary_file_group:
+            static_ancillary_inputs_flag: bool(required=False)
+
+            # MGRS database sqlite file
+            mgrs_database_file: str(required=False)
+
+            # MGRS collection database sqlite file
+            mgrs_collection_database_file: str(required=False)
+
           primary_executable:
             product_type: enum('dswx_s1', 'twele')
 
@@ -100,5 +109,14 @@ RunConfig:
             sas_output_path: str()
 
             product_version: num(required=False)
+
+            # DSWx-S1 product format (default is 'COG')
+            output_imagery_format: enum('GTiff', 'COG', required=False)
+
+            # DSWx-S1 Compression Options for COG
+            output_imagery_compression: str(required=False)
+
+            # DSWx-S1 Compression bits for COG
+            output_imagery_nbits: int(min=1, required=False)
 
           log_file: str(required=False)

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
@@ -29,15 +29,15 @@
     },
     {
       "name":"input_dataset_id",
+      "from": "value",
       "type":"text",
-      "from":"value",
-      "value": "OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1"
+      "value":"placeholder_id"
     },
     {
      "name": "product_metadata",
      "from": "value",
      "type": "object",
-     "value" : "{ \"metadata\": { \"FileName\": \"OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1_VV.tif\", \"id\": \"OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1\" } }"
+     "value" : "s3://opera-dev-lts-fwd-collinss/sample_dswx_s1_product_metadata.json"
     },
     {
       "name": "accountability_module_path",
@@ -73,13 +73,13 @@
       "name": "container_home",
       "from": "value",
       "type": "text",
-      "value": "/home/conda"
+      "value": "/home/dswx_user"
     },
     {
       "name": "container_working_dir",
       "from": "value",
       "type": "text",
-      "value": "/home/conda"
+      "value": "/home/dswx_user"
     }
   ]
 }

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -1,8 +1,8 @@
 {
   "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
   "disk_usage":"25GB",
-  "soft_time_limit": 3600,
-  "time_limit": 3660,
+  "soft_time_limit": 7200,
+  "time_limit": 7260,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_s1:3.0.0-er.4.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0-er.4.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_s1:3.0.0-er.5.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0-er.5.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]
@@ -48,7 +48,7 @@
       "destination": "context"
     },
     {
-      "name":"input_dataset_id",
+      "name": "input_dataset_id",
       "destination": "context"
     },
     {

--- a/opera_chimera/accountability.py
+++ b/opera_chimera/accountability.py
@@ -88,8 +88,8 @@ class OperaAccountability(Accountability):
         elif self.input_files_type in ('L1_S1_SLC',):
             self.product_paths = [os.path.join(metadata['FileLocation'], metadata['FileName'])]
         elif self.input_files_type in ('L2_RTC_S1','L2_CSLC_S1'):
-            # TODO: unsure about this, revisit once input staging/trigger logic are implemented
-            self.product_paths = [os.path.join(metadata['FileName'])]
+            self.product_paths = [os.path.join(file_metadata['FileLocation'], file_metadata['FileName'])
+                                  for file_metadata in metadata.get('Files', {})]
         else:
             raise RuntimeError(f'Unknown input file type "{self.input_files_type}"')
 

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -36,6 +36,7 @@ runconfig:
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
+  - set_sample_product_metadata  # TODO: remove after testing
   - get_product_version
   - get_cnm_version
   - set_daac_product_type
@@ -50,6 +51,10 @@ preconditions:
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
   - update_product_accountability
+
+set_sample_product_metadata:
+  s3_bucket: "opera-dev-lts-fwd-collinss"
+  s3_key: "sample_dswx_s1_product_metadata.json"
 
 get_product_version:
   version_key: "DSWX_S1_PRODUCT_VERSION"

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -38,9 +38,9 @@ preconditions:
   - get_cnm_version
   - set_daac_product_type
   - get_algorithm_parameters
+  - get_dswx_s1_input_filepaths
   - get_dswx_s1_static_ancillary_files
   # TODO: to be implemented with further releases
-  #- get_dswx_s1_input_filepaths
   #- get_dswx_s1_dem
   #- get_hand_file
   #- get_worldcover

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -40,11 +40,9 @@ preconditions:
   - get_algorithm_parameters
   - get_dswx_s1_input_filepaths
   - get_dswx_s1_static_ancillary_files
+  - get_dswx_s1_dynamic_ancillary_maps
   # TODO: to be implemented with further releases
   #- get_dswx_s1_dem
-  #- get_hand_file
-  #- get_worldcover
-  #- get_reference_water_file
   #- get_shoreline_shapefiles
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
@@ -70,6 +68,21 @@ get_dswx_s1_static_ancillary_files:
   mgrs_collection_database_file:
     s3_bucket: "opera-ancillaries"
     s3_key: "mgrs_tiles/dswx_s1/MGRS_tile_collection_v0.2.1.sqlite"
+
+get_dswx_s1_dynamic_ancillary_maps:
+  # The s3 locations of the ancillary map VRT files (excluding DEM) used by DSWx-S1
+  hand_file:
+    s3_bucket: "opera-hand"
+    s3_key: "v1/2021/glo-30-hand-2021.vrt"
+  worldcover_file:
+    s3_bucket: "opera-world-cover"
+    s3_key: "v100/2020/ESA_WorldCover_10m_2020_v100_Map_AWS.vrt"
+  reference_water_file:
+    s3_bucket: "opera-reference-water"
+    s3_key: "2021/occurrence/occurrence_v1_4_2021.vrt"
+    # TODO: The following water map is also available, need to confirm with ADT
+    #       which will be used in the long run
+    # s3_key: "2021/seasonality/seasonality_v1_4_2021.vrt"
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -20,6 +20,8 @@ runconfig:
     hand_file: __CHIMERA_VAL__
     worldcover_file: __CHIMERA_VAL__
     reference_water_file: __CHIMERA_VAL__
+    # TODO: enable if shoreline files are needed by DSWx-S1 SAS
+    # shoreline_shapefile: __CHIMERA_VAL__
   static_ancillary_file_group:
     mgrs_database_file: __CHIMERA_VAL__
     mgrs_collection_database_file: __CHIMERA_VAL__
@@ -42,7 +44,7 @@ preconditions:
   - get_dswx_s1_static_ancillary_files
   - get_dswx_s1_dynamic_ancillary_maps
   - get_dswx_s1_dem
-  # TODO: to be implemented with further releases
+  # TODO: enable if shoreline files are needed by DSWx-S1 SAS
   #- get_shoreline_shapefiles
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
@@ -88,6 +90,18 @@ get_dswx_s1_dem:
   # The s3 location containing the global DEM(s) to download regions from
   s3_bucket: "opera-dem"
   s3_key: "v1.1"
+
+get_shoreline_shapefiles:
+  # The s3 bucket containing the Shoreline shapefile data set
+  s3_bucket: "opera-dist2coast"
+  # Key paths to the files that comprise the Shoreline shapefile data set
+  # Typically should be a set of 4 files, one of which MUST be the .shp which
+  # gets configured within the PGE RunConfig
+  s3_keys:
+    - "GSHHS_f_L1.dbf"
+    - "GSHHS_f_L1.prj"
+    - "GSHHS_f_L1.shp"
+    - "GSHHS_f_L1.shx"
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -41,8 +41,8 @@ preconditions:
   - get_dswx_s1_input_filepaths
   - get_dswx_s1_static_ancillary_files
   - get_dswx_s1_dynamic_ancillary_maps
+  - get_dswx_s1_dem
   # TODO: to be implemented with further releases
-  #- get_dswx_s1_dem
   #- get_shoreline_shapefiles
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
@@ -83,6 +83,11 @@ get_dswx_s1_dynamic_ancillary_maps:
     # TODO: The following water map is also available, need to confirm with ADT
     #       which will be used in the long run
     # s3_key: "2021/seasonality/seasonality_v1_4_2021.vrt"
+
+get_dswx_s1_dem:
+  # The s3 location containing the global DEM(s) to download regions from
+  s3_bucket: "opera-dem"
+  s3_key: "v1.1"
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -20,6 +20,9 @@ runconfig:
     hand_file: __CHIMERA_VAL__
     worldcover_file: __CHIMERA_VAL__
     reference_water_file: __CHIMERA_VAL__
+  static_ancillary_file_group:
+    mgrs_database_file: __CHIMERA_VAL__
+    mgrs_collection_database_file: __CHIMERA_VAL__
   product_path_group:
     product_version: __CHIMERA_VAL__
     product_path: output_dir
@@ -34,7 +37,8 @@ preconditions:
   - get_product_version
   - get_cnm_version
   - set_daac_product_type
-  - get_dswx_s1_sample_inputs
+  - get_algorithm_parameters
+  - get_dswx_s1_static_ancillary_files
   # TODO: to be implemented with further releases
   #- get_dswx_s1_input_filepaths
   #- get_dswx_s1_dem
@@ -52,6 +56,20 @@ get_product_version:
 
 set_daac_product_type:
   template: OPERA_L3_DSWX_S1_{cnm_version}
+
+get_algorithm_parameters:
+  # The s3 location containing the algorithm parameters RunConfig to use
+  s3_bucket: "opera-ancillaries"
+  s3_key: "algorithm_parameters/dswx_s1/dswx_s1_algorithm_parameters_beta_0.2.1.yaml"
+
+get_dswx_s1_static_ancillary_files:
+  # The s3 locations of each of the static ancillary file types used by DSWx-S1
+  mgrs_database_file:
+    s3_bucket: "opera-ancillaries"
+    s3_key: "mgrs_tiles/dswx_s1/MGRS_tile_v0.2.1.sqlite"
+  mgrs_collection_database_file:
+    s3_bucket: "opera-ancillaries"
+    s3_key: "mgrs_tiles/dswx_s1/MGRS_tile_collection_v0.2.1.sqlite"
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:
@@ -79,8 +97,9 @@ primary_output: "L3_DSWx_S1"
 # The entries MUST reference a property of `$.runconfig` of this YAML.
 # The referenced properties MUST be maps.
 localize_groups:
-  - product_paths
-  - dynamic_ancillary_file_group
+  - input_file_group
+  - static_ancillary_file_group
+  - processing
 
 
 #######################################################################

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -28,6 +28,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     INPUT_DATASET_ID = "input_dataset_id"
 
+    INPUT_FILE_PATHS = "input_file_paths"
+
     DATASET_TYPE = "dataset_type"
 
     PRODUCT_VERSION = "product_version"

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -24,6 +24,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     SET_EXTRA_PGE_OUTPUT_METADATA = "set_extra_pge_output_metadata"
 
+    SET_SAMPLE_PRODUCT_METADATA = "set_sample_product_metadata"
+
     SET_DAAC_PRODUCT_TYPE = "set_daac_product_type"
 
     INPUT_DATASET_ID = "input_dataset_id"

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -90,6 +90,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     GET_DSWX_S1_STATIC_ANCILLARY_FILES = "get_dswx_s1_static_ancillary_files"
 
+    GET_DSWX_S1_DYNAMIC_ANCILLARY_MAPS = "get_dswx_s1_dynamic_ancillary_maps"
+
     GET_SLC_S1_POLARIZATION = "get_slc_s1_polarization"
 
     GET_SLC_S1_BURST_DATABASE = "get_slc_s1_burst_database"

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -40,6 +40,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     ORBIT_FILE_PATH = "orbit_file_path"
 
+    ALGORITHM_PARAMETERS = "algorithm_parameters"
+
     BURST_ID = "burst_id"
 
     BURST_DATABASE_FILE = "burst_database_file"
@@ -81,6 +83,10 @@ class OperaChimeraConstants(ChimeraConstants):
     VERSION_KEY = "version_key"
 
     BBOX = "bbox"
+
+    GET_ALGORITHM_PARAMETERS = "get_algorithm_parameters"
+
+    GET_DSWX_S1_STATIC_ANCILLARY_FILES = "get_dswx_s1_static_ancillary_files"
 
     GET_SLC_S1_POLARIZATION = "get_slc_s1_polarization"
 

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -88,6 +88,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     GET_ALGORITHM_PARAMETERS = "get_algorithm_parameters"
 
+    GET_DSWX_S1_DEM = "get_dswx_s1_dem"
+
     GET_DSWX_S1_STATIC_ANCILLARY_FILES = "get_dswx_s1_static_ancillary_files"
 
     GET_DSWX_S1_DYNAMIC_ANCILLARY_MAPS = "get_dswx_s1_dynamic_ancillary_maps"

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -961,55 +961,6 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
-    def get_dswx_s1_sample_inputs(self):
-        """
-        Temporary function to stage the "golden" inputs for use with the DSWx-S1
-        PGE.
-
-        TODO: this function will eventually be phased out as functions to
-              acquire the appropriate input files are implemented with future
-              releases
-        """
-        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
-
-        # get the working directory
-        working_dir = get_working_dir()
-
-        s3_bucket = "opera-dev-lts-fwd-collinss"
-        s3_key = "dswx_s1_sample_input_data.zip"
-
-        output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
-
-        pge_metrics = download_object_from_s3(
-            s3_bucket, s3_key, output_filepath, filetype="DSWx-S1 Inputs"
-        )
-
-        with zipfile.ZipFile(output_filepath) as myzip:
-            zip_contents = myzip.namelist()
-            zip_contents = list(filter(lambda x: not x.startswith('__'), zip_contents))
-            zip_contents = list(filter(lambda x: not x.endswith('.DS_Store'), zip_contents))
-            myzip.extractall(path=working_dir, members=zip_contents)
-
-        rtc_data_dir = os.path.join(working_dir, 'dswx_s1_sample_input_data', 'rtc_data')
-        ancillary_data_dir = os.path.join(working_dir, 'dswx_s1_sample_input_data', 'ancillary_data')
-
-        rtc_dirs = os.listdir(rtc_data_dir)
-
-        rtc_file_list = [os.path.join(rtc_data_dir, rtc_dir) for rtc_dir in rtc_dirs]
-
-        rc_params = {
-            'input_file_paths': rtc_file_list,
-            'dem_file': os.path.join(ancillary_data_dir, 'dem.tif'),
-            'hand_file': os.path.join(ancillary_data_dir, 'hand.tif'),
-            'worldcover_file': os.path.join(ancillary_data_dir, 'worldcover.tif'),
-            'reference_water_file': os.path.join(ancillary_data_dir, 'reference_water.tif'),
-            'algorithm_parameters': os.path.join(ancillary_data_dir, 'algorithm_parameter_s1.yaml')
-        }
-
-        logger.info(f"rc_params : {rc_params}")
-
-        return rc_params
-
     def get_algorithm_parameters(self):
         """
         Gets the S3 path to the designated algorithm parameters runconfig for use

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1009,6 +1009,44 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_algorithm_parameters(self):
+        """
+        Gets the S3 path to the designated algorithm parameters runconfig for use
+        with a DSWx-S1/DISP-S1 job
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        s3_bucket = self._pge_config.get(oc_const.GET_ALGORITHM_PARAMETERS, {}).get(oc_const.S3_BUCKET)
+        s3_key = self._pge_config.get(oc_const.GET_ALGORITHM_PARAMETERS, {}).get(oc_const.S3_KEY)
+
+        rc_params = {
+            oc_const.ALGORITHM_PARAMETERS: f"s3://{s3_bucket}/{s3_key}"
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
+    def get_dswx_s1_static_ancillary_files(self):
+        """
+        Gets the S3 paths to the configured static ancillary input files for
+        DSWx-S1 processing
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        rc_params = {}
+
+        static_ancillary_products = self._pge_config.get(oc_const.GET_DSWX_S1_STATIC_ANCILLARY_FILES, {})
+
+        for static_ancillary_product in static_ancillary_products.keys():
+            s3_bucket = static_ancillary_products.get(static_ancillary_product, {}).get(oc_const.S3_BUCKET)
+            s3_key = static_ancillary_products.get(static_ancillary_product, {}).get(oc_const.S3_KEY)
+
+            rc_params[static_ancillary_product] = f"s3://{s3_bucket}/{s3_key}"
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
 
     def get_opera_ancillary(self, ancillary_type, output_filepath, staging_func, staging_func_args):
         """

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -161,10 +161,8 @@ def convert(
             dataset_met_json["input_granule_id"] = product_metadata["id"]
             dataset_met_json["orbit_file"] = PurePath(extra_met["runconfig"]["localize"][0]).name
         elif pge_name == "L3_DSWx_S1":
-            # TODO: this is probably insufficient, as there will be multiple input granule ID's for each DSWx-S1 job
             dataset_met_json["input_granule_id"] = product_metadata["id"]
         elif pge_name == "L3_DISP_S1":
-            # TODO: this is probably insufficient, as there will be multiple input granule ID's for each DISP-S1 job
             dataset_met_json["input_granule_id"] = product_metadata["id"]
 
         dataset_met_json["pcm_version"] = job_json_util.get_pcm_version(job_json_dict)

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -450,6 +450,73 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
         expected_pge_metrics = join(self.working_dir.name, 'pge_metrics.json')
         self.assertTrue(exists(expected_pge_metrics))
 
+    def test_get_algorithm_parameters(self):
+        """Unit tests for get_algorithm_parameters() precondition function"""
+        # Set up the arguments to OperaPreConditionFunctions
+        pge_config = {
+            oc_const.GET_ALGORITHM_PARAMETERS: {
+                oc_const.S3_BUCKET: "opera-ancillaries",
+                oc_const.S3_KEY: "algorithm_parameters/pge_name/pge_name_algorithm_parameters_beta_0.1.0.yaml"
+            }
+        }
+
+        # These are not used with get_algorithm_parameters()
+        context = {}
+        settings = {}
+        job_params = None
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        rc_params = precondition_functions.get_algorithm_parameters()
+
+        # Ensure the S3 URI was formed as expected
+        self.assertIn(oc_const.ALGORITHM_PARAMETERS, rc_params)
+        self.assertIsInstance(rc_params[oc_const.ALGORITHM_PARAMETERS], str)
+        self.assertEqual(rc_params[oc_const.ALGORITHM_PARAMETERS],
+                         "s3://opera-ancillaries/algorithm_parameters/pge_name/pge_name_algorithm_parameters_beta_0.1.0.yaml")
+
+    def test_get_dswx_s1_static_ancillary_files(self):
+        """Unit tests for get_dswx_s1_static_ancillary_files() precondition function"""
+        # Set up the arguments to OperaPreConditionFunctions
+        pge_config = {
+            oc_const.GET_DSWX_S1_STATIC_ANCILLARY_FILES: {
+                "mgrs_database_file": {
+                    oc_const.S3_BUCKET: "opera-ancillaries",
+                    oc_const.S3_KEY: "mgrs_tiles/dswx_s1/MGRS_tile_v0.2.1.sqlite"
+                },
+                "mgrs_collection_database_file": {
+                    oc_const.S3_BUCKET: "opera-ancillaries",
+                    oc_const.S3_KEY: "mgrs_tiles/dswx_s1/MGRS_tile_collection_v0.2.1.sqlite"
+                }
+            }
+        }
+
+        # These are not used with get_dswx_s1_static_ancillary_files()
+        context = {}
+        settings = {}
+        job_params = None
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        rc_params = precondition_functions.get_dswx_s1_static_ancillary_files()
+
+        expected_static_ancillary_products = ["mgrs_database_file", "mgrs_collection_database_file"]
+
+        for expected_static_ancillary_product in expected_static_ancillary_products:
+            self.assertIn(expected_static_ancillary_product, rc_params)
+            self.assertIsInstance(rc_params[expected_static_ancillary_product], str)
+            self.assertEqual(
+                rc_params[expected_static_ancillary_product],
+                "s3://{}/{}".format(
+                    pge_config[oc_const.GET_DSWX_S1_STATIC_ANCILLARY_FILES][expected_static_ancillary_product][oc_const.S3_BUCKET],
+                    pge_config[oc_const.GET_DSWX_S1_STATIC_ANCILLARY_FILES][expected_static_ancillary_product][oc_const.S3_KEY]
+                )
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -517,6 +517,53 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
                 )
             )
 
+    def test_get_dswx_s1_input_filepaths(self):
+        """Unit tests for get_dswx_s1_input_filepaths() precondition function"""
+        # Set up the arguments to OperaPreConditionFunctions
+        context = {
+            "dataset_type": "L2_RTC_S1",
+            "product_metadata": {
+                "metadata": {
+                    "product_paths": {
+                        "L2_RTC_S1": [
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_17$146/OPERA_L2_RTC-S1_T012-023801-IW1_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_mask.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_17$146/OPERA_L2_RTC-S1_T012-023801-IW1_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_VH.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_17$146/OPERA_L2_RTC-S1_T012-023801-IW1_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_VV.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_17$146/OPERA_L2_RTC-S1_T012-023801-IW1_20231019T121502Z_20231019T232415Z_S1A_30_v1.0.h5",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_18$147/OPERA_L2_RTC-S1_T013-023802-IW2_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_mask.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_18$147/OPERA_L2_RTC-S1_T013-023802-IW2_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_VH.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_18$147/OPERA_L2_RTC-S1_T013-023802-IW2_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_VV.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_18$147/OPERA_L2_RTC-S1_T013-023802-IW2_20231019T121502Z_20231019T232415Z_S1A_30_v1.0.h5",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_19$148/OPERA_L2_RTC-S1_T014-023803-IW3_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_mask.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_19$148/OPERA_L2_RTC-S1_T014-023803-IW3_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_VH.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_19$148/OPERA_L2_RTC-S1_T014-023803-IW3_20231019T121502Z_20231019T232415Z_S1A_30_v1.0_VV.tif",
+                            "s3://opera-dev-rs-fwd/dswx_s1/MS_12_19$148/OPERA_L2_RTC-S1_T014-023803-IW3_20231019T121502Z_20231019T232415Z_S1A_30_v1.0.h5",
+                        ]
+                    }
+                }
+            }
+        }
+
+        # These are not used with get_dswx_s1_input_filepaths()
+        pge_config = {}
+        settings = {}
+        job_params = None
+
+        precondition_functions = OperaPreConditionFunctions(
+            context, pge_config, settings, job_params
+        )
+
+        rc_params = precondition_functions.get_dswx_s1_input_filepaths()
+
+        # Ensure the list of input file paths was populated with only the set of
+        # unique S3 directories that make up the set of input RTC files
+        self.assertIn(oc_const.INPUT_FILE_PATHS, rc_params)
+        self.assertIsInstance(rc_params[oc_const.INPUT_FILE_PATHS], list)
+        self.assertEqual(len(rc_params[oc_const.INPUT_FILE_PATHS]), 3)
+        self.assertIn("s3://opera-dev-rs-fwd/dswx_s1/MS_12_17$146", rc_params[oc_const.INPUT_FILE_PATHS])
+        self.assertIn("s3://opera-dev-rs-fwd/dswx_s1/MS_12_18$147", rc_params[oc_const.INPUT_FILE_PATHS])
+        self.assertIn("s3://opera-dev-rs-fwd/dswx_s1/MS_12_19$148", rc_params[oc_const.INPUT_FILE_PATHS])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -61,7 +61,7 @@ class MockGdal:
         return MockGdal.MockGdalDataset()
 
 
-def _check_aws_connection_patch(bucket_name, dem_key=""):
+def _check_aws_connection_patch(bucket, key):
     """
     No-op patch function for use with testing precondition functions that attempt
     AWS access
@@ -277,7 +277,8 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
         pge_config = {
             'pge_name': 'L2_CSLC_S1',
             oc_const.GET_SLC_S1_DEM: {
-                oc_const.S3_BUCKET: 'opera-bucket'
+                oc_const.S3_BUCKET: 'opera-bucket',
+                oc_const.S3_KEY: 'key/to/dem/'
             }
         }
 

--- a/tools/stage_ancillary_map.py
+++ b/tools/stage_ancillary_map.py
@@ -6,7 +6,6 @@ import argparse
 import os
 
 import backoff
-import boto3
 
 from osgeo import gdal
 
@@ -14,6 +13,7 @@ from commons.logger import logger
 from commons.logger import LogLevels
 from util.geo_util import (check_dateline,
                            polygon_from_bounding_box)
+from util.pge_util import check_aws_connection
 
 # Enable exceptions
 gdal.UseExceptions()
@@ -98,37 +98,6 @@ def download_map(polys, map_bucket, map_vrt_key, outfile):
 
     # Build VRT with downloaded sub-regions
     gdal.BuildVRT(outfile, region_list)
-
-
-def check_aws_connection(bucket, key):
-    """
-    Check connection to the provided S3 bucket by performing a test read
-    on the provided bucket/key location.
-
-    Parameters
-    ----------
-    bucket : str
-        Name of the S3 bucket to use with the connection test.
-    key : str, optional
-        S3 key path to append to the bucket name.
-
-    Raises
-    ------
-    RuntimeError
-        If not connection can be established.
-
-    """
-    s3 = boto3.resource('s3')
-    obj = s3.Object(bucket, key)
-
-    try:
-        logger.info(f'Attempting test read of s3://{obj.bucket_name}/{obj.key}')
-        obj.get()['Body'].read()
-        logger.info('Connection test successful.')
-    except Exception:
-        errmsg = (f'No access to the {bucket} S3 bucket. '
-                  f'Check your AWS credentials and re-run the code.')
-        raise RuntimeError(errmsg)
 
 
 def main(args):

--- a/tools/stage_ancillary_map.py
+++ b/tools/stage_ancillary_map.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+
+# Staging script for ancillary map inputs, such as HAND, Worldcover, etc...
+
+import argparse
+import os
+
+import backoff
+import boto3
+
+from osgeo import gdal
+
+from commons.logger import logger
+from commons.logger import LogLevels
+from util.geo_util import (check_dateline,
+                           polygon_from_bounding_box)
+
+# Enable exceptions
+gdal.UseExceptions()
+
+def get_parser():
+    """Returns the command line parser for stage_ancillary_map.py"""
+    parser = argparse.ArgumentParser(
+        description="Stage a sub-region of a global map, stored in S3, based on "
+                    "a provided bounding box region. This script leverages the "
+                    "VRT virtual table feature of GDAL to sub-select a region of a"
+                    "global map from an arbitrary projection window (bbox).",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument('-o', '--output-file', type=str, action='store',
+                        required=True, dest='outfile',
+                        help='Path to the output VRT file which composes '
+                             'each of the staged map sub-regions. Must be a file'
+                             'ending with the .vrt extension.')
+    parser.add_argument('-s', '--s3-bucket', type=str, action='store',
+                        required=True, dest='s3_bucket',
+                        help='Name of the S3 bucket containing the global '
+                             'map to extract from.')
+    parser.add_argument('-k', '--s3-key', type=str, action='store',
+                        required=True, dest="s3_key",
+                        help='S3 key path to the GDAL VRT file for the global map.')
+    parser.add_argument('-b', '--bbox', type=float, action='store',
+                        required=True, dest='bbox', nargs=4, metavar='VAL',
+                        help='Spatial bounding box of the map sub-region to stage '
+                             'in latitude/longitude (WSEN, decimal degrees)')
+    parser.add_argument('-m', '--margin', type=int, action='store',
+                        default=5, help='Margin, in km, to apply to the sub-region '
+                                        'denoted by the provided bounding box.')
+    parser.add_argument("--log-level",
+                        type=lambda log_level: LogLevels[log_level].value,
+                        choices=LogLevels.list(),
+                        default=LogLevels.INFO.value,
+                        help="Specify a logging verbosity level.")
+
+    return parser
+
+
+@backoff.on_exception(backoff.expo, Exception, max_time=600, max_value=32)
+def download_map(polys, map_bucket, map_vrt_key, outfile):
+    """
+    Download a map subregion corresponding to the provided polygon(s)
+    from the designated S3 location.
+
+    Parameters
+    ----------
+    polys : list of shapely.geometry.Polygon
+        List of polygons comprising the sub-regions of the global map to download.
+    map_bucket : str
+        Name of the S3 bucket containing the global map.
+    map_vrt_key : str
+        S3 key path to the location of the global map VRT within the
+        bucket.
+    outfile : str
+        Path to where the output map VRT (and corresponding tifs) will be staged.
+
+    """
+    # Download the map for each provided Polygon
+    file_prefix = os.path.splitext(outfile)[0]
+    region_list = []
+
+    for idx, poly in enumerate(polys):
+        vrt_filename = f'/vsis3/{map_bucket}/{map_vrt_key}'
+        output_path = f'{file_prefix}_{idx}.tif'
+        region_list.append(output_path)
+
+        x_min, y_min, x_max, y_max = poly.bounds
+
+        logger.info(
+            f"Translating map for projection window "
+            f"{str([x_min, y_max, x_max, y_min])} to {output_path}"
+        )
+
+        ds = gdal.Open(vrt_filename, gdal.GA_ReadOnly)
+
+        gdal.Translate(
+            output_path, ds, format='GTiff', projWin=[x_min, y_max, x_max, y_min]
+        )
+
+    # Build VRT with downloaded sub-regions
+    gdal.BuildVRT(outfile, region_list)
+
+
+def check_aws_connection(bucket, key):
+    """
+    Check connection to the provided S3 bucket by performing a test read
+    on the provided bucket/key location.
+
+    Parameters
+    ----------
+    bucket : str
+        Name of the S3 bucket to use with the connection test.
+    key : str, optional
+        S3 key path to append to the bucket name.
+
+    Raises
+    ------
+    RuntimeError
+        If not connection can be established.
+
+    """
+    s3 = boto3.resource('s3')
+    obj = s3.Object(bucket, key)
+
+    try:
+        logger.info(f'Attempting test read of s3://{obj.bucket_name}/{obj.key}')
+        obj.get()['Body'].read()
+        logger.info('Connection test successful.')
+    except Exception:
+        errmsg = (f'No access to the {bucket} S3 bucket. '
+                  f'Check your AWS credentials and re-run the code.')
+        raise RuntimeError(errmsg)
+
+
+def main(args):
+    """
+    Main script to execute ancillary map staging.
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        Arguments parsed from the command-line.
+
+    """
+    # Set the logging level
+    if args.log_level:
+        LogLevels.set_level(args.log_level)
+
+    # Make sure that output file has VRT extension
+    if not args.outfile.lower().endswith('.vrt'):
+        err_msg = "Output filename extension is not .vrt"
+        raise ValueError(err_msg)
+
+    # Derive the region polygon from the provided bounding box
+    logger.info('Determining polygon from bounding box')
+    poly = polygon_from_bounding_box(args.bbox, args.margin)
+
+    # Check dateline crossing
+    polys = check_dateline(poly)
+
+    # Check connection to the S3 bucket
+    logger.info(f'Checking connection to AWS S3 {args.s3_bucket} bucket.')
+    check_aws_connection(bucket=args.s3_bucket, key=args.s3_key)
+
+    # Download the map for each polygon region and assemble them into a
+    # single output VRT file
+    download_map(polys, args.s3_bucket, args.s3_key, args.outfile)
+
+    logger.info(f'Done, ancillary map stored locally to {args.outfile}')
+
+
+if __name__ == '__main__':
+    parser = get_parser()
+    args = parser.parse_args()
+    main(args)

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -199,7 +199,9 @@ def simulate_run_pge(runconfig: Dict, pge_config: Dict, context: Dict, output_di
 
     input_dataset_id = get_input_dataset_id(context)
 
-    # TODO: this check can be removed once we move away from sample inputs
+    # For PGE's that are triggered off of multiple input datasets (such as
+    # DSWx-S1 and DISP-S1) we substitute a single sample dataset ID to pattern
+    # match against for the sake of generating dummy output files
     if not input_dataset_id:
         input_dataset_id = pge_config.get('sample_input_dataset_id')
 
@@ -210,7 +212,7 @@ def simulate_run_pge(runconfig: Dict, pge_config: Dict, context: Dict, output_di
             break
     else:
         raise RuntimeError(
-            f"Could not match dataset ID '{get_input_dataset_id(context)}' to any "
+            f"Could not match dataset ID '{input_dataset_id}' to any "
             f"input file base name regex in the PGE configuration yaml file."
         )
 

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -211,8 +211,8 @@ def simulate_run_pge(runconfig: Dict, pge_config: Dict, context: Dict, output_di
     # For PGE's that are triggered off of multiple input datasets (such as
     # DSWx-S1 and DISP-S1) we substitute a single sample dataset ID to pattern
     # match against for the sake of generating dummy output files
-    if not input_dataset_id:
-        input_dataset_id = pge_config.get('sample_input_dataset_id')
+    if 'sample_input_dataset_id' in pge_config:
+        input_dataset_id = pge_config['sample_input_dataset_id']
 
     for input_file_base_name_regex in input_file_base_name_regexes:
         pattern = re.compile(input_file_base_name_regex)

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -105,6 +105,37 @@ def get_time_for_filename():
     return PRODUCTION_TIME
 
 
+def check_aws_connection(bucket, key):
+    """
+    Check connection to the provided S3 bucket by performing a test read
+    on the provided bucket/key location.
+
+    Parameters
+    ----------
+    bucket : str
+        Name of the S3 bucket to use with the connection test.
+    key : str, optional
+        S3 key path to append to the bucket name.
+
+    Raises
+    ------
+    RuntimeError
+        If not connection can be established.
+
+    """
+    s3 = boto3.resource('s3')
+    obj = s3.Object(bucket, key)
+
+    try:
+        logger.info(f'Attempting test read of s3://{obj.bucket_name}/{obj.key}')
+        obj.get()['Body'].read()
+        logger.info('Connection test successful.')
+    except Exception:
+        errmsg = (f'No access to the {bucket} S3 bucket. '
+                  f'Check your AWS credentials and re-run the code.')
+        raise RuntimeError(errmsg)
+
+
 def download_object_from_s3(s3_bucket, s3_key, output_filepath, filetype="Ancillary"):
     """Helper function to download an arbitrary file from S3"""
     if not s3_bucket or not s3_key:

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -76,22 +76,40 @@ def dswx_hls_lineage_metadata(context, work_dir):
 
 def dswx_s1_lineage_metadata(context, work_dir):
     """Gathers the lineage metadata for the DSWx-S1 PGE"""
+    run_config: Dict = context.get("run_config")
+
     lineage_metadata = []
 
-    rtc_data_dir = os.path.join(work_dir, 'dswx_s1_sample_input_data', 'rtc_data')
+    for s3_input_filepath in run_config["input_file_group"]["input_file_paths"]:
+        local_input_filepath = os.path.join(work_dir, basename(s3_input_filepath))
+        lineage_metadata.append(local_input_filepath)
 
-    # TODO: update paths as necessary as sample inputs are phased out
-    lineage_metadata.extend(
-        [os.path.join(rtc_data_dir, rtc_dir)
-         for rtc_dir in os.listdir(rtc_data_dir)]
+    # Copy the ancillaries downloaded for this job to the pge input directory
+    local_dem_filepaths = glob.glob(os.path.join(work_dir, "dem*.*"))
+    lineage_metadata.extend(local_dem_filepaths)
+
+    local_hand_filepaths = glob.glob(os.path.join(work_dir, "hand_file*.*"))
+    lineage_metadata.extend(local_hand_filepaths)
+
+    local_worldcover_filepaths = glob.glob(os.path.join(work_dir, "worldcover_file*.*"))
+    lineage_metadata.extend(local_worldcover_filepaths)
+
+    local_ref_water_filepaths = glob.glob(os.path.join(work_dir, "reference_water_file*.*"))
+    lineage_metadata.extend(local_ref_water_filepaths)
+
+    local_db_filepaths = glob.glob(os.path.join(work_dir, "*.sqlite*"))
+    lineage_metadata.extend(local_db_filepaths)
+
+    local_algorithm_parameters_filepath = os.path.join(
+        work_dir, basename(run_config["processing"]["algorithm_parameters"])
     )
+    lineage_metadata.append(local_algorithm_parameters_filepath)
 
-    ancillary_data_dir = os.path.join(work_dir, 'dswx_s1_sample_input_data', 'ancillary_data')
-
-    lineage_metadata.extend(
-        [os.path.join(ancillary_data_dir, ancillary)
-         for ancillary in os.listdir(ancillary_data_dir)]
-    )
+    # TODO: enable if shoreline files are needed by DSWx-S1 SAS
+    #shoreline_shape_filename = run_config["dynamic_ancillary_file_group"]["shoreline_shapefile"]
+    #shoreline_shape_basename = splitext(basename(shoreline_shape_filename))[0]
+    #local_shoreline_filepaths = glob.glob(os.path.join(work_dir, f"{shoreline_shape_basename}.*"))
+    #lineage_metadata.extend(local_shoreline_filepaths)
 
     return lineage_metadata
 
@@ -219,20 +237,28 @@ def update_dswx_s1_runconfig(context, work_dir):
 
     container_home: str = container_home_param['value']
     container_home_prefix = f'{container_home}/input_dir'
-    rtc_data_prefix = os.path.join(work_dir, 'dswx_s1_sample_input_data', 'rtc_data')
 
     input_file_paths = run_config["input_file_group"]["input_file_paths"]
-    input_file_paths = list(map(lambda x: x.replace(rtc_data_prefix, container_home_prefix), input_file_paths))
+    updated_input_file_paths = [os.path.join(container_home_prefix, basename(input_file_path))
+                                for input_file_path in input_file_paths]
+    run_config["input_file_group"]["input_file_paths"] = updated_input_file_paths
 
-    run_config["input_file_group"]["input_file_paths"] = input_file_paths
+    dynamic_ancillary_file_paths = run_config["dynamic_ancillary_file_group"]
+    updated_dynamic_ancillary_file_paths = {
+        ancillary_file_type: os.path.join(container_home_prefix, basename(ancillary_file_path))
+        for ancillary_file_type, ancillary_file_path in dynamic_ancillary_file_paths.items()
+    }
+    run_config["dynamic_ancillary_file_group"] = updated_dynamic_ancillary_file_paths
 
-    # TODO update these once we move away from sample inputs
-    run_config["dynamic_ancillary_file_group"]["dem_file"] = f'{container_home_prefix}/dem.tif'
-    run_config["dynamic_ancillary_file_group"]["hand_file"] = f'{container_home_prefix}/hand.tif'
-    run_config["dynamic_ancillary_file_group"]["worldcover_file"] = f'{container_home_prefix}/worldcover.tif'
-    run_config["dynamic_ancillary_file_group"]["reference_water_file"] = f'{container_home_prefix}/reference_water.tif'
+    static_ancillary_file_paths = run_config["static_ancillary_file_group"]
+    updated_static_ancillary_file_paths = {
+        ancillary_file_type: os.path.join(container_home_prefix, basename(ancillary_file_path))
+        for ancillary_file_type, ancillary_file_path in static_ancillary_file_paths.items()
+    }
+    run_config["static_ancillary_file_group"] = updated_static_ancillary_file_paths
 
-    run_config["processing"]["algorithm_parameters"] = f'{container_home_prefix}/algorithm_parameter_s1.yaml'
+    algorithm_parameters_filename = basename(run_config["processing"]["algorithm_parameters"])
+    run_config["processing"]["algorithm_parameters"] = f'{container_home_prefix}/{algorithm_parameters_filename}'
 
     return run_config
 

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -6,6 +6,7 @@ import os
 from os.path import basename, splitext
 from typing import Dict
 
+from commons.logger import logger
 
 def slc_s1_lineage_metadata(context, work_dir):
     """Gathers the lineage metadata for the CSLC-S1 and RTC-S1 PGEs"""
@@ -83,6 +84,15 @@ def dswx_s1_lineage_metadata(context, work_dir):
     for s3_input_filepath in run_config["input_file_group"]["input_file_paths"]:
         local_input_filepath = os.path.join(work_dir, basename(s3_input_filepath))
         lineage_metadata.append(local_input_filepath)
+
+        # TODO: kludge to support current version of DSWx-S1 SAS, which wants
+        #  a "_layover_shadow_mask.tif" file, remove for next patch release
+        mask_files = glob.glob(os.path.join(local_input_filepath, "*_mask.tif"))
+        mask_file = mask_files[0]
+        old_name = mask_file
+        new_name = mask_file.replace("_mask.tif", "_layover_shadow_mask.tif")
+        logger.info(f"Renaming {old_name} to {new_name}")
+        os.rename(old_name, new_name)
 
     # Copy the ancillaries downloaded for this job to the pge input directory
     local_dem_filepaths = glob.glob(os.path.join(work_dir, "dem*.*"))


### PR DESCRIPTION
## Purpose
- This branch integrates v3.0.0-er.5.0 of the DSWx-S1 PGE with OPERA PCM. This release incorporates the beta v0.2.1 of the DSWx-S1 SAS.
- As part of this integration, support for staging all (current) ancillary file types has been added.
## Issues
- Resolves #682 
## Testing
- Similar to the previous integration, the DSWx-S1 PGE can be tested by invoking an on-demand job via the Tosca UI. No additional arguments are needed. In its current configuration, the DSWx-S1 SCIFLO job will read a JSON file from S3 containing a canned set of product metadata, such as would be produced by the actual DSWx-S1 trigger logic.
**NOTE**: To disable the use of this canned metadata, the following line should be removed from the DSWx-S1 chimera config: https://github.com/nasa/opera-sds-pcm/blob/issue_682_dswx_s1_er5.0_integration/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml#L39
Please ensure this line is removed once the actual trigger logic for DSWx-S1 is integrated, otherwise the job will always overwrite whatever product metadata is provided.
