### PR TITLE
R2/R3 Fixes

### DIFF
--- a/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
+++ b/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
@@ -184,6 +184,12 @@ echo '{
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
           },
           {
+            "file_path": "/home/ops/verdi/log/opera-job_worker-sciflo-l2_rtc_s1_static.log",
+            "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-sciflo-l2_rtc_s1_static.log",
+            "timezone": "Local",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
+          },
+          {
             "file_path": "/home/ops/verdi/log/opera-job_worker-send_cnm_notify.log",
             "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-send_cnm_notify.log",
             "timezone": "Local",

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -335,7 +335,7 @@ variable "queues" {
     }
     "opera-job_worker-sciflo-l3_dswx_s1" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_s1"
-      "instance_type"     = ["c5a.large", "c6a.large", "c6i.large"]
+      "instance_type"     = ["r6a.large", "r6i.large"]
       "root_dev_size"     = 50
       "data_dev_size"     = 100
       "min_size"          = 0

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -316,6 +316,14 @@ variable "queues" {
       "max_size"          = 25
       "total_jobs_metric" = true
     }
+    "opera-job_worker-sciflo-l2_rtc_s1_static" = {
+      "name"              = "opera-job_worker-sciflo-l2_rtc_s1_static"
+      "instance_type"     = ["r6a.2xlarge", "r6i.2xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 100
+      "max_size"          = 25
+      "total_jobs_metric" = true
+    }
     "opera-job_worker-sciflo-l3_dswx_hls" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_hls"
       "instance_type"     = ["c5a.large", "c6a.large", "c6i.large"]

--- a/conf/sds/rules/user_rules.json
+++ b/conf/sds/rules/user_rules.json
@@ -78,7 +78,7 @@
       "priority": 0,
       "query_all": false,
       "query_string": "{\"bool\": {\"must\": [{\"terms\": {\"dataset_type.keyword\": [\"L1_S1_SLC\"]}}], \"must_not\": [{\"term\": {\"metadata.processing_mode\": \"historical\"}}]}}",
-      "queue": "opera-job_worker-sciflo-l2_rtc_s1",
+      "queue": "opera-job_worker-sciflo-l2_rtc_s1_static",
       "rule_name": "trigger-SCIFLO_L2_RTC_S1_STATIC",
       "username": "hysdsops",
       "workflow": "hysds-io-SCIFLO_L2_RTC_S1_STATIC:__TAG__",

--- a/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
+++ b/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
@@ -77,6 +77,23 @@ def load_mgrs_burst_db_raw(filter_land=True) -> GeoDataFrame:
 
 
 def get_bounding_box_for_mgrs_set_id(mgrs_burst_collections_gdf: GeoDataFrame, mgrs_set_id):
+    """
+    Extracts the bounding box for the provided MGRS tile set ID from within the
+    MGRS burst collection database.
+
+    Parameters
+    ----------
+    mgrs_burst_collections_gdf : GeoDataFrame
+        The MGRS burst collection database as read into memory.
+    mgrs_set_id : str
+        Identifier of the MGRS tile set to extract the bounding box for.
+
+    returns
+    -------
+    bounding_box : list
+        List containing the bounding box in West South East North (WSEN) order.
+
+    """
     gdf = mgrs_burst_collections_gdf
     if not len(gdf[gdf["mgrs_set_id"] == mgrs_set_id]):
         raise Exception(f"No MGRS burst database entry for {mgrs_set_id}")
@@ -85,15 +102,19 @@ def get_bounding_box_for_mgrs_set_id(mgrs_burst_collections_gdf: GeoDataFrame, m
     proj_4326 = gdf.crs  # "EPSG:4326"
     transformer = Transformer.from_crs(proj_32645, proj_4326)
 
-    xmin, ymin = transformer.transform(
+    # Extract the bounding box coordinates in EPSG4326.
+    # Note that the coordinates seem to be stored in reverse lat/lon order, with
+    # xmin/max corresponding to longitude and ymin/max corresponding to latitude
+    ymin, xmin = transformer.transform(
         xx=gdf[gdf["mgrs_set_id"] == mgrs_set_id].iloc[0].xmin,
         yy=gdf[gdf["mgrs_set_id"] == mgrs_set_id].iloc[0].ymin
     )
-    xmax, ymax = transformer.transform(
+    ymax, xmax = transformer.transform(
         xx=gdf[gdf["mgrs_set_id"] == mgrs_set_id].iloc[0].xmax,
         yy=gdf[gdf["mgrs_set_id"] == mgrs_set_id].iloc[0].ymax
     )
 
+    # Return the bounding box in the expected WSEN order
     return [xmin, ymin, xmax, ymax]
 
 

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -18,7 +18,7 @@
       }
     }
   ],
-  "recommended-queues": [ "opera-job_worker-sciflo-l2_rtc_s1"],
+  "recommended-queues": [ "opera-job_worker-sciflo-l2_rtc_s1_static"],
   "disable_pre_builtins": true,
   "disable_post_builtins": true,
   "pre": [

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -1,6 +1,6 @@
 {
   "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
-  "disk_usage":"25GB",
+  "disk_usage":"100GB",
   "soft_time_limit": 7200,
   "time_limit": 7260,
   "imported_worker_files": {


### PR DESCRIPTION
## Purpose
- This branch fixes two issues, one for R2 processing and one for R3:
    - For R2, this branch adds a new auto-scaling group queue specifically for RTC-S1-STATIC jobs, which utilize memory optimized instances instead of compute optimized. There were about 4 failures from static layer production which we caused by workers running out of available memory on compute optimized instances. By switching to memory optimized versions, the 4 jobs were all able to run to completion.
    - For R3, this branch fixes the bug where the lat/lon bounding box extracted from the MGRS tile set database had coordinates swapped between lat and lon. Previously this caused nearly all DSWx-S1 jobs to fail since the DEM was staged incorrectly. With this fix, many more jobs are able to complete succesfully (only 4 failures out of about 40 completed after running for several hours).

## Issues
- N/A

## Testing
- This branch was tested on a dev cluster with simulation mode disabled
- To test the fix for R2 processing the following SLC granules were tested:
     - S1A_IW_SLC__1SDV_20160714T214542_20160714T214612_012150_012D48_277C
     - S1B_IW_SLC__1SDV_20180820T215305_20180820T215332_012352_016C5A_044D
     - S1B_IW_SLC__1SDV_20180820T215355_20180820T215422_012352_016C5A_3145
     - S1B_IW_SLC__1SDV_20180820T215330_20180820T215358_012352_016C5A_451D
- To test the fix for R3 processing, the RTC query timer was enabled for a single iteration, which resulted in triggering of about 90 DSWx-S1 jobs. At time of creation of this PR, about 40 jobs had completed successfully, with only 4 failures. Since this is already a much better result than without the fix, it should be safe to merge this branch before creating the next PCM engineering release for R3. When all jobs complete, I will send a notification to ADT with details of the jobs that still failed.
