### PR TITLE
DSWx-S1 E2E Integration

### DIFF
--- a/data_subscriber/rtc/rtc_job_submitter.py
+++ b/data_subscriber/rtc/rtc_job_submitter.py
@@ -1,6 +1,6 @@
 import asyncio
-import json
 import logging
+import os
 from functools import partial
 from pathlib import PurePath
 from typing import Optional
@@ -46,7 +46,7 @@ def submit_dswx_s1_job_submissions_tasks(uploaded_batch_id_to_s3paths_map, args)
                         {
                             "FileName": PurePath(s3path).name,
                             "FileSize": 1,
-                            "FileLocation": "...",
+                            "FileLocation": os.path.dirname(s3path),
                             "id": PurePath(s3path).name,
                             "product_paths": "$.product_paths"
                         }
@@ -85,13 +85,13 @@ def create_job_params(product):
           "name":"input_dataset_id",
           "type":"text",
           "from":"value",
-          "value": "OPERA_L2_RTC-S1_T047-100908-IW3_20200702T231843Z_20230305T140222Z_S1B_30_v0.1"
+          "value": product["_source"]["metadata"]["mgrs_set_id"]
         },
         {
            "name": "product_metadata",
            "from": "value",
            "type": "object",
-           "value": json.dumps(product["_source"])
+           "value": product["_source"]
         }
     ]
 

--- a/docker/job-spec.json.rtc_query
+++ b/docker/job-spec.json.rtc_query
@@ -1,8 +1,8 @@
 {
   "command":"/home/ops/verdi/ops/opera-pcm/data_subscriber/rtc/rtc_query.sh",
   "disk_usage":"25GB",
-  "soft_time_limit": 3600,
-  "time_limit": 3660,
+  "soft_time_limit": 7200,
+  "time_limit": 7260,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -36,7 +36,6 @@ runconfig:
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
-  - set_sample_product_metadata  # TODO: remove after testing
   - get_product_version
   - get_cnm_version
   - set_daac_product_type

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -130,7 +130,9 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
                 json.dump(pge_metrics, f, indent=2)
 
             # set additional files to triage
-            self._context["_triage_additional_globs"] = ["output", "RunConfig.yaml", "pge_output_dir"]
+            self._context["_triage_additional_globs"] = [
+                "output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir"
+            ]
 
             # set force publish (disable no-clobber)
             force_publish = self._settings.get(oc_const.FORCE_INGEST, {}).get(

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -56,7 +56,10 @@ def main(job_json_file: str, workdir: str):
     job_context = jc.ctx
 
     # set additional files to triage
-    jc.set('_triage_additional_globs', ["output", "RunConfig.yaml", "pge_output_dir"])
+    jc.set(
+        '_triage_additional_globs',
+        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir"]
+    )
 
     # Disable no-clobber errors for published files. Either the file naming conventions
     # will guarantee uniqueness, or we want certain files to be overwritten to avoid


### PR DESCRIPTION
## Purpose
- This branch makes the minor modifications needed to integrate the RTC download/trigger logic with actual invocation of the DSWx-S1 PGE.
## Proposed Changes
- Small modifications have been made to the product metadata provided by rtc_job_submittter.py to make it compatible with the chimera pre-condition functions for DSWx-S1
- The set_sample_product_metadata precondition for DSWx-S1 has been removed, so the metadata provided by rtc_job_submitter.py will be used instead.
- Additional directories have been added to the list of triaged locations to aide in debugging of runtime errors with the current DSWx-S1 SAS
- The time limit for RTC query/download jobs has been increased to 7200 seconds since the occasional time-out failure was observed during testing. This was usually during the initial download of all available RTC products.
## Testing
- This branch was tested on a dev cluster by disabling PGE simulation mode, then enabling the event trigger for the RTC query/download job. The cluster ran for about 2 hours, in which time there were a small handful of successful DSWx-S1 jobs (about 3), and many more failed jobs (about 90) where the SAS errored out. S3 locations of the successful job outputs, as well as the triaged jobs will be provided to ADT for diagnosis.
