### PR TITLE
DISP S1 Historical Processing Fixes

### DIFF
--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -48,6 +48,13 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
                                                                       key_prefix=f"tmp/disp_s1/{batch_id}",
                                                                       files=files_to_upload))
 
+            # Delete the files from the file system after uploading to S3
+            if rm_downloads_dir:
+                logger.info("Removing downloaded files from local filesystem")
+                for fp_set in product_to_filepaths.values():
+                    for fp in fp_set:
+                        os.remove(fp)
+
         # Compute bounding box for frame. All batches should have the same frame_id so we pick the first one
         frame_id, _ = split_download_batch_id(args.batch_ids[0])
         frame = self.disp_burst_map[int(frame_id)]

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -13,6 +13,8 @@ from tools.ops.cmr_audit.cmr_client import cmr_requests_get, async_cmr_posts
 
 logger = logging.getLogger(__name__)
 
+CMR_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+
 COLLECTION_TO_PROVIDER_MAP = {
     "HLSL30": "LPCLOUD",
     "HLSS30": "LPCLOUD",
@@ -78,14 +80,14 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
             params["options[native-id][pattern]"] = 'true'
 
     # derive and apply param "temporal"
-    now_date = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    now_date = now.strftime(CMR_TIME_FORMAT)
     temporal_range = _get_temporal_range(timerange.start_date, timerange.end_date, now_date)
     if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "RTC":
         if args.native_id:
             match_native_id = re.match(rtc_granule_regex, args.native_id)
             acquisition_dt = dateutil.parser.parse(match_native_id.group("acquisition_ts"))
-            timerange_start_date = (acquisition_dt - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
-            timerange_end_date = (acquisition_dt + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+            timerange_start_date = (acquisition_dt - timedelta(hours=1)).strftime(CMR_TIME_FORMAT)
+            timerange_end_date = (acquisition_dt + timedelta(hours=1)).strftime(CMR_TIME_FORMAT)
             temporal_range = _get_temporal_range(timerange_start_date, timerange_end_date, now_date)
 
     if not silent:
@@ -100,7 +102,7 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
         if args.temporal_start_date:
             if not silent:
                 logger.info(f"{args.temporal_start_date=}")
-            params["temporal"] = dateutil.parser.isoparse(args.temporal_start_date).strftime("%Y-%m-%dT%H:%M:%SZ")
+            params["temporal"] = dateutil.parser.isoparse(args.temporal_start_date).strftime(CMR_TIME_FORMAT)
 
     if not silent:
         logger.info(f"Querying CMR. {request_url=} {params=}")

--- a/data_subscriber/cslc/cslc_query.py
+++ b/data_subscriber/cslc/cslc_query.py
@@ -130,9 +130,9 @@ class CslcCmrQuery(CmrQuery):
 
                 # Retrieve K- granules and M- compressed CSLCs for this batch
                 # Go back K- 12-day windows and find the same frame
+                args = self.args
                 if args.k > 1:
                     logger.info(f"Retrieving K-1 granules")
-                    args = self.args
 
                     # Add native-id condition in args
                     native_id = build_cslc_native_ids(frame_id, self.disp_burst_map)
@@ -185,6 +185,13 @@ class CslcCmrQuery(CmrQuery):
                 native_id = build_cslc_native_ids(frame, self.disp_burst_map)
                 args.native_id = native_id # Note that the native_id is overwritten here. It doesn't get used after this point so this should be ok.
                 granules.extend(await async_query_cmr(args, token, cmr, settings, timerange, now))
+
+        # If we are in reprocessing mode, we will expand the native_id to
+        # include all bursts in the frame to which this granule belongs.
+        elif self.proc_mode == "reprocessing":
+            native_id = build_cslc_native_ids(frame, self.disp_burst_map)
+            args.native_id = native_id  # Note that the native_id is overwritten here. It doesn't get used after this point so this should be ok.
+            granules = await async_query_cmr(args, token, cmr, settings, timerange, now)
 
         else:
             granules = await async_query_cmr(args, token, cmr, settings, timerange, now)

--- a/data_subscriber/cslc/cslc_query.py
+++ b/data_subscriber/cslc/cslc_query.py
@@ -2,7 +2,7 @@ import logging
 import re
 import copy
 from datetime import datetime, timedelta
-from data_subscriber.cmr import async_query_cmr
+from data_subscriber.cmr import async_query_cmr, CMR_TIME_FORMAT
 from data_subscriber.cslc_utils import localize_disp_frame_burst_json, build_cslc_native_ids, \
     process_disp_frame_burst_json, download_batch_id_forward_reproc, download_batch_id_hist, split_download_batch_id
 from data_subscriber.query import CmrQuery, DateTimeRange
@@ -68,9 +68,8 @@ class CslcCmrQuery(CmrQuery):
         """For CSLC this is used to determine download_batch_id and attaching it the granule.
         Function extend_additional_records must have been called before this function."""
 
-        #TODO: There's no need to use different methods for historical. We can use the median date and then derive acquisition cycle from that.
         if self.proc_mode == "historical":
-            download_batch_id = download_batch_id_hist(args)
+            download_batch_id = download_batch_id_hist(args, granule)
         else: # forward or reprocessing
             download_batch_id = download_batch_id_forward_reproc(granule)
 
@@ -115,7 +114,7 @@ class CslcCmrQuery(CmrQuery):
 
         # Combine unsubmitted and new granules and determine which granules meet the criteria for download
         # Rule #1: If all granules for a given download_batch_id are present, download all granules for that batch
-        # TODO Rule #2: If it's been xxx hrs since last granule discovery (by OPERA) and xx% are available, download all granules for that batch
+        # TODO Rule #2: If it's been xxx hrs since last granule discovery (by OPERA) download all granules for that batch
         # TODO Rule #3: If granules have been downloaded already but with less than 100% and we have new granules for that batch, download all granules for that batch
         download_granules = []
         for batch_id, download_batch in by_download_batch_id.items():
@@ -131,8 +130,8 @@ class CslcCmrQuery(CmrQuery):
 
                 # Retrieve K- granules and M- compressed CSLCs for this batch
                 # Go back K- 12-day windows and find the same frame
-                logger.info(f"Retrieving K-1 granules")
-                for i in range(self.args.k - 1):
+                if args.k > 1:
+                    logger.info(f"Retrieving K-1 granules")
                     args = self.args
 
                     # Add native-id condition in args
@@ -143,11 +142,11 @@ class CslcCmrQuery(CmrQuery):
                     #TODO: We can only use past frames which contain the exact same bursts as the current frame
                     # If not, we will need to go back another cycle until, as long as we have to, we find one that does
 
-                    # Move start and end date of args back by 12 * (i + 1) days, and then expand 10 days to cast a wide net
-                    start_date = (datetime.strptime(args.start_date, "%Y-%m-%dT%H:%M:%SZ") - timedelta(
-                        days=12 * (i + 1) + 5)).strftime("%Y-%m-%dT%H:%M:%SZ")
-                    end_date = (datetime.strptime(args.end_date, "%Y-%m-%dT%H:%M:%SZ") - timedelta(
-                        days=12 * (i + 1) - 5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+                    # Move start and end date of args back and expand 5 days at both ends to capture all k granules
+                    start_date = (datetime.strptime(args.start_date, CMR_TIME_FORMAT) - timedelta(
+                        days=12 * (args.k - 1) + 5)).strftime(CMR_TIME_FORMAT)
+                    end_date = (datetime.strptime(args.end_date, CMR_TIME_FORMAT) - timedelta(
+                        days=12 - 5)).strftime(CMR_TIME_FORMAT)
                     query_timerange = DateTimeRange(start_date, end_date)
                     logger.info(f"{query_timerange=}")
                     granules = await self.query_cmr(args, self.token, self.cmr, self.settings, query_timerange, datetime.utcnow())

--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -56,6 +56,9 @@ def process_disp_frame_burst_json(file = DISP_FRAME_BURST_MAP_JSON):
 
     return sorted_frame_data, burst_to_frame, metadata, version
 
+def parse_cslc_native_id(native_id, disp_burst_map):
+    pass
+
 def build_cslc_native_ids(frame, disp_burst_map):
     """Builds the native_id string for a given frame. The native_id string is used in the CMR query."""
 

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -80,7 +80,8 @@ async def run(argv: list[str]):
         else:
             results["download"] = await run_download(args, token, es_conn, netloc, username, password, job_id)  # return None
 
-    logger.info(f"{results=}")
+    logger.info(f"{len(results)=}")
+    logger.debug(f"{results=}")
     logger.info("END")
 
     return results

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -20,7 +20,7 @@ from smart_open import open
 import data_subscriber
 from commons.logger import NoJobUtilsFilter, NoBaseFilter
 from data_subscriber.aws_token import supply_token
-from data_subscriber.cmr import CMR_COLLECTION_TO_PROVIDER_TYPE_MAP
+from data_subscriber.cmr import CMR_COLLECTION_TO_PROVIDER_TYPE_MAP, CMR_TIME_FORMAT
 from data_subscriber.download import run_download
 from data_subscriber.hls.hls_catalog_connection import get_hls_catalog_connection
 from data_subscriber.query import update_url_index, run_query
@@ -450,7 +450,7 @@ def _validate_bounds(bbox):
 
 def _validate_date(date, prefix="start"):
     try:
-        datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
+        datetime.strptime(date, CMR_TIME_FORMAT)
     except ValueError:
         raise ValueError(
             f"Error parsing {prefix} date: {date}. Format must be like 2021-01-14T00:00:00Z")

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -13,7 +13,7 @@ import validators
 from cachetools.func import ttl_cache
 
 import extractor.extract
-from data_subscriber.cmr import COLLECTION_TO_PROVIDER_MAP
+from data_subscriber.cmr import COLLECTION_TO_PROVIDER_MAP, CMR_TIME_FORMAT
 from data_subscriber.query import DateTimeRange
 from data_subscriber.url import _to_batch_id, _to_orbit_number
 from util.conf_util import SettingsConf
@@ -136,7 +136,7 @@ class DaacDownload:
 
     def get_download_timerange(self, args):
         start_date = args.start_date if args.start_date else "1900-01-01T00:00:00Z"
-        end_date = args.end_date if args.end_date else datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")
+        end_date = args.end_date if args.end_date else datetime.utcnow().strftime(CMR_TIME_FORMAT)
         download_timerange = DateTimeRange(start_date, end_date)
         logger.info(f"{download_timerange=}")
         return download_timerange

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -110,7 +110,7 @@ class CmrQuery:
 
         results = await asyncio.gather(*job_submission_tasks, return_exceptions=True)
         logger.info(f"{len(results)=}")
-        logger.info(f"{results=}")
+        logger.debug(f"{results=}")
 
         succeeded = [job_id for job_id in results if isinstance(job_id, str)]
         failed = [e for e in results if isinstance(e, Exception)]
@@ -208,7 +208,7 @@ class CmrQuery:
                         batch_id_to_urls_map[granule["download_batch_id"]].add(filter_url)
                     else:
                         batch_id_to_urls_map[url_grouping_func(granule_id, revision_id)].add(filter_url)
-        logger.info(f"{batch_id_to_urls_map=}")
+        logger.debug(f"{batch_id_to_urls_map=}")
         if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "RTC":
             raise NotImplementedError()
         else:
@@ -229,7 +229,7 @@ class CmrQuery:
                 chunk_urls.extend(urls)
 
             logger.info(f"{chunk_batch_ids=}")
-            logger.info(f"{chunk_urls=}")
+            logger.debug(f"{chunk_urls=}")
 
             download_job_id = asyncio.get_event_loop().run_in_executor(
                     executor=None,

--- a/data_subscriber/survey.py
+++ b/data_subscriber/survey.py
@@ -3,10 +3,10 @@ from datetime import datetime, timedelta
 
 import backoff
 
-from data_subscriber.cmr import async_query_cmr
+from data_subscriber.cmr import async_query_cmr, CMR_TIME_FORMAT
 from data_subscriber.query import get_query_timerange, DateTimeRange
 
-_date_format_str = "%Y-%m-%dT%H:%M:%SZ"
+_date_format_str = CMR_TIME_FORMAT
 _date_format_str_cmr = _date_format_str[:-1] + ".%fZ"
 
 
@@ -21,8 +21,8 @@ async def run_survey(args, token, cmr, settings):
     end_dt = datetime.strptime(args.end_date, _date_format_str)
 
     out_csv = open(args.out_csv, 'w')
-    out_csv.write("# DateTime Range:" + start_dt.strftime("%Y-%m-%dT%H:%M:%SZ") + " to " + end_dt.strftime(
-        "%Y-%m-%dT%H:%M:%SZ") + '\n')
+    out_csv.write("# DateTime Range:" + start_dt.strftime(_date_format_str) + " to " + end_dt.strftime(
+        _date_format_str) + '\n')
 
     raw_csv = open(args.out_csv+".raw.csv", 'w')
     raw_csv.write("# Granule ID, Revision Time, Temporal Time, Revision-Temporal Delta Hours, revision-id \n")
@@ -38,8 +38,8 @@ async def run_survey(args, token, cmr, settings):
         step_time = timedelta(hours=float(args.step_hours))
         incre_time = step_time - timedelta(seconds=1)
 
-        start_str = start_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
-        end_str = (start_dt + incre_time).strftime("%Y-%m-%dT%H:%M:%SZ")
+        start_str = start_dt.strftime(_date_format_str)
+        end_str = (start_dt + incre_time).strftime(_date_format_str)
         args.start_date = start_str
         args.end_date = end_str
 

--- a/docker/job-spec.json.cslc_query
+++ b/docker/job-spec.json.cslc_query
@@ -1,8 +1,8 @@
 {
   "command":"/home/ops/verdi/ops/opera-pcm/data_subscriber/cslc/cslc_query.sh",
   "disk_usage":"1GB",
-  "soft_time_limit": 600,
-  "time_limit": 660,
+  "soft_time_limit": 1200,
+  "time_limit": 1260,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/docker/job-spec.json.cslc_query_frame_range
+++ b/docker/job-spec.json.cslc_query_frame_range
@@ -1,8 +1,8 @@
 {
   "command":"/home/ops/verdi/ops/opera-pcm/data_subscriber/cslc/cslc_query.sh",
   "disk_usage":"1GB",
-  "soft_time_limit": 600,
-  "time_limit": 660,
+  "soft_time_limit": 1200,
+  "time_limit": 1260,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/docker/job-spec.json.cslc_query_hist
+++ b/docker/job-spec.json.cslc_query_hist
@@ -1,8 +1,8 @@
 {
   "command":"/home/ops/verdi/ops/opera-pcm/data_subscriber/cslc/cslc_query.sh",
   "disk_usage":"1GB",
-  "soft_time_limit": 600,
-  "time_limit": 660,
+  "soft_time_limit": 1200,
+  "time_limit": 1300,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/tests/data_subscriber/test_cslc_query.py
+++ b/tests/data_subscriber/test_cslc_query.py
@@ -20,6 +20,18 @@ disp_burst_map, burst_to_frame, metadata, version = cslc_utils.process_disp_fram
 def test_frame_range():
     assert forward_args.native_id == "*iw1*"
 
+def test_split_download_batch_id():
+    """Test that the download batch id is correctly split into frame and acquisition cycle"""
+    # Forward and reprocessing mode
+    frame_id, acquisition_cycle = cslc_utils.split_download_batch_id("f100_a200")
+    assert frame_id == 100
+    assert acquisition_cycle == 200
+
+    # Historical mode
+    frame_id, acquisition_cycle = cslc_utils.split_download_batch_id("2023_10_01t00_00_00z_2023_10_25t00_00_00z_3601")
+    assert frame_id == 3601
+    assert acquisition_cycle == None
+
 def test_arg_expansion():
     '''Test that the native_id field is expanded correctly for a given frame range'''
     native_id = cslc_utils.build_cslc_native_ids(100, disp_burst_map)

--- a/tests/scenarios/cslc_query_fwd_test.py
+++ b/tests/scenarios/cslc_query_fwd_test.py
@@ -12,8 +12,9 @@ from data_subscriber.cslc.cslc_catalog import CSLCProductCatalog
 from data_subscriber import daac_data_subscriber, query, cslc_utils
 from data_subscriber.cslc import cslc_query
 from data_subscriber.aws_token import supply_token
+from data_subscriber.cmr import CMR_TIME_FORMAT
 
-DT_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+DT_FORMAT = CMR_TIME_FORMAT
 
 """This test runs cslc query several times in succession and verifies download jobs submitted
 This test is run as a regular python script as opposed to pytest


### PR DESCRIPTION
This doesn't yet have anything about the triggering grade period logic yet. Instead, it **fixes various DISP S1 historical processing. All known issues have been resolved**:
1. CSLC Historical Query was failing in general because the batch id is in different form than in forward processing. This is now handled.
2. CSLC Historical Query was incorrectly sending all download batches to a single download job. This was incorrect. It now generates one download job per download batch, which maps to a complete frame.
3. CSLC Download now deletes local files after they are uploaded to S3 RS so that it doesn't run out of local space.
4. Query soft timer has been doubled. This should suffice for all cases w frame range of 100 or less unless CMR has major slow down - in which case the query can be retried.
5. CMR query is now more efficient by sending a single query instead of several broken down by date ranges.

This following batch proc was run to completion with zero errors. Forward processing was also regression tested.

```
{
  "enabled": true,
  "label": "DISP-S1 Historical",
  "processing_mode": "historical",
  "include_regions": "north_america_opera",
  "exclude_regions": "",
  "temporal": true,
  "data_start_date": "2023-10-01T00:00:00",
  "data_end_date": "2023-10-25T04:00:00",
  "last_attempted_proc_data_date": "1900-01-00T01:00:00",
  "last_successful_proc_data_date": "1900-01-01T01:00:00",
  "last_run_date": "1900-01-01T12:57:01",
  "k": 2,
  "frames_per_query": 100,
  "run_interval_mins": 1,
  "job_type": "cslc_query_hist",
  "collection_short_name": "OPERA_L2_CSLC-S1_V1",
  "provider_name": "ASF",
  "job_queue": "opera-job_worker-cslc_data_query_hist",
  "download_job_queue": "opera-job_worker-cslc_data_download_hist",
  "chunk_size": 1
  }
```
