### PR TITLE
DISP-S1 DEM/Ionosphere Ancillary Input Support

### DIFF
--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -1,20 +1,20 @@
+
+import copy
 import logging
 import os
-from collections import defaultdict
-from pathlib import PurePath, Path
-import copy
-import requests
-import requests.utils
-from more_itertools import partition
 
-import extractor.extract
+from os.path import basename
+from pathlib import PurePath, Path
+
+from data_subscriber import ionosphere_download
 from data_subscriber.asf_rtc_download import AsfDaacRtcDownload
-from data_subscriber.url import _has_url, _to_urls, _to_https_urls, _rtc_url_to_chunk_id
 from util.aws_util import concurrent_s3_client_try_upload_file
 from util.conf_util import SettingsConf
 from util.job_submitter import try_submit_mozart_job
 
-from data_subscriber.cslc_utils import localize_disp_frame_burst_json, split_download_batch_id, get_bounding_box_for_frame
+from data_subscriber.cslc_utils import (localize_disp_frame_burst_json,
+                                        split_download_batch_id,
+                                        get_bounding_box_for_frame)
 
 logger = logging.getLogger(__name__)
 
@@ -30,23 +30,35 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
         settings = SettingsConf().cfg
         product_id = "_".join([batch_id for batch_id in args.batch_ids])
         logger.info(f"{product_id=}")
-        s3paths = []
+        cslc_s3paths = []
+        ionosphere_s3paths = []
 
         new_args = copy.deepcopy(args)
         for batch_id in args.batch_ids:
-            logger.info(f"Downloading batch {batch_id}")
+            logger.info(f"Downloading CSLC files for batch {batch_id}")
             new_args.batch_ids = [batch_id]
+
             # First, download the files from ASF
             product_to_filepaths: dict[str, set[Path]] = await super().run_download(new_args, token, es_conn,
-                                                                                                netloc, username, password,
-                                                                                                job_id,
-                                                                                                rm_downloads_dir=False)
+                                                                                    netloc, username, password,
+                                                                                    job_id, rm_downloads_dir=False)
 
             logger.info(f"Uploading CSLC input files to S3")
-            files_to_upload = [fp for fp_set in product_to_filepaths.values() for fp in fp_set]
-            s3paths.extend(concurrent_s3_client_try_upload_file(bucket=settings["DATASET_BUCKET"],
-                                                                      key_prefix=f"tmp/disp_s1/{batch_id}",
-                                                                      files=files_to_upload))
+            cslc_files_to_upload = [fp for fp_set in product_to_filepaths.values() for fp in fp_set]
+            cslc_s3paths.extend(concurrent_s3_client_try_upload_file(bucket=settings["DATASET_BUCKET"],
+                                                                     key_prefix=f"tmp/disp_s1/{batch_id}",
+                                                                     files=cslc_files_to_upload))
+
+            # Download all Ionosphere files corresponding to the dates covered by the
+            # input CSLC set
+            logger.info(f"Downloading Ionosphere files for {batch_id}")
+            ionosphere_paths = self.download_ionosphere_files_for_cslc_batch(cslc_files_to_upload,
+                                                                             self.downloads_dir)
+
+            logger.info(f"Uploading Ionosphere files to S3")
+            ionosphere_s3paths.extend(concurrent_s3_client_try_upload_file(bucket=settings["DATASET_BUCKET"],
+                                                                           key_prefix=f"tmp/disp_s1/{batch_id}",
+                                                                           files=ionosphere_paths))
 
             # Delete the files from the file system after uploading to S3
             if rm_downloads_dir:
@@ -54,6 +66,9 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
                 for fp_set in product_to_filepaths.values():
                     for fp in fp_set:
                         os.remove(fp)
+
+                for iono_file in ionosphere_paths:
+                    os.remove(iono_file)
 
         # Compute bounding box for frame. All batches should have the same frame_id so we pick the first one
         frame_id, _ = split_download_batch_id(args.batch_ids[0])
@@ -72,7 +87,10 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
                 "metadata": {
                     "batch_id": product_id,
                     "frame_id": frame_id, # frame_id should be same for all download batches
-                    "product_paths": {"L2_CSLC_S1": s3paths},
+                    "product_paths": {
+                        "L2_CSLC_S1": cslc_s3paths,
+                        "IONOSPHERE_TEC": ionosphere_s3paths
+                    },
                     "FileName": product_id,
                     "id": product_id,
                     "bounding_box": bounding_box,
@@ -84,7 +102,7 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
                             "id": PurePath(s3path).name,
                             "product_paths": "$.product_paths"
                         }
-                        for s3path in s3paths
+                        for s3path in cslc_s3paths + ionosphere_s3paths
                     ]
                 }
             }
@@ -105,7 +123,6 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
         )
 
     def get_downloads(self, args, es_conn):
-
         # For CSLC download, the batch_ids are globally unique so there's no need to query for dates
         all_downloads = []
         for batch_id in args.batch_ids:
@@ -114,6 +131,34 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
             all_downloads.extend(downloads)
 
         return all_downloads
+
+    def download_ionosphere_files_for_cslc_batch(self, cslc_files, download_dir):
+        # Reduce the provided CSLC paths to just the filenames
+        cslc_files = list(map(lambda path: basename(path), cslc_files))
+
+        downloaded_ionosphere_dates = set()
+        downloaded_ionosphere_files = set()
+
+        for cslc_file in cslc_files:
+            logger.info(f'Downloading Ionosphere file for CSLC granule {cslc_file}')
+
+            cslc_file_tokens = cslc_file.split('_')
+            acq_datetime = cslc_file_tokens[4]
+            acq_date = acq_datetime.split('T')[0]
+
+            logger.debug(f'{acq_date=}')
+
+            if acq_date not in downloaded_ionosphere_dates:
+                ionosphere_filepath = ionosphere_download.download_ionosphere_correction_file(
+                    dataset_dir=download_dir, product_filepath=cslc_file
+                )
+
+                downloaded_ionosphere_dates.add(acq_date)
+                downloaded_ionosphere_files.add(ionosphere_filepath)
+            else:
+                logger.info(f'Already downloaded Ionosphere file for date {acq_date}, skipping...')
+
+        return downloaded_ionosphere_files
 
     def create_job_params(self, product):
         return [

--- a/data_subscriber/asf_download.py
+++ b/data_subscriber/asf_download.py
@@ -1,8 +1,7 @@
 import json
 import logging
-import netrc
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 from pathlib import PurePath, Path
 
 import backoff
@@ -11,20 +10,13 @@ import requests.utils
 
 from data_subscriber.download import DaacDownload
 from data_subscriber.url import _has_url, _to_urls, _to_https_urls, _slc_url_to_chunk_id, form_batch_id
-from tools import stage_orbit_file
-from tools.stage_ionosphere_file import IonosphereFileNotFoundException
-from tools.stage_orbit_file import (parse_orbit_time_range_from_safe,
-                                    fatal_code,
-                                    NoQueryResultsException,
-                                    NoSuitableOrbitFileException,
-                                    T_ORBIT,
-                                    ORBIT_PAD)
+from tools.stage_orbit_file import fatal_code
 
 logger = logging.getLogger(__name__)
 
 
 class DaacDownloadAsf(DaacDownload):
-    '''This is practically an abstract class. You should never instantiate this.'''
+    """This is practically an abstract class. You should never instantiate this."""
     def perform_download(self,
             session: requests.Session,
             es_conn,
@@ -84,8 +76,8 @@ class DaacDownloadAsf(DaacDownload):
                 additional_metadata["intersects_north_america"] = True
 
             dataset_dir = self.extract_one_to_one(product, self.cfg, working_dir=Path.cwd(),
-                                             extra_metadata=additional_metadata,
-                                             name_postscript='-r'+str(download['revision_id']))
+                                                  extra_metadata=additional_metadata,
+                                                  name_postscript='-r'+str(download['revision_id']))
 
             self.update_pending_dataset_with_index_name(dataset_dir, '-r'+str(download['revision_id']))
 

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -20,7 +20,7 @@ runconfig:
     amplitude_mean_files: __CHIMERA_VAL__
     static_layers_files: __CHIMERA_VAL__
     #mask_file: __CHIMERA_VAL__  # TODO: need to determine source of (global?) mask
-    #dem_file: __CHIMERA_VAL__  # TODO: need bounding box info from query job
+    dem_file: __CHIMERA_VAL__
     ionosphere_files: __CHIMERA_VAL__
     troposphere_files: __CHIMERA_VAL__
   static_ancillary_file_group:
@@ -41,7 +41,6 @@ runconfig:
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
 preconditions:
-  #- set_sample_product_metadata  # TODO: remove after integration with CSLC query/download job
   - get_product_version
   - get_cnm_version
   - set_daac_product_type
@@ -56,8 +55,8 @@ preconditions:
   - get_disp_s1_static_layers_files
   - get_disp_s1_ionosphere_files
   - get_disp_s1_troposphere_files
+  - get_disp_s1_dem
   # TODO: to be implemented with further releases
-  #- get_disp_s1_dem  # TODO: need bounding box info from query job
   #- get_disp_s1_mask_file  # TODO: need to determine source of (global?) mask
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -38,6 +38,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     GET_DISP_S1_ALGORITHM_PARAMETERS = "get_disp_s1_algorithm_parameters"
 
+    GET_DISP_S1_DEM = "get_disp_s1_dem"
+
     GET_DSWX_HLS_DEM = "get_dswx_hls_dem"
 
     GET_DSWX_S1_DEM = "get_dswx_s1_dem"

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -194,6 +194,59 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_disp_s1_dem(self):
+        """
+        This function downloads a DEM sub-region over the bounding box provided
+        in the input product metadata for a DISP-S1 processing job.
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        # get the working directory
+        working_dir = get_working_dir()
+
+        logger.info("working_dir : {}".format(working_dir))
+
+        # Get the bounding box for the sub-region to select
+        metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
+
+        bbox = metadata.get('bounding_box')
+
+        # Get the s3 location parameters
+        s3_bucket = self._pge_config.get(oc_const.GET_DISP_S1_DEM, {}).get(oc_const.S3_BUCKET)
+        s3_key = self._pge_config.get(oc_const.GET_DISP_S1_DEM, {}).get(oc_const.S3_KEY)
+
+        output_filepath = os.path.join(working_dir, 'dem.vrt')
+
+        # Set up arguments to stage_dem.py
+        # Note that since we provide an argparse.Namespace directly,
+        # all arguments must be specified, even if it's only with a null value
+        args = argparse.Namespace()
+        args.s3_bucket = s3_bucket
+        args.s3_key = s3_key
+        args.outfile = output_filepath
+        args.filepath = None
+        args.bbox = bbox
+        args.tile_code = None
+        args.margin = int(self._settings.get("DISP_S1", {}).get("ANCILLARY_MARGIN", 50))  # KM
+        args.log_level = LogLevels.INFO.value
+
+        logger.info(f'Using margin value of {args.margin} with staged DEM')
+
+        pge_metrics = self.get_opera_ancillary(ancillary_type='DISP-S1 DEM',
+                                               output_filepath=output_filepath,
+                                               staging_func=stage_dem,
+                                               staging_func_args=args)
+
+        write_pge_metrics(os.path.join(working_dir, "pge_metrics.json"), pge_metrics)
+
+        rc_params = {
+            oc_const.DEM_FILE: output_filepath
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def get_disp_s1_frame_id(self):
         """
         Assigns the frame ID to the RunConfig for DISP-S1 PGE jobs.

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -219,14 +219,15 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         """
         Derives the list of S3 paths to the ionosphere files to be used with a
         DISP-S1 job.
-
-        TODO: current a stub, implement once CSLC static layer files are downloaded
-              to s3 by query job.
         """
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 
+        metadata = self._context["product_metadata"]["metadata"]
+
+        ionosphere_paths = metadata["product_paths"].get("IONOSPHERE_TEC", [])
+
         rc_params = {
-            oc_const.IONOSPHERE_FILES: list()
+            oc_const.IONOSPHERE_FILES: ionosphere_paths
         }
 
         logger.info(f"rc_params : {rc_params}")

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -254,11 +254,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 
         metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
-
-        # Currently, DISP frame number is stored as the first part of the "batch" ID
-        batch_id = metadata['batch_id']
-
-        frame_id = batch_id.split('_')[0]
+        frame_id = metadata['frame_id']
 
         rc_params = {
             oc_const.FRAME_ID: frame_id

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -137,7 +137,8 @@ def disp_s1_lineage_metadata(context, work_dir):
         if os.path.isdir(local_input_filepath):
             lineage_metadata.extend(
                 [os.path.join(local_input_filepath, file_name)
-                 for file_name in os.listdir(local_input_filepath)]
+                 for file_name in os.listdir(local_input_filepath)
+                 if file_name.endswith(".h5")]
             )
         else:
             lineage_metadata.append(local_input_filepath)


### PR DESCRIPTION
## Purpose
- This branch integrates support for download and staging of the DEM and Ionosphere ancillary input types with the DISP-S1 PGE workflow
- To resolve the current issue with frame IDs starting with "f", this branch cherry-picks commit 0923975b59af687665040a2156b3de0592fb0d45 from #735. If that branch is merged before this one, I will rebase this branch to ensure there are no conflicts.

## Issues
- Resolves #736 

## Testing
- This branch was tested on a dev cluster by submitting the following command to query/download CSLC-S1 products for a single DISP-S1 job:
```
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query \
    --collection-shortname=OPERA_L2_CSLC-S1_V1 \
    --endpoint=OPS \
    --k=4 \
    --release-version=issue_736_disp_s1_initial_dynamic_ancillary_support \
    --job-queue=opera-job_worker-cslc_data_download \
    --chunk-size=1 \
    --processing-mode=reprocessing \
    --transfer-protocol=auto \
    --native-id=OPERA_L2_CSLC-S1_T093-197858-IW3_20231118T013640Z_20231119T073552Z_S1A_VV_v1.0
```
Note that, while the staging of the new ancillary inputs works as expected, the SAS itself fails due to a bug in the current release.
