### PR TITLE
CSLC-S1 Static Layer Query/Download Support

### DIFF
--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python3
+
 import logging
 import re
 from datetime import datetime, timedelta
+from enum import Enum
 from typing import Iterable
 
 import dateutil.parser
@@ -13,33 +16,68 @@ from tools.ops.cmr_audit.cmr_client import cmr_requests_get, async_cmr_posts
 
 logger = logging.getLogger(__name__)
 
+class Collection(str, Enum):
+    HLSL30 = "HLSL30"
+    HLSS30 = "HLSS30"
+    S1A_SLC = "SENTINEL-1A_SLC"
+    S1B_SLC = "SENTINEL-1B_SLC"
+    RTC_S1_V1 = "OPERA_L2_RTC-S1_V1"
+    CSLC_S1_V1 = "OPERA_L2_CSLC-S1_V1"
+
+class Endpoint(str, Enum):
+    OPS = "OPS"
+    UAT = "UAT"
+
+class Provider(str, Enum):
+    LPCLOUD = "LPCLOUD"
+    ASF = "ASF"
+    ASF_SLC = "ASF-SLC"
+    ASF_RTC = "ASF-RTC"
+    ASF_CSLC = "ASF-CSLC"
+
+class ProductType(str, Enum):
+    HLS = "HLS"
+    SLC = "SLC"
+    RTC = "RTC"
+    CSLC = "CSLC"
+
 CMR_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 COLLECTION_TO_PROVIDER_MAP = {
-    "HLSL30": "LPCLOUD",
-    "HLSS30": "LPCLOUD",
-    "SENTINEL-1A_SLC": "ASF",
-    "SENTINEL-1B_SLC": "ASF",
-    "OPERA_L2_RTC-S1_V1": "ASF",
-    "OPERA_L2_CSLC-S1_V1": "ASF"
+    Collection.HLSL30: Provider.LPCLOUD,
+    Collection.HLSS30: Provider.LPCLOUD,
+    Collection.S1A_SLC: Provider.ASF,
+    Collection.S1B_SLC: Provider.ASF,
+    Collection.RTC_S1_V1: Provider.ASF,
+    Collection.CSLC_S1_V1: Provider.ASF
 }
 
-CMR_COLLECTION_TO_PROVIDER_TYPE_MAP = {
-    "HLSL30": "LPCLOUD",
-    "HLSS30": "LPCLOUD",
-    "SENTINEL-1A_SLC": "ASF",
-    "SENTINEL-1B_SLC": "ASF",
-    "OPERA_L2_RTC-S1_V1": "ASF-RTC",
-    "OPERA_L2_CSLC-S1_V1": "ASF-CSLC"
+COLLECTION_TO_PROVIDER_TYPE_MAP = {
+    Collection.HLSL30: Provider.LPCLOUD,
+    Collection.HLSS30: Provider.LPCLOUD,
+    Collection.S1A_SLC: Provider.ASF,
+    Collection.S1B_SLC: Provider.ASF,
+    Collection.RTC_S1_V1: Provider.ASF_RTC,
+    Collection.CSLC_S1_V1: Provider.ASF_CSLC
 }
 
 COLLECTION_TO_PRODUCT_TYPE_MAP = {
-    "HLSL30": "HLS",
-    "HLSS30": "HLS",
-    "SENTINEL-1A_SLC": "SLC",
-    "SENTINEL-1B_SLC": "SLC",
-    "OPERA_L2_RTC-S1_V1": "RTC",
-    "OPERA_L2_CSLC-S1_V1": "CSLC"
+    Collection.HLSL30: ProductType.HLS,
+    Collection.HLSS30: ProductType.HLS,
+    Collection.S1A_SLC: ProductType.SLC,
+    Collection.S1B_SLC: ProductType.SLC,
+    Collection.RTC_S1_V1: ProductType.RTC,
+    Collection.CSLC_S1_V1: ProductType.CSLC
+}
+
+COLLECTION_TO_EXTENSIONS_FILTER_MAP = {
+    Collection.HLSL30: ["B02.tif", "B03.tif", "B04.tif", "B05.tif", "B06.tif", "B07.tif", "Fmask.tif"],
+    Collection.HLSS30: ["B02.tif", "B03.tif", "B04.tif", "B8A.tif", "B11.tif", "B12.tif", "Fmask.tif"],
+    Collection.S1A_SLC: ["zip"],
+    Collection.S1B_SLC: ["zip"],
+    Collection.RTC_S1_V1: ["tif", "h5"],
+    Collection.CSLC_S1_V1: ["h5"],
+    "DEFAULT": ["tif", "h5"]
 }
 
 
@@ -47,7 +85,7 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
     request_url = f"https://{cmr}/search/granules.umm_json"
     bounding_box = args.bbox
 
-    if args.collection == "SENTINEL-1A_SLC" or args.collection == "SENTINEL-1B_SLC":
+    if args.collection in (Collection.S1A_SLC, Collection.S1B_SLC):
         bound_list = bounding_box.split(",")
 
         # Excludes Antarctica
@@ -64,13 +102,17 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
     }
 
     if args.native_id:
-        if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "RTC":
+        if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
             mgrs = mbc_client.cached_load_mgrs_burst_db(filter_land=True)
             match_native_id = re.match(rtc_granule_regex, args.native_id)
             burst_id = mbc_client.product_burst_id_to_mapping_burst_id(match_native_id.group("burst_id"))
             native_ids = mbc_client.get_reduced_rtc_native_id_patterns(mgrs[mgrs["bursts"].str.contains(burst_id)])
+
             if not native_ids:
-                raise Exception(f"The supplied {args.native_id=} is not associated with any MGRS tile collection")
+                raise Exception(
+                    f"The supplied {args.native_id=} is not associated with any MGRS tile collection"
+                )
+
             params["options[native-id][pattern]"] = 'true'
             params["native-id[]"] = native_ids
         else:
@@ -82,7 +124,8 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
     # derive and apply param "temporal"
     now_date = now.strftime(CMR_TIME_FORMAT)
     temporal_range = _get_temporal_range(timerange.start_date, timerange.end_date, now_date)
-    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "RTC":
+
+    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
         if args.native_id:
             match_native_id = re.match(rtc_granule_regex, args.native_id)
             acquisition_dt = dateutil.parser.parse(match_native_id.group("acquisition_ts"))
@@ -106,20 +149,24 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
 
     if not silent:
         logger.info(f"Querying CMR. {request_url=} {params=}")
+
     product_granules = await _async_request_search_cmr_granules(args, request_url, [params])
     logger.info(f"Found {len(product_granules)} granules")
 
     # Filter out granules with revision-id greater than max allowed
     least_revised_granules = []
+
     for granule in product_granules:
         if granule['revision_id'] <= args.max_revision:
             least_revised_granules.append(granule)
         else:
             logger.warning(
-                f"Granule {granule['granule_id']} currently has revision-id of {granule['revision_id']} "
-                f"which is greater than the max {args.max_revision}. "
-                "Ignoring and not storing or processing this granule."
+                f"Granule {granule['granule_id']} currently has revision-id of "
+                f"{granule['revision_id']} which is greater than the max "
+                f"{args.max_revision}. Ignoring and not storing or processing "
+                f"this granule."
             )
+
     product_granules = least_revised_granules
     logger.info(f"Filtered to {len(product_granules)} granules")
 
@@ -132,7 +179,7 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
     for granule in product_granules:
         granule["filtered_urls"] = _filter_granules(granule, args)
 
-    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "SLC":
+    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.SLC:
         for granule in product_granules:
             granule["filtered_urls"] = _filter_slc_granules(granule)
 
@@ -162,8 +209,8 @@ def response_jsons_to_cmr_granules(args, response_jsons):
              for item in response_json.get("items")]
 
     collection_identifier_map = {
-        "HLSL30": "LANDSAT_PRODUCT_ID",
-        "HLSS30": "PRODUCT_URI"
+        Collection.HLSL30: "LANDSAT_PRODUCT_ID",
+        Collection.HLSS30: "PRODUCT_URI"
     }
 
     granules = []
@@ -199,28 +246,23 @@ def response_jsons_to_cmr_granules(args, response_jsons):
                 if attr.get("Name") == collection_identifier_map[args.collection]
             ) if args.collection in collection_identifier_map else None
         })
+
     return granules
 
 
 def _filter_granules(granule, args):
-    collection_to_extensions_filter_map = {
-        "HLSL30": ["B02.tif", "B03.tif", "B04.tif", "B05.tif", "B06.tif", "B07.tif", "Fmask.tif"],
-        "HLSS30": ["B02.tif", "B03.tif", "B04.tif", "B8A.tif", "B11.tif", "B12.tif", "Fmask.tif"],
-        "SENTINEL-1A_SLC": ["zip"],
-        "SENTINEL-1B_SLC": ["zip"],
-        "OPERA_L2_RTC-S1_V1": ["tif", "h5"],
-        "OPERA_L2_CSLC-S1_V1": ["h5"],
-        "DEFAULT": ["tif"]
-    }
-
-    filter_extension_key = first_true(collection_to_extensions_filter_map.keys(), pred=lambda x: x == args.collection, default="DEFAULT")
+    filter_extension_key = first_true(
+        COLLECTION_TO_EXTENSIONS_FILTER_MAP.keys(),
+        pred=lambda x: x == args.collection, default="DEFAULT"
+    )
 
     return [
         url
         for url in granule.get("related_urls")
-        for extension in collection_to_extensions_filter_map.get(filter_extension_key)
+        for extension in COLLECTION_TO_EXTENSIONS_FILTER_MAP.get(filter_extension_key)
         if url.endswith(extension)
     ]
+
 
 def _filter_slc_granules(granule):
     return [url for url in granule["related_urls"] if "IW" in url]

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -175,13 +175,16 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
             )
 
     product_granules = least_revised_granules
-    logger.info(f"Filtered to {len(product_granules)} granules")
+    logger.info(f"Filtered to {len(product_granules)} granules after least "
+                f"revision check")
 
     if args.collection in settings["SHORTNAME_FILTERS"]:
-        product_granules = [granule for granule in product_granules if _match_identifier(settings, args, granule)]
+        product_granules = [granule for granule in product_granules
+                            if _match_identifier(settings, args, granule)]
 
-    if not silent:
-        logger.info(f"Filtered to {len(product_granules)} total granules")
+        if not silent:
+            logger.info(f"Filtered to {len(product_granules)} total granules "
+                        f"after shortname filter check")
 
     for granule in product_granules:
         granule["filtered_urls"] = _filter_granules(granule, args)

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -47,33 +47,33 @@ class ProductType(str, Enum):
 CMR_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 COLLECTION_TO_PROVIDER_MAP = {
-    Collection.HLSL30: Provider.LPCLOUD,
-    Collection.HLSS30: Provider.LPCLOUD,
-    Collection.S1A_SLC: Provider.ASF,
-    Collection.S1B_SLC: Provider.ASF,
-    Collection.RTC_S1_V1: Provider.ASF,
-    Collection.CSLC_S1_V1: Provider.ASF,
-    Collection.CSLC_S1_STATIC_V1: Provider.ASF
+    Collection.HLSL30: Provider.LPCLOUD.value,
+    Collection.HLSS30: Provider.LPCLOUD.value,
+    Collection.S1A_SLC: Provider.ASF.value,
+    Collection.S1B_SLC: Provider.ASF.value,
+    Collection.RTC_S1_V1: Provider.ASF.value,
+    Collection.CSLC_S1_V1: Provider.ASF.value,
+    Collection.CSLC_S1_STATIC_V1: Provider.ASF.value
 }
 
 COLLECTION_TO_PROVIDER_TYPE_MAP = {
-    Collection.HLSL30: Provider.LPCLOUD,
-    Collection.HLSS30: Provider.LPCLOUD,
-    Collection.S1A_SLC: Provider.ASF,
-    Collection.S1B_SLC: Provider.ASF,
-    Collection.RTC_S1_V1: Provider.ASF_RTC,
-    Collection.CSLC_S1_V1: Provider.ASF_CSLC,
-    Collection.CSLC_S1_STATIC_V1: Provider.ASF_CSLC_STATIC
+    Collection.HLSL30: Provider.LPCLOUD.value,
+    Collection.HLSS30: Provider.LPCLOUD.value,
+    Collection.S1A_SLC: Provider.ASF.value,
+    Collection.S1B_SLC: Provider.ASF.value,
+    Collection.RTC_S1_V1: Provider.ASF_RTC.value,
+    Collection.CSLC_S1_V1: Provider.ASF_CSLC.value,
+    Collection.CSLC_S1_STATIC_V1: Provider.ASF_CSLC_STATIC.value
 }
 
 COLLECTION_TO_PRODUCT_TYPE_MAP = {
-    Collection.HLSL30: ProductType.HLS,
-    Collection.HLSS30: ProductType.HLS,
-    Collection.S1A_SLC: ProductType.SLC,
-    Collection.S1B_SLC: ProductType.SLC,
-    Collection.RTC_S1_V1: ProductType.RTC,
-    Collection.CSLC_S1_V1: ProductType.CSLC,
-    Collection.CSLC_S1_STATIC_V1: ProductType.CSLC_STATIC
+    Collection.HLSL30: ProductType.HLS.value,
+    Collection.HLSS30: ProductType.HLS.value,
+    Collection.S1A_SLC: ProductType.SLC.value,
+    Collection.S1B_SLC: ProductType.SLC.value,
+    Collection.RTC_S1_V1: ProductType.RTC.value,
+    Collection.CSLC_S1_V1: ProductType.CSLC.value,
+    Collection.CSLC_S1_STATIC_V1: ProductType.CSLC_STATIC.value
 }
 
 COLLECTION_TO_EXTENSIONS_FILTER_MAP = {

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -23,6 +23,7 @@ class Collection(str, Enum):
     S1B_SLC = "SENTINEL-1B_SLC"
     RTC_S1_V1 = "OPERA_L2_RTC-S1_V1"
     CSLC_S1_V1 = "OPERA_L2_CSLC-S1_V1"
+    CSLC_S1_STATIC_V1 = "OPERA_L2_CSLC-S1-STATIC_V1"
 
 class Endpoint(str, Enum):
     OPS = "OPS"
@@ -34,12 +35,14 @@ class Provider(str, Enum):
     ASF_SLC = "ASF-SLC"
     ASF_RTC = "ASF-RTC"
     ASF_CSLC = "ASF-CSLC"
+    ASF_CSLC_STATIC = "ASF-CSLC-STATIC"
 
 class ProductType(str, Enum):
     HLS = "HLS"
     SLC = "SLC"
     RTC = "RTC"
     CSLC = "CSLC"
+    CSLC_STATIC = "CSLC_STATIC"
 
 CMR_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
@@ -49,7 +52,8 @@ COLLECTION_TO_PROVIDER_MAP = {
     Collection.S1A_SLC: Provider.ASF,
     Collection.S1B_SLC: Provider.ASF,
     Collection.RTC_S1_V1: Provider.ASF,
-    Collection.CSLC_S1_V1: Provider.ASF
+    Collection.CSLC_S1_V1: Provider.ASF,
+    Collection.CSLC_S1_STATIC_V1: Provider.ASF
 }
 
 COLLECTION_TO_PROVIDER_TYPE_MAP = {
@@ -58,7 +62,8 @@ COLLECTION_TO_PROVIDER_TYPE_MAP = {
     Collection.S1A_SLC: Provider.ASF,
     Collection.S1B_SLC: Provider.ASF,
     Collection.RTC_S1_V1: Provider.ASF_RTC,
-    Collection.CSLC_S1_V1: Provider.ASF_CSLC
+    Collection.CSLC_S1_V1: Provider.ASF_CSLC,
+    Collection.CSLC_S1_STATIC_V1: Provider.ASF_CSLC_STATIC
 }
 
 COLLECTION_TO_PRODUCT_TYPE_MAP = {
@@ -67,7 +72,8 @@ COLLECTION_TO_PRODUCT_TYPE_MAP = {
     Collection.S1A_SLC: ProductType.SLC,
     Collection.S1B_SLC: ProductType.SLC,
     Collection.RTC_S1_V1: ProductType.RTC,
-    Collection.CSLC_S1_V1: ProductType.CSLC
+    Collection.CSLC_S1_V1: ProductType.CSLC,
+    Collection.CSLC_S1_STATIC_V1: ProductType.CSLC_STATIC
 }
 
 COLLECTION_TO_EXTENSIONS_FILTER_MAP = {
@@ -77,6 +83,7 @@ COLLECTION_TO_EXTENSIONS_FILTER_MAP = {
     Collection.S1B_SLC: ["zip"],
     Collection.RTC_S1_V1: ["tif", "h5"],
     Collection.CSLC_S1_V1: ["h5"],
+    Collection.CSLC_S1_STATIC_V1: ["h5"],
     "DEFAULT": ["tif", "h5"]
 }
 

--- a/data_subscriber/cslc/cslc_query.py
+++ b/data_subscriber/cslc/cslc_query.py
@@ -1,15 +1,21 @@
-import logging
-import re
+#!/usr/bin/env python3
+
 import copy
-from datetime import datetime, timedelta
-from data_subscriber.cmr import async_query_cmr, CMR_TIME_FORMAT
-from data_subscriber.cslc_utils import localize_disp_frame_burst_json, localize_disp_frame_burst_hist, build_cslc_native_ids, \
-    parse_cslc_native_id, process_disp_frame_burst_json, process_disp_frame_burst_hist, download_batch_id_forward_reproc, \
-    download_batch_id_hist, split_download_batch_id
-from data_subscriber.query import CmrQuery, DateTimeRange
-from data_subscriber.rtc.rtc_query import MISSION_EPOCH_S1A, MISSION_EPOCH_S1B
-from data_subscriber.url import determine_acquisition_cycle
+import logging
 from collections import defaultdict
+from datetime import datetime, timedelta
+
+from data_subscriber.cmr import async_query_cmr, CMR_TIME_FORMAT
+from data_subscriber.cslc_utils import (localize_disp_frame_burst_json,
+                                        localize_disp_frame_burst_hist,
+                                        build_cslc_native_ids,
+                                        parse_cslc_native_id,
+                                        process_disp_frame_burst_json,
+                                        process_disp_frame_burst_hist,
+                                        download_batch_id_forward_reproc,
+                                        download_batch_id_hist,
+                                        split_download_batch_id)
+from data_subscriber.query import CmrQuery, DateTimeRange
 
 logger = logging.getLogger(__name__)
 

--- a/data_subscriber/cslc/cslc_query.py
+++ b/data_subscriber/cslc/cslc_query.py
@@ -125,7 +125,6 @@ class CslcCmrQuery(CmrQuery):
         for batch_id, download_batch in by_download_batch_id.items():
             submitted = self.es_conn.get_submitted_granules(batch_id)
             if len(submitted) > 0:
-                asdf
                 for download in download_batch.values():
                     download_granules.append(download)
                 for granule in submitted:

--- a/data_subscriber/cslc/cslc_static_catalog.py
+++ b/data_subscriber/cslc/cslc_static_catalog.py
@@ -1,17 +1,14 @@
 import logging
 from datetime import datetime
-from ..hls.hls_catalog import HLSProductCatalog
-from pathlib import Path
-
-from data_subscriber import es_conn_util
+from data_subscriber.hls.hls_catalog import HLSProductCatalog
 
 null_logger = logging.getLogger('dummy')
 null_logger.addHandler(logging.NullHandler())
 null_logger.propagate = False
 
-class SLCProductCatalog(HLSProductCatalog):
+class CSLCStaticProductCatalog(HLSProductCatalog):
     """
-    Class to track products downloaded by daac_data_subscriber.py
+    Class to track CSLC-S1 Static Layer products downloaded by daac_data_subscriber.py
 
     https://github.com/hysds/hysds_commons/blob/develop/hysds_commons/elasticsearch_utils.py
     ElasticsearchUtility methods
@@ -25,15 +22,13 @@ class SLCProductCatalog(HLSProductCatalog):
     """
     def __init__(self, /, logger=None):
         super().__init__(logger=logger)
-        self.ES_INDEX_PATTERNS = "slc_catalog*"
+        self.ES_INDEX_PATTERNS = "cslc_static_catalog*"
 
     def granule_and_revision(self, es_id):
-        '''For S1A_IW_SLC__1SDV_20220601T000522_20220601T000549_043462_05308F_86F3.zip-r5 returns:
-               S1A_IW_SLC__1SDV_20220601T000522_20220601T000549_043462_05308F_86F3-SLC and 5 '''
-        return es_id.split('.zip')[0]+'-SLC', es_id.split('-r')[1]
+        return es_id.split('-r')[0], es_id.split('-r')[1]
 
     def generate_es_index_name(self):
-        return "slc_catalog-{date}".format(date=datetime.utcnow().strftime("%Y.%m"))
+        return "cslc_static_catalog-{date}".format(date=datetime.utcnow().strftime("%Y.%m"))
 
     def filter_query_result(self, query_result):
         return [result['_source'] for result in (query_result or [])]

--- a/data_subscriber/cslc/cslc_static_query.py
+++ b/data_subscriber/cslc/cslc_static_query.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python3
+
+import logging
+
+from data_subscriber.query import CmrQuery
+
+logger = logging.getLogger(__name__)
+
+class CslcStaticCmrQuery(CmrQuery):
+
+    def __init__(self, args, token, es_conn, cmr, job_id, settings):
+        super().__init__(args, token, es_conn, cmr, job_id, settings)

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -50,13 +50,20 @@ logger = logging.getLogger(__name__)
 
 @exec_wrapper
 def main():
+    asyncio.run(run(sys.argv))
+
+
+def configure_logger(args):
+    global logger
+    loglevel = "DEBUG" if args.verbose else "INFO"
+    logging.basicConfig(level=loglevel)
+    logger.info("Log level set to " + loglevel)
+
     logger_hysds_commons = logging.getLogger("hysds_commons")
     logger_hysds_commons.addFilter(NoJobUtilsFilter())
 
     logger_elasticsearch = logging.getLogger("elasticsearch")
     logger_elasticsearch.addFilter(NoBaseFilter())
-
-    asyncio.run(run(sys.argv))
 
 
 async def run(argv: list[str]):
@@ -64,6 +71,7 @@ async def run(argv: list[str]):
     parser = create_parser()
     args = parser.parse_args(argv[1:])
 
+    configure_logger(args)
     validate_args(args)
 
     es_conn = supply_es_conn(args)

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -151,6 +151,8 @@ async def run_download(args, token, es_conn, netloc, username, password, job_id)
         downloader = AsfDaacRtcDownload(provider)
     elif provider == Provider.ASF_CSLC:
         downloader = AsfDaacCslcDownload(provider)
+    elif provider == Provider.ASF_CSLC_STATIC:
+        raise NotImplementedError("Direct download of CSLC-STATIC products is not supported")
     else:
         raise ValueError(f'Unknown product provider "{provider}"')
 

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -19,6 +19,7 @@ from commons.logger import NoJobUtilsFilter, NoBaseFilter
 from data_subscriber.aws_token import supply_token
 from data_subscriber.cmr import Provider, COLLECTION_TO_PROVIDER_TYPE_MAP
 from data_subscriber.cslc.cslc_catalog import CSLCProductCatalog
+from data_subscriber.cslc.cslc_static_catalog import CSLCStaticProductCatalog
 from data_subscriber.download import run_download
 from data_subscriber.hls.hls_catalog_connection import get_hls_catalog_connection
 from data_subscriber.parser import create_parser, validate_args
@@ -230,8 +231,10 @@ def supply_es_conn(args):
         es_conn = RTCProductCatalog(logging.getLogger(__name__))
     elif provider == Provider.ASF_CSLC:
         es_conn = CSLCProductCatalog(logging.getLogger(__name__))
+    elif provider == Provider.ASF_CSLC_STATIC:
+        es_conn = CSLCStaticProductCatalog(logging.getLogger(__name__))
     else:
-        raise AssertionError(f"Unsupported {provider=}")
+        raise ValueError(f'Unsupported provider "{provider}"')
 
     return es_conn
 

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 
-import argparse
 import asyncio
 import logging
 import netrc
@@ -8,7 +7,6 @@ import re
 import sys
 import uuid
 from collections import defaultdict, namedtuple
-from datetime import datetime
 from itertools import chain
 from pathlib import Path
 from urllib.parse import urlparse
@@ -19,14 +17,15 @@ from smart_open import open
 import data_subscriber
 from commons.logger import NoJobUtilsFilter, NoBaseFilter
 from data_subscriber.aws_token import supply_token
-from data_subscriber.cmr import CMR_COLLECTION_TO_PROVIDER_TYPE_MAP, CMR_TIME_FORMAT
+from data_subscriber.cmr import CMR_COLLECTION_TO_PROVIDER_TYPE_MAP
+from data_subscriber.cslc.cslc_catalog import CSLCProductCatalog
 from data_subscriber.download import run_download
 from data_subscriber.hls.hls_catalog_connection import get_hls_catalog_connection
+from data_subscriber.parser import create_parser, validate_args
 from data_subscriber.query import update_url_index, run_query
 from data_subscriber.rtc.rtc_catalog import RTCProductCatalog
 from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.slc.slc_catalog_connection import get_slc_catalog_connection
-from data_subscriber.cslc.cslc_catalog import CSLCProductCatalog
 from data_subscriber.survey import run_survey
 from rtc_utils import rtc_product_file_revision_regex
 from util.aws_util import concurrent_s3_client_try_upload_file
@@ -54,10 +53,8 @@ async def run(argv: list[str]):
     logger.info(f"{argv=}")
     parser = create_parser()
     args = parser.parse_args(argv[1:])
-    try:
-        validate(args)
-    except ValueError as v:
-        raise v
+
+    validate_args(args)
 
     es_conn = supply_es_conn(args)
 
@@ -79,10 +76,13 @@ async def run(argv: list[str]):
     token = supply_token(edl, username, password)
 
     results = {}
+
     if args.subparser_name == "survey":
         await run_survey(args, token, cmr, settings)
+
     if args.subparser_name == "query" or args.subparser_name == "full":
         results["query"] = await run_query(args, token, es_conn, cmr, job_id, settings)
+
     if args.subparser_name == "download" or args.subparser_name == "full":
         netloc = urlparse(f"https://{edl}").netloc
 
@@ -224,270 +224,6 @@ def supply_es_conn(args):
         raise AssertionError(f"Unsupported {provider=}")
 
     return es_conn
-
-
-def create_parser():
-    parser = argparse.ArgumentParser()
-    subparsers = parser.add_subparsers(dest="subparser_name", required=True)
-
-    verbose = {"positionals": ["-v", "--verbose"],
-               "kwargs": {"dest": "verbose",
-                          "action": "store_true",
-                          "help": "Verbose mode."}}
-
-    file = {"positionals": ["-f", "--file"],
-            "kwargs": {"dest": "file",
-                       "help": "Path to file with newline-separated URIs to ingest into data product ES index (to be downloaded later)."}}
-
-    endpoint = {"positionals": ["--endpoint"],
-                "kwargs": {"dest": "endpoint",
-                           "choices": ["OPS", "UAT"],
-                           "default": "OPS",
-                           "help": "Specify DAAC endpoint to use. Defaults to OPS."}}
-
-    provider = {"positionals": ["-p", "--provider"],
-                "kwargs": {"dest": "provider",
-                           "choices": ["LPCLOUD", "ASF", "ASF-SLC", "ASF-RTC", "ASF-CSLC"],
-                           "default": "LPCLOUD",
-                           "help": "Specify a provider for collection search. Default is LPCLOUD."}}
-
-    collection = {
-        "positionals": ["-c", "--collection-shortname"],
-        "kwargs": {
-            "dest": "collection",
-            "choices": [
-                "HLSL30",
-                "HLSS30",
-                "SENTINEL-1A_SLC",
-                "SENTINEL-1B_SLC",
-                "OPERA_L2_RTC-S1_V1",
-                "OPERA_L2_CSLC-S1_V1"
-            ],
-            "required": True,
-            "help": "The collection shortname for which you want to retrieve data."
-        }
-    }
-
-    start_date = {"positionals": ["-s", "--start-date"],
-                  "kwargs": {"dest": "start_date",
-                             "default": None,
-                             "help": "The ISO date time after which data should be retrieved. For Example, "
-                                     "--start-date 2021-01-14T00:00:00Z"}}
-
-    end_date = {"positionals": ["-e", "--end-date"],
-                "kwargs": {"dest": "end_date",
-                           "default": None,
-                           "help": "The ISO date time before which data should be retrieved. For Example, --end-date "
-                                   "2021-01-14T00:00:00Z"}}
-
-    bbox = {"positionals": ["-b", "--bounds"],
-            "kwargs": {"dest": "bbox",
-                       "default": "-180,-90,180,90",
-                       "help": "The bounding rectangle to filter result in. Format is W Longitude,S Latitude,"
-                               "E Longitude,N Latitude without spaces. Due to an issue with parsing arguments, "
-                               "to use this command, please use the -b=\"-180,-90,180,90\" syntax when calling from "
-                               "the command line. Default: \"-180,-90,180,90\"."}}
-
-    minutes = {"positionals": ["-m", "--minutes"],
-               "kwargs": {"dest": "minutes",
-                          "type": int,
-                          "default": 60,
-                          "help": "How far back in time, in minutes, should the script look for data. If running this "
-                                  "script as a cron, this value should be equal to or greater than how often your "
-                                  "cron runs (default: 60 minutes)."}}
-
-    dry_run = {"positionals": ["--dry-run"],
-               "kwargs": {"dest": "dry_run",
-                          "action": "store_true",
-                          "help": "Toggle for skipping physical downloads."}}
-
-    smoke_run = {"positionals": ["--smoke-run"],
-                 "kwargs": {"dest": "smoke_run",
-                            "action": "store_true",
-                            "help": "Toggle for processing a single tile."}}
-
-    no_schedule_download = {"positionals": ["--no-schedule-download"],
-                            "kwargs": {"dest": "no_schedule_download",
-                                       "action": "store_true",
-                                       "help": "Toggle for query only operation (no downloads)."}}
-
-    release_version = {"positionals": ["--release-version"],
-                       "kwargs": {"dest": "release_version",
-                                  "help": "The release version of the download job-spec."}}
-
-    job_queue = {"positionals": ["--job-queue"],
-                 "kwargs": {"dest": "job_queue",
-                            "help": "The queue to use for the scheduled download job."}}
-
-    chunk_size = {"positionals": ["--chunk-size"],
-                  "kwargs": {"dest": "chunk_size",
-                             "type": int,
-                             "help": "chunk-size = 1 means 1 tile per job. chunk-size > 1 means multiple (N) tiles "
-                                     "per job"}}
-    max_revision = {"positionals": ["--max-revision"],
-                  "kwargs": {"dest": "max_revision",
-                             "type": int,
-                             "default": 1000,
-                             "help": "The maximum number of revision-id to process. If the granule's revision-id is higher than this, it is ignored."}}
-
-    batch_ids = {"positionals": ["--batch-ids"],
-                 "kwargs": {"dest": "batch_ids",
-                            "nargs": "*",
-                            "help": "A list of target tile IDs pending download."}}
-
-    use_temporal = {"positionals": ["--use-temporal"],
-                    "kwargs": {"dest": "use_temporal",
-                               "action": "store_true",
-                               "help": "Toggle for using temporal range rather than revision date (range) in the query."}}
-
-    temporal_start_date = {"positionals": ["--temporal-start-date"],
-                           "kwargs": {"dest": "temporal_start_date",
-                                      "default": None,
-                                      "help": "The ISO date time after which data should be retrieved. Only valid when --use-temporal is false/omitted. For Example, "
-                                              "--temporal-start-date 2021-01-14T00:00:00Z"}}
-
-    native_id = {"positionals": ["--native-id"],
-                 "kwargs": {"dest": "native_id",
-                            "help": "The native ID of a single product granule to be queried, overriding other query arguments if present. "
-                                    "The native ID value supports the '*' and '?' wildcards."}}
-
-    k = {"positionals": ["--k"],
-                  "kwargs": {"dest": "k",
-                             "type": int,
-                             "help": "k is used only in DISP-S1 processing."}}
-
-    coverage_percent = {"positionals": ["--coverage-percent"],
-         "kwargs": {"dest": "coverage_percent",
-                    "type": int,
-                    "help": "Used when querying for RTC and CSLC input files."}}
-
-    grace_mins = {"positionals": ["--grace-mins"],
-                        "kwargs": {"dest": "grace_mins",
-                                   "type": int,
-                                   "help": "Used when querying for RTC and CSLC input files."}}
-
-    m = {"positionals": ["--m"],
-         "kwargs": {"dest": "m",
-                    "type": int,
-                    "help": "m is used only in DISP-S1 processing."}}
-
-    proc_mode = {"positionals": ["--processing-mode"],
-               "kwargs": {"dest": "proc_mode",
-                          "default": "forward",
-                          "choices": ["forward", "reprocessing", "historical"],
-                          "help": "Processing mode changes SLC data processing behavior"}}
-
-    include_regions = {"positionals": ["--include-regions"],
-                    "kwargs": {"dest": "include_regions",
-                               "help": "Only process granules whose bounding bbox intersects with the region specified. Comma-separated list. Only applies in Historical processing mode."}}
-
-    exclude_regions = {"positionals": ["--exclude-regions"],
-                    "kwargs": {"dest": "exclude_regions",
-                               "help": "Only process granules whose bounding bbox do not intersect with these regions. Comma-separated list. Only applies in Historical processing mode."}}
-
-    frame_range = {"positionals": ["--frame-range"],
-                       "kwargs": {"dest": "frame_range",
-                                  "help": "Only applies to DISP-S1 processing. Start and stop frame number range, inclusive on both ends."}}
-
-    step_hours = {"positionals": ["--step-hours"],
-                           "kwargs": {"dest": "step_hours",
-                            "default": 1,
-                            "help": "Number of hours to step for each survey iteration"}}
-
-    out_csv = {"positionals": ["--out-csv"],
-                           "kwargs": {"dest": "out_csv",
-                            "default": "cmr_survey.csv",
-                            "help": "Specify name of the output CSV file"}}
-
-    transfer_protocol = {"positionals": ["-x", "--transfer-protocol"],
-               "kwargs": {"dest": "transfer_protocol",
-                          "choices": ["s3", "https", "auto"],
-                          "default": "auto",
-                          "help": "The protocol used for retrieving data, HTTPS or S3 or AUTO, default of auto"}}
-
-    param_dswx_s1_coverage_target = {"positionals": ["--coverage-target"],
-         "kwargs": {"dest": "coverage_target",
-                    "type": int,
-                    "help": "For DSWx-S1 processing."}}
-
-
-    parser_arg_list = [verbose, file]
-    _add_arguments(parser, parser_arg_list)
-
-    survey_parser = subparsers.add_parser("survey")
-    survey_parser_arg_list = [verbose, endpoint, provider, collection, start_date, end_date, bbox, minutes, max_revision,
-                              smoke_run, native_id, frame_range, use_temporal, temporal_start_date, step_hours, out_csv]
-    _add_arguments(survey_parser, survey_parser_arg_list)
-
-    full_parser = subparsers.add_parser("full")
-    full_parser_arg_list = [verbose, endpoint, collection, start_date, end_date, bbox, minutes,
-                            dry_run, smoke_run, no_schedule_download, release_version, job_queue, chunk_size, max_revision,
-                            batch_ids, use_temporal, temporal_start_date, native_id, transfer_protocol,
-                            frame_range, include_regions, exclude_regions, proc_mode, param_dswx_s1_coverage_target]
-    _add_arguments(full_parser, full_parser_arg_list)
-
-    query_parser = subparsers.add_parser("query")
-    query_parser_arg_list = [verbose, endpoint, collection, start_date, end_date, bbox, minutes, k, m, coverage_percent, grace_mins,
-                             dry_run, smoke_run, no_schedule_download, release_version, job_queue, chunk_size, max_revision,
-                             native_id, use_temporal, temporal_start_date, transfer_protocol,
-                             frame_range, include_regions, exclude_regions, proc_mode, param_dswx_s1_coverage_target]
-    _add_arguments(query_parser, query_parser_arg_list)
-
-    download_parser = subparsers.add_parser("download")
-    download_parser_arg_list = [verbose, file, endpoint, dry_run, smoke_run, provider, batch_ids,
-                                start_date, end_date, use_temporal, temporal_start_date, transfer_protocol, release_version]
-    _add_arguments(download_parser, download_parser_arg_list)
-
-    return parser
-
-
-def _add_arguments(parser, arg_list):
-    for argument in arg_list:
-        parser.add_argument(*argument["positionals"], **argument["kwargs"])
-
-
-def validate(args):
-    if hasattr(args, "bbox") and args.bbox:
-        _validate_bounds(args.bbox)
-
-    if hasattr(args, "start_date") and args.start_date:
-        _validate_date(args.start_date, "start")
-
-    if hasattr(args, "end_date") and args.end_date:
-        _validate_date(args.end_date, "end")
-
-    if hasattr(args, "minutes") and args.minutes:
-        _validate_minutes(args.minutes)
-
-
-def _validate_bounds(bbox):
-    bounds = bbox.split(",")
-    value_error = ValueError(
-        f"Error parsing bounds: {bbox}. Format is <W Longitude>,<S Latitude>,<E Longitude>,<N Latitude> without spaces")
-
-    if len(bounds) != 4:
-        raise value_error
-
-    for b in bounds:
-        try:
-            float(b)
-        except ValueError:
-            raise value_error
-
-
-def _validate_date(date, prefix="start"):
-    try:
-        datetime.strptime(date, CMR_TIME_FORMAT)
-    except ValueError:
-        raise ValueError(
-            f"Error parsing {prefix} date: {date}. Format must be like 2021-01-14T00:00:00Z")
-
-
-def _validate_minutes(minutes):
-    try:
-        int(minutes)
-    except ValueError:
-        raise ValueError(f"Error parsing minutes: {minutes}. Number must be an integer.")
 
 
 if __name__ == "__main__":

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import asyncio
+import boto3
 import logging
 import netrc
 import re
@@ -66,6 +67,8 @@ def configure_logger(args):
 
     logger_elasticsearch = logging.getLogger("elasticsearch")
     logger_elasticsearch.addFilter(NoBaseFilter())
+
+    boto3.set_stream_logger(name='botocore.credentials', level=logging.ERROR)
 
 
 async def run(argv: list[str]):

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -13,9 +13,7 @@ import validators
 from cachetools.func import ttl_cache
 
 import extractor.extract
-from data_subscriber.cmr import (Provider,
-                                 COLLECTION_TO_PROVIDER_TYPE_MAP,
-                                 CMR_TIME_FORMAT)
+from data_subscriber.cmr import Provider, CMR_TIME_FORMAT
 from data_subscriber.query import DateTimeRange
 from data_subscriber.url import _to_batch_id, _to_orbit_number
 from util.conf_util import SettingsConf
@@ -48,11 +46,6 @@ class SessionWithHeaderRedirection(requests.Session):
                 del headers["Authorization"]
 
 
-async def run_download(args, token, es_conn, netloc, username, password, job_id):
-    download = DaacDownload.get_download_object(args)
-    await download.run_download(args, token, es_conn, netloc, username, password, job_id)
-
-
 class DaacDownload:
 
     def __init__(self, provider):
@@ -60,26 +53,6 @@ class DaacDownload:
         self.cfg = SettingsConf().cfg  # has metadata extractor config
 
         self.downloads_dir = None
-
-    @staticmethod
-    def get_download_object(args):
-        provider = (COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
-                    if hasattr(args, "collection") else args.provider)
-
-        if provider == Provider.LPCLOUD:
-            from data_subscriber.lpdaac_download import DaacDownloadLpdaac
-            return DaacDownloadLpdaac(provider)
-        elif provider in (Provider.ASF, Provider.ASF_SLC):
-            from data_subscriber.asf_slc_download import AsfDaacSlcDownload
-            return AsfDaacSlcDownload(provider)
-        elif provider == Provider.ASF_RTC:
-            from data_subscriber.asf_rtc_download import AsfDaacRtcDownload
-            return AsfDaacRtcDownload(provider)
-        elif provider == Provider.ASF_CSLC:
-            from data_subscriber.asf_cslc_download import AsfDaacCslcDownload
-            return AsfDaacCslcDownload(provider)
-
-        raise ValueError("Unknown product provider: " + provider)
 
     async def run_download(self, args, token, es_conn, netloc, username, password,
                            job_id, rm_downloads_dir=True):

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -56,11 +56,16 @@ class DaacDownload:
 
     async def run_download(self, args, token, es_conn, netloc, username, password,
                            job_id, rm_downloads_dir=True):
+        product_to_product_filepaths_map = {}
         downloads = self.get_downloads(args, es_conn)
 
         if not downloads:
             logger.info(f"No undownloaded files found in index.")
-            return
+            return product_to_product_filepaths_map
+
+        if args.dry_run:
+            logger.info(f"{args.dry_run=}. Skipping downloads.")
+            return product_to_product_filepaths_map
 
         session = SessionWithHeaderRedirection(username, password, netloc)
 
@@ -69,9 +74,6 @@ class DaacDownload:
         # house all file downloads
         self.downloads_dir = Path("downloads")
         self.downloads_dir.mkdir(exist_ok=True)
-
-        if args.dry_run:
-            logger.info(f"{args.dry_run=}. Skipping downloads.")
 
         product_to_product_filepaths_map = self.perform_download(
             session, es_conn, downloads, args, token, job_id

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -226,7 +226,8 @@ def create_parser():
     full_parser = subparsers.add_parser("full",
                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     full_parser_arg_list = [verbose, endpoint, collection, start_date, end_date,
-                            bbox, minutes, dry_run, smoke_run, no_schedule_download,
+                            bbox, minutes, k, m, coverage_percent, grace_mins,
+                            dry_run, smoke_run, no_schedule_download,
                             release_version, job_queue, chunk_size, max_revision,
                             batch_ids, use_temporal, temporal_start_date, native_id,
                             transfer_protocol, frame_range, include_regions,

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -3,11 +3,13 @@
 import argparse
 from datetime import datetime
 
-from data_subscriber.cmr import CMR_TIME_FORMAT
-
+from data_subscriber.cmr import (Collection,
+                                 Endpoint,
+                                 Provider,
+                                 CMR_TIME_FORMAT)
 
 def create_parser():
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     subparsers = parser.add_subparsers(dest="subparser_name", required=True)
 
     verbose = {"positionals": ["-v", "--verbose"],
@@ -22,30 +24,23 @@ def create_parser():
 
     endpoint = {"positionals": ["--endpoint"],
                 "kwargs": {"dest": "endpoint",
-                           "choices": ["OPS", "UAT"],
-                           "default": "OPS",
-                           "help": "Specify DAAC endpoint to use. Defaults to OPS."}}
+                           "choices": [endpoint.value for endpoint in Endpoint],
+                           "default": Endpoint.OPS.value,
+                           "help": "Specify the DAAC endpoint to use."}}
 
     provider = {"positionals": ["-p", "--provider"],
                 "kwargs": {"dest": "provider",
-                           "choices": ["LPCLOUD", "ASF", "ASF-SLC", "ASF-RTC", "ASF-CSLC"],
-                           "default": "LPCLOUD",
-                           "help": "Specify a provider for collection search. Default is LPCLOUD."}}
+                           "choices": [provider.value for provider in Provider],
+                           "default": Provider.LPCLOUD.value,
+                           "help": "Specify a provider for collection search."}}
 
     collection = {
         "positionals": ["-c", "--collection-shortname"],
         "kwargs": {
             "dest": "collection",
-            "choices": [
-                "HLSL30",
-                "HLSS30",
-                "SENTINEL-1A_SLC",
-                "SENTINEL-1B_SLC",
-                "OPERA_L2_RTC-S1_V1",
-                "OPERA_L2_CSLC-S1_V1"
-            ],
+            "choices": [collection.value for collection in Collection],
             "required": True,
-            "help": "The collection shortname for which you want to retrieve data."
+            "help": "The collection shortname to retrieve data for."
         }
     }
 
@@ -72,7 +67,7 @@ def create_parser():
                                "Due to an issue with parsing arguments, "
                                "to use this command, please use the "
                                "-b=\"-180,-90,180,90\" syntax when calling from "
-                               "the command line. Default: \"-180,-90,180,90\"."}}
+                               "the command line."}}
 
     minutes = {"positionals": ["-m", "--minutes"],
                "kwargs": {"dest": "minutes",
@@ -81,8 +76,7 @@ def create_parser():
                           "help": "How far back in time, in minutes, should the "
                                   "script look for data. If running this "
                                   "script as a cron, this value should be equal "
-                                  "to or greater than how often your "
-                                  "cron runs (default: 60 minutes)."}}
+                                  "to or greater than how often your cron runs."}}
 
     dry_run = {"positionals": ["--dry-run"],
                "kwargs": {"dest": "dry_run",
@@ -198,20 +192,20 @@ def create_parser():
     step_hours = {"positionals": ["--step-hours"],
                            "kwargs": {"dest": "step_hours",
                             "default": 1,
-                            "help": "Number of hours to step for each survey "
-                                    "iteration"}}
+                            "help": "Number of hours to step for each survey iteration."}}
 
     out_csv = {"positionals": ["--out-csv"],
                            "kwargs": {"dest": "out_csv",
                             "default": "cmr_survey.csv",
-                            "help": "Specify name of the output CSV file"}}
+                            "help": "Specify name of the output CSV file."}}
 
     transfer_protocol = {"positionals": ["-x", "--transfer-protocol"],
                "kwargs": {"dest": "transfer_protocol",
                           "choices": ["s3", "https", "auto"],
                           "default": "auto",
+                          "type": str.lower,
                           "help": "The protocol used for retrieving data, "
-                                  "HTTPS or S3 or AUTO, default of auto"}}
+                                  "HTTPS or S3 or AUTO."}}
 
     param_dswx_s1_coverage_target = {"positionals": ["--coverage-target"],
                                      "kwargs": {"dest": "coverage_target",
@@ -221,14 +215,16 @@ def create_parser():
     parser_arg_list = [verbose, file]
     _add_arguments(parser, parser_arg_list)
 
-    survey_parser = subparsers.add_parser("survey")
+    survey_parser = subparsers.add_parser("survey",
+                                          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     survey_parser_arg_list = [verbose, endpoint, provider, collection,
                               start_date, end_date, bbox, minutes, max_revision,
                               smoke_run, native_id, frame_range, use_temporal,
                               temporal_start_date, step_hours, out_csv]
     _add_arguments(survey_parser, survey_parser_arg_list)
 
-    full_parser = subparsers.add_parser("full")
+    full_parser = subparsers.add_parser("full",
+                                        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     full_parser_arg_list = [verbose, endpoint, collection, start_date, end_date,
                             bbox, minutes, dry_run, smoke_run, no_schedule_download,
                             release_version, job_queue, chunk_size, max_revision,
@@ -237,7 +233,8 @@ def create_parser():
                             exclude_regions, proc_mode, param_dswx_s1_coverage_target]
     _add_arguments(full_parser, full_parser_arg_list)
 
-    query_parser = subparsers.add_parser("query")
+    query_parser = subparsers.add_parser("query",
+                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     query_parser_arg_list = [verbose, endpoint, collection, start_date, end_date,
                              bbox, minutes, k, m, coverage_percent, grace_mins,
                              dry_run, smoke_run, no_schedule_download,
@@ -247,7 +244,8 @@ def create_parser():
                              param_dswx_s1_coverage_target]
     _add_arguments(query_parser, query_parser_arg_list)
 
-    download_parser = subparsers.add_parser("download")
+    download_parser = subparsers.add_parser("download",
+                                            formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     download_parser_arg_list = [verbose, file, endpoint, dry_run, smoke_run, provider,
                                 batch_ids, start_date, end_date, use_temporal,
                                 temporal_start_date, transfer_protocol, release_version]

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+
+import argparse
+from datetime import datetime
+
+from data_subscriber.cmr import CMR_TIME_FORMAT
+
+
+def create_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="subparser_name", required=True)
+
+    verbose = {"positionals": ["-v", "--verbose"],
+               "kwargs": {"dest": "verbose",
+                          "action": "store_true",
+                          "help": "Verbose mode."}}
+
+    file = {"positionals": ["-f", "--file"],
+            "kwargs": {"dest": "file",
+                       "help": "Path to file with newline-separated URIs to "
+                               "ingest into data product ES index (to be downloaded later)."}}
+
+    endpoint = {"positionals": ["--endpoint"],
+                "kwargs": {"dest": "endpoint",
+                           "choices": ["OPS", "UAT"],
+                           "default": "OPS",
+                           "help": "Specify DAAC endpoint to use. Defaults to OPS."}}
+
+    provider = {"positionals": ["-p", "--provider"],
+                "kwargs": {"dest": "provider",
+                           "choices": ["LPCLOUD", "ASF", "ASF-SLC", "ASF-RTC", "ASF-CSLC"],
+                           "default": "LPCLOUD",
+                           "help": "Specify a provider for collection search. Default is LPCLOUD."}}
+
+    collection = {
+        "positionals": ["-c", "--collection-shortname"],
+        "kwargs": {
+            "dest": "collection",
+            "choices": [
+                "HLSL30",
+                "HLSS30",
+                "SENTINEL-1A_SLC",
+                "SENTINEL-1B_SLC",
+                "OPERA_L2_RTC-S1_V1",
+                "OPERA_L2_CSLC-S1_V1"
+            ],
+            "required": True,
+            "help": "The collection shortname for which you want to retrieve data."
+        }
+    }
+
+    start_date = {"positionals": ["-s", "--start-date"],
+                  "kwargs": {"dest": "start_date",
+                             "default": None,
+                             "help": "The ISO date time after which data should "
+                                     "be retrieved. For Example, "
+                                     "--start-date 2021-01-14T00:00:00Z"}}
+
+    end_date = {"positionals": ["-e", "--end-date"],
+                "kwargs": {"dest": "end_date",
+                           "default": None,
+                           "help": "The ISO date time before which data should "
+                                   "be retrieved. For Example, --end-date "
+                                   "2021-01-14T00:00:00Z"}}
+
+    bbox = {"positionals": ["-b", "--bounds"],
+            "kwargs": {"dest": "bbox",
+                       "default": "-180,-90,180,90",
+                       "help": "The bounding rectangle to filter result in. "
+                               "Format is W Longitude, S Latitude, "
+                               "E Longitude, N Latitude (without spaces). "
+                               "Due to an issue with parsing arguments, "
+                               "to use this command, please use the "
+                               "-b=\"-180,-90,180,90\" syntax when calling from "
+                               "the command line. Default: \"-180,-90,180,90\"."}}
+
+    minutes = {"positionals": ["-m", "--minutes"],
+               "kwargs": {"dest": "minutes",
+                          "type": int,
+                          "default": 60,
+                          "help": "How far back in time, in minutes, should the "
+                                  "script look for data. If running this "
+                                  "script as a cron, this value should be equal "
+                                  "to or greater than how often your "
+                                  "cron runs (default: 60 minutes)."}}
+
+    dry_run = {"positionals": ["--dry-run"],
+               "kwargs": {"dest": "dry_run",
+                          "action": "store_true",
+                          "help": "Toggle for skipping physical downloads."}}
+
+    smoke_run = {"positionals": ["--smoke-run"],
+                 "kwargs": {"dest": "smoke_run",
+                            "action": "store_true",
+                            "help": "Toggle for processing a single tile."}}
+
+    no_schedule_download = {"positionals": ["--no-schedule-download"],
+                            "kwargs": {"dest": "no_schedule_download",
+                                       "action": "store_true",
+                                       "help": "Toggle for query only operation "
+                                               "(no downloads)."}}
+
+    release_version = {"positionals": ["--release-version"],
+                       "kwargs": {"dest": "release_version",
+                                  "help": "The release version of the download job-spec."}}
+
+    job_queue = {"positionals": ["--job-queue"],
+                 "kwargs": {"dest": "job_queue",
+                            "help": "The queue to use for the scheduled download job."}}
+
+    chunk_size = {"positionals": ["--chunk-size"],
+                  "kwargs": {"dest": "chunk_size",
+                             "type": int,
+                             "help": "chunk-size = 1 means 1 tile per job. "
+                                     "chunk-size > 1 means multiple (N) tiles "
+                                     "per job"}}
+
+    max_revision = {"positionals": ["--max-revision"],
+                  "kwargs": {"dest": "max_revision",
+                             "type": int,
+                             "default": 1000,
+                             "help": "The maximum number of revision-id to process. "
+                                     "If the granule's revision-id is higher "
+                                     "than this, it is ignored."}}
+
+    batch_ids = {"positionals": ["--batch-ids"],
+                 "kwargs": {"dest": "batch_ids",
+                            "nargs": "*",
+                            "help": "A list of target tile IDs pending download."}}
+
+    use_temporal = {"positionals": ["--use-temporal"],
+                    "kwargs": {"dest": "use_temporal",
+                               "action": "store_true",
+                               "help": "Toggle for using temporal range rather "
+                                       "than revision date (range) in the query."}}
+
+    temporal_start_date = {"positionals": ["--temporal-start-date"],
+                           "kwargs": {"dest": "temporal_start_date",
+                                      "default": None,
+                                      "help": "The ISO date time after which data "
+                                              "should be retrieved. Only valid when "
+                                              "--use-temporal is false/omitted. "
+                                              "For Example, --temporal-start-date 2021-01-14T00:00:00Z"}}
+
+    native_id = {"positionals": ["--native-id"],
+                 "kwargs": {"dest": "native_id",
+                            "help": "The native ID of a single product granule to "
+                                    "be queried, overriding other query arguments "
+                                    "if present. The native ID value supports the "
+                                    "'*' and '?' wildcards."}}
+
+    k = {"positionals": ["--k"],
+                  "kwargs": {"dest": "k",
+                             "type": int,
+                             "help": "k is used only in DISP-S1 processing."}}
+
+    coverage_percent = {"positionals": ["--coverage-percent"],
+         "kwargs": {"dest": "coverage_percent",
+                    "type": int,
+                    "help": "Used when querying for RTC and CSLC input files."}}
+
+    grace_mins = {"positionals": ["--grace-mins"],
+                        "kwargs": {"dest": "grace_mins",
+                                   "type": int,
+                                   "help": "Used when querying for RTC and CSLC input files."}}
+
+    m = {"positionals": ["--m"],
+         "kwargs": {"dest": "m",
+                    "type": int,
+                    "help": "m is used only in DISP-S1 processing."}}
+
+    proc_mode = {"positionals": ["--processing-mode"],
+               "kwargs": {"dest": "proc_mode",
+                          "default": "forward",
+                          "choices": ["forward", "reprocessing", "historical"],
+                          "help": "Processing mode changes SLC data processing behavior"}}
+
+    include_regions = {"positionals": ["--include-regions"],
+                    "kwargs": {"dest": "include_regions",
+                               "help": "Only process granules whose bounding bbox "
+                                       "intersects with the region specified. "
+                                       "Comma-separated list. Only applies in "
+                                       "Historical processing mode."}}
+
+    exclude_regions = {"positionals": ["--exclude-regions"],
+                    "kwargs": {"dest": "exclude_regions",
+                               "help": "Only process granules whose bounding bbox "
+                                       "do not intersect with these regions. "
+                                       "Comma-separated list. Only applies in "
+                                       "Historical processing mode."}}
+
+    frame_range = {"positionals": ["--frame-range"],
+                       "kwargs": {"dest": "frame_range",
+                                  "help": "Only applies to DISP-S1 processing. "
+                                          "Start and stop frame number range, "
+                                          "inclusive on both ends."}}
+
+    step_hours = {"positionals": ["--step-hours"],
+                           "kwargs": {"dest": "step_hours",
+                            "default": 1,
+                            "help": "Number of hours to step for each survey "
+                                    "iteration"}}
+
+    out_csv = {"positionals": ["--out-csv"],
+                           "kwargs": {"dest": "out_csv",
+                            "default": "cmr_survey.csv",
+                            "help": "Specify name of the output CSV file"}}
+
+    transfer_protocol = {"positionals": ["-x", "--transfer-protocol"],
+               "kwargs": {"dest": "transfer_protocol",
+                          "choices": ["s3", "https", "auto"],
+                          "default": "auto",
+                          "help": "The protocol used for retrieving data, "
+                                  "HTTPS or S3 or AUTO, default of auto"}}
+
+    param_dswx_s1_coverage_target = {"positionals": ["--coverage-target"],
+                                     "kwargs": {"dest": "coverage_target",
+                                                "type": int,
+                                                "help": "For DSWx-S1 processing."}}
+
+    parser_arg_list = [verbose, file]
+    _add_arguments(parser, parser_arg_list)
+
+    survey_parser = subparsers.add_parser("survey")
+    survey_parser_arg_list = [verbose, endpoint, provider, collection,
+                              start_date, end_date, bbox, minutes, max_revision,
+                              smoke_run, native_id, frame_range, use_temporal,
+                              temporal_start_date, step_hours, out_csv]
+    _add_arguments(survey_parser, survey_parser_arg_list)
+
+    full_parser = subparsers.add_parser("full")
+    full_parser_arg_list = [verbose, endpoint, collection, start_date, end_date,
+                            bbox, minutes, dry_run, smoke_run, no_schedule_download,
+                            release_version, job_queue, chunk_size, max_revision,
+                            batch_ids, use_temporal, temporal_start_date, native_id,
+                            transfer_protocol, frame_range, include_regions,
+                            exclude_regions, proc_mode, param_dswx_s1_coverage_target]
+    _add_arguments(full_parser, full_parser_arg_list)
+
+    query_parser = subparsers.add_parser("query")
+    query_parser_arg_list = [verbose, endpoint, collection, start_date, end_date,
+                             bbox, minutes, k, m, coverage_percent, grace_mins,
+                             dry_run, smoke_run, no_schedule_download,
+                             release_version, job_queue, chunk_size, max_revision,
+                             native_id, use_temporal, temporal_start_date, transfer_protocol,
+                             frame_range, include_regions, exclude_regions, proc_mode,
+                             param_dswx_s1_coverage_target]
+    _add_arguments(query_parser, query_parser_arg_list)
+
+    download_parser = subparsers.add_parser("download")
+    download_parser_arg_list = [verbose, file, endpoint, dry_run, smoke_run, provider,
+                                batch_ids, start_date, end_date, use_temporal,
+                                temporal_start_date, transfer_protocol, release_version]
+    _add_arguments(download_parser, download_parser_arg_list)
+
+    return parser
+
+
+def _add_arguments(parser, arg_list):
+    for argument in arg_list:
+        parser.add_argument(*argument["positionals"], **argument["kwargs"])
+
+
+def validate_args(args):
+    if hasattr(args, "bbox") and args.bbox:
+        _validate_bounds(args.bbox)
+
+    if hasattr(args, "start_date") and args.start_date:
+        _validate_date(args.start_date, "start")
+
+    if hasattr(args, "end_date") and args.end_date:
+        _validate_date(args.end_date, "end")
+
+    if hasattr(args, "minutes") and args.minutes:
+        _validate_minutes(args.minutes)
+
+
+def _validate_bounds(bbox):
+    bounds = bbox.split(",")
+    value_error = ValueError(
+        f"Error parsing bounds: {bbox}. "
+        f"Format is <W Longitude>,<S Latitude>,<E Longitude>,<N Latitude> without spaces"
+    )
+
+    if len(bounds) != 4:
+        raise value_error
+
+    for b in bounds:
+        try:
+            float(b)
+        except ValueError:
+            raise value_error
+
+
+def _validate_date(date, prefix="start"):
+    try:
+        datetime.strptime(date, CMR_TIME_FORMAT)
+    except ValueError:
+        raise ValueError(
+            f"Error parsing {prefix} date: {date}. "
+            f"Format must be like 2021-01-14T00:00:00Z")
+
+
+def _validate_minutes(minutes):
+    try:
+        int(minutes)
+    except ValueError:
+        raise ValueError(f"Error parsing minutes: {minutes}. "
+                         f"Number must be an integer.")

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -77,10 +77,16 @@ class CmrQuery:
         if args.subparser_name == "full":
             logger.info(
                 f"{args.subparser_name=}. Skipping download job submission. Download will be performed directly.")
+
             if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
                 args.provider = COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
                 args.batch_ids = self.affected_mgrs_set_id_acquisition_ts_cycle_indexes
-            return
+            elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.CSLC:
+                args.provider = COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
+                args.chunk_size = args.k
+                args.batch_ids = list(set(granule["download_batch_id"] for granule in download_granules))
+
+            return {"download_granules": download_granules}
 
         if args.no_schedule_download:
             logger.info(f"{args.no_schedule_download=}. Forcefully skipping download job submission.")

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -5,17 +5,19 @@ from collections import namedtuple, defaultdict
 from datetime import datetime, timedelta
 from functools import partial
 from pathlib import Path
-from typing import Literal
 
 import dateutil.parser
-from hysds_commons.job_utils import submit_mozart_job
 from more_itertools import chunked
 
-from data_subscriber.cmr import COLLECTION_TO_PRODUCT_TYPE_MAP, async_query_cmr, CMR_COLLECTION_TO_PROVIDER_TYPE_MAP
+from data_subscriber.cmr import (async_query_cmr,
+                                 ProductType,
+                                 COLLECTION_TO_PRODUCT_TYPE_MAP,
+                                 COLLECTION_TO_PROVIDER_TYPE_MAP)
 from data_subscriber.geojson_utils import localize_include_exclude, filter_granules_by_regions, download_from_s3
 from data_subscriber.hls.hls_catalog import HLSProductCatalog
 from data_subscriber.rtc.rtc_download_job_submitter import submit_rtc_download_job_submissions_tasks
 from data_subscriber.url import form_batch_id, _slc_url_to_chunk_id
+from hysds_commons.job_utils import submit_mozart_job
 from util.conf_util import SettingsConf
 
 logger = logging.getLogger(__name__)
@@ -23,20 +25,23 @@ logger = logging.getLogger(__name__)
 DateTimeRange = namedtuple("DateTimeRange", ["start_date", "end_date"])
 
 async def run_query(args, token, es_conn: HLSProductCatalog, cmr, job_id, settings):
-    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "HLS":
+    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.HLS:
         from data_subscriber.hls.hls_query import HlsCmrQuery
         cmr_query = HlsCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "SLC":
+    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.SLC:
         from data_subscriber.slc.slc_query import SlcCmrQuery
         cmr_query = SlcCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "RTC":
+    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
         from data_subscriber.rtc.rtc_query import RtcCmrQuery
         cmr_query = RtcCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "CSLC":
+    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.CSLC:
         from data_subscriber.cslc.cslc_query import CslcCmrQuery
         cmr_query = CslcCmrQuery(args, token, es_conn, cmr, job_id, settings)
+    else:
+        raise ValueError(f'Unknown collection type "{args.collection}" provided')
 
     result = await cmr_query.run_query(args, token, es_conn, cmr, job_id, settings)
+
     return result
 
 class CmrQuery:
@@ -87,8 +92,8 @@ class CmrQuery:
         if args.subparser_name == "full":
             logger.info(
                 f"{args.subparser_name=}. Skipping download job submission. Download will be performed directly.")
-            if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "RTC":
-                args.provider = CMR_COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
+            if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
+                args.provider = COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
                 args.batch_ids = self.affected_mgrs_set_id_acquisition_ts_cycle_indexes
             return
         if args.no_schedule_download:
@@ -98,7 +103,7 @@ class CmrQuery:
             logger.info(f"{args.chunk_size=}. Insufficient chunk size. Skipping download job submission.")
             return
 
-        if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == "RTC":
+        if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
             job_submission_tasks = submit_rtc_download_job_submissions_tasks(batch_id_to_products_map.keys(), args)
         else:
             job_submission_tasks = self.download_job_submission_handler(download_granules, query_timerange)
@@ -139,7 +144,6 @@ class CmrQuery:
         return granules
 
     def prepare_additional_fields(self, granule, args, granule_id):
-
         additional_fields = {}
         additional_fields["revision_id"] = granule.get("revision_id")
         additional_fields["processing_mode"] = args.proc_mode
@@ -185,30 +189,33 @@ class CmrQuery:
 
             if granule.get("filtered_urls"):
                 # group URLs by this mapping func. E.g. group URLs by granule_id
-                if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "HLS":
+                if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.HLS:
                     url_grouping_func = form_batch_id
-                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "SLC":
+                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.SLC:
                     url_grouping_func = _slc_url_to_chunk_id
-                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "RTC":
+                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.RTC:
                     pass
-                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "CSLC":
+                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.CSLC:
                     # For CSLC force chunk_size to be the same as k in args
                     if self.args.k:
                         self.args.chunk_size = self.args.k
                 else:
-                    raise AssertionError(f"Can't use {self.args.collection=} to select grouping function.")
+                    raise ValueError(f"Can't use {self.args.collection=} to select grouping function.")
 
                 #print("&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&&", granule["download_batch_id"])
                 for filter_url in granule.get("filtered_urls"):
-                    if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "CSLC":
+                    if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.CSLC:
                         batch_id_to_urls_map[granule["download_batch_id"]].add(filter_url)
                     else:
                         batch_id_to_urls_map[url_grouping_func(granule_id, revision_id)].add(filter_url)
+
         logger.debug(f"{batch_id_to_urls_map=}")
-        if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == "RTC":
+
+        if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.RTC:
             raise NotImplementedError()
         else:
             job_submission_tasks = self.submit_download_job_submissions_tasks(batch_id_to_urls_map, query_timerange)
+
         return job_submission_tasks
 
     def get_download_chunks(self, batch_id_to_urls_map):
@@ -306,7 +313,7 @@ class CmrQuery:
         return download_job_params
 
 
-def submit_download_job(*, release_version=None, product_type: Literal["HLS", "SLC", "RTC", "CSLC"], params: list[dict[str, str]], job_queue: str) -> str:
+def submit_download_job(*, release_version=None, product_type: ProductType, params: list[dict[str, str]], job_queue: str) -> str:
     job_spec_str = f"job-{product_type.lower()}_download:{release_version}"
 
     return _submit_mozart_job_minimal(
@@ -316,7 +323,7 @@ def submit_download_job(*, release_version=None, product_type: Literal["HLS", "S
             "job-specification": job_spec_str
         },
         job_queue=job_queue,
-        provider_str=product_type.lower()
+        provider_str=product_type.value.lower()
     )
 
 

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -15,16 +15,11 @@ from data_subscriber.cmr import (async_query_cmr,
                                  ProductType,
                                  COLLECTION_TO_PRODUCT_TYPE_MAP,
                                  COLLECTION_TO_PROVIDER_TYPE_MAP)
-from data_subscriber.cslc.cslc_query import CslcCmrQuery
-from data_subscriber.cslc.cslc_static_query import CslcStaticCmrQuery
 from data_subscriber.geojson_utils import (localize_include_exclude,
                                            filter_granules_by_regions,
                                            download_from_s3)
 from data_subscriber.hls.hls_catalog import HLSProductCatalog
-from data_subscriber.hls.hls_query import HlsCmrQuery
 from data_subscriber.rtc.rtc_download_job_submitter import submit_rtc_download_job_submissions_tasks
-from data_subscriber.rtc.rtc_query import RtcCmrQuery
-from data_subscriber.slc.slc_query import SlcCmrQuery
 from data_subscriber.url import form_batch_id, _slc_url_to_chunk_id
 from hysds_commons.job_utils import submit_mozart_job
 from util.conf_util import SettingsConf
@@ -33,23 +28,6 @@ logger = logging.getLogger(__name__)
 
 DateTimeRange = namedtuple("DateTimeRange", ["start_date", "end_date"])
 
-async def run_query(args, token, es_conn: HLSProductCatalog, cmr, job_id, settings):
-    if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.HLS:
-        cmr_query = HlsCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.SLC:
-        cmr_query = SlcCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
-        cmr_query = RtcCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.CSLC:
-        cmr_query = CslcCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.CSLC_STATIC:
-        cmr_query = CslcStaticCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    else:
-        raise ValueError(f'Unknown collection type "{args.collection}" provided')
-
-    result = await cmr_query.run_query(args, token, es_conn, cmr, job_id, settings)
-
-    return result
 
 class CmrQuery:
     def __init__(self, args, token, es_conn, cmr, job_id, settings):

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import asyncio
 import logging
 import uuid
@@ -13,9 +15,16 @@ from data_subscriber.cmr import (async_query_cmr,
                                  ProductType,
                                  COLLECTION_TO_PRODUCT_TYPE_MAP,
                                  COLLECTION_TO_PROVIDER_TYPE_MAP)
-from data_subscriber.geojson_utils import localize_include_exclude, filter_granules_by_regions, download_from_s3
+from data_subscriber.cslc.cslc_query import CslcCmrQuery
+from data_subscriber.cslc.cslc_static_query import CslcStaticCmrQuery
+from data_subscriber.geojson_utils import (localize_include_exclude,
+                                           filter_granules_by_regions,
+                                           download_from_s3)
 from data_subscriber.hls.hls_catalog import HLSProductCatalog
+from data_subscriber.hls.hls_query import HlsCmrQuery
 from data_subscriber.rtc.rtc_download_job_submitter import submit_rtc_download_job_submissions_tasks
+from data_subscriber.rtc.rtc_query import RtcCmrQuery
+from data_subscriber.slc.slc_query import SlcCmrQuery
 from data_subscriber.url import form_batch_id, _slc_url_to_chunk_id
 from hysds_commons.job_utils import submit_mozart_job
 from util.conf_util import SettingsConf
@@ -26,17 +35,15 @@ DateTimeRange = namedtuple("DateTimeRange", ["start_date", "end_date"])
 
 async def run_query(args, token, es_conn: HLSProductCatalog, cmr, job_id, settings):
     if COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.HLS:
-        from data_subscriber.hls.hls_query import HlsCmrQuery
         cmr_query = HlsCmrQuery(args, token, es_conn, cmr, job_id, settings)
     elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.SLC:
-        from data_subscriber.slc.slc_query import SlcCmrQuery
         cmr_query = SlcCmrQuery(args, token, es_conn, cmr, job_id, settings)
     elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.RTC:
-        from data_subscriber.rtc.rtc_query import RtcCmrQuery
         cmr_query = RtcCmrQuery(args, token, es_conn, cmr, job_id, settings)
     elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.CSLC:
-        from data_subscriber.cslc.cslc_query import CslcCmrQuery
         cmr_query = CslcCmrQuery(args, token, es_conn, cmr, job_id, settings)
+    elif COLLECTION_TO_PRODUCT_TYPE_MAP[args.collection] == ProductType.CSLC_STATIC:
+        cmr_query = CslcStaticCmrQuery(args, token, es_conn, cmr, job_id, settings)
     else:
         raise ValueError(f'Unknown collection type "{args.collection}" provided')
 
@@ -199,6 +206,8 @@ class CmrQuery:
                     # For CSLC force chunk_size to be the same as k in args
                     if self.args.k:
                         self.args.chunk_size = self.args.k
+                elif COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.CSLC_STATIC:
+                    url_grouping_func = form_batch_id
                 else:
                     raise ValueError(f"Can't use {self.args.collection=} to select grouping function.")
 

--- a/data_subscriber/rtc/rtc_query.py
+++ b/data_subscriber/rtc/rtc_query.py
@@ -11,7 +11,7 @@ from pathlib import Path
 import dateutil.parser
 from more_itertools import first, last
 
-from data_subscriber.cmr import async_query_cmr, CMR_COLLECTION_TO_PROVIDER_TYPE_MAP
+from data_subscriber.cmr import async_query_cmr, COLLECTION_TO_PROVIDER_TYPE_MAP
 from data_subscriber.geojson_utils import localize_include_exclude, filter_granules_by_regions
 from data_subscriber.query import CmrQuery
 from data_subscriber.rtc import mgrs_bursts_collection_db_client as mbc_client, evaluator
@@ -155,7 +155,7 @@ class RtcCmrQuery(CmrQuery):
 
         if args.subparser_name == "full":
             logger.info(f"{args.subparser_name=}. Skipping download job submission. Download will be performed directly.")
-            args.provider = CMR_COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
+            args.provider = COLLECTION_TO_PROVIDER_TYPE_MAP[args.collection]
             args.batch_ids = affected_mgrs_set_id_acquisition_ts_cycle_indexes
             return
         if args.no_schedule_download:

--- a/tests/data_subscriber/test_cslc_query.py
+++ b/tests/data_subscriber/test_cslc_query.py
@@ -1,17 +1,16 @@
-import random
-from datetime import datetime
-from pathlib import Path
+#!/usr/bin/env python3
 
 import pytest
 
-from data_subscriber import daac_data_subscriber, query, cslc_utils
+from data_subscriber import cslc_utils
+from data_subscriber.parser import create_parser
 from data_subscriber.cslc import cslc_query
 
 forward_arguments = ["query", "-c", "OPERA_L2_CSLC-S1_V1", "--processing-mode=forward", "--start-date=2021-01-24T23:00:00Z", "--end-date=2021-01-25T00:00:00Z"]
-forward_args = daac_data_subscriber.create_parser().parse_args(forward_arguments)
+forward_args = create_parser().parse_args(forward_arguments)
 
 hist_arguments = ["query", "-c", "OPERA_L2_CSLC-S1_V1", "--processing-mode=historical", "--start-date=2021-01-24T23:00:00Z", "--end-date=2021-01-24T23:00:00Z", "--frame-range=100,101"]
-hist_args = daac_data_subscriber.create_parser().parse_args(hist_arguments)
+hist_args = create_parser().parse_args(hist_arguments)
 
 disp_burst_map, burst_to_frame, metadata, version = cslc_utils.process_disp_frame_burst_json(cslc_utils.DISP_FRAME_BURST_MAP_JSON)
 disp_burst_map_hist = cslc_utils.process_disp_frame_burst_hist(cslc_utils.DISP_FRAME_BURST_MAP_HIST)

--- a/tests/scenarios/cslc_query_test.py
+++ b/tests/scenarios/cslc_query_test.py
@@ -1,18 +1,19 @@
-import random
+#!/usr/bin/env python3
+
 import asyncio
-import sys
 import json
-from time import sleep
-from datetime import datetime, timedelta
 import logging
-from pathlib import Path
 import netrc
-from util.conf_util import SettingsConf
-from data_subscriber.cslc.cslc_catalog import CSLCProductCatalog
-from data_subscriber import daac_data_subscriber, query, cslc_utils
-from data_subscriber.cslc import cslc_query
+import sys
+from datetime import datetime, timedelta
+
+from data_subscriber import cslc_utils
 from data_subscriber.aws_token import supply_token
 from data_subscriber.cmr import CMR_TIME_FORMAT
+from data_subscriber.cslc import cslc_query
+from data_subscriber.cslc.cslc_catalog import CSLCProductCatalog
+from data_subscriber.parser import create_parser
+from util.conf_util import SettingsConf
 
 DT_FORMAT = CMR_TIME_FORMAT
 
@@ -23,7 +24,7 @@ Set ASG Max of cslc_download worker to 0 to prevent it from running if that's de
 
 # k comes from the input json file. We could parameterize other argments too if desired.
 query_arguments = ["query", "-c", "OPERA_L2_CSLC-S1_V1", "--chunk-size=1"]#, "--no-schedule-download"]
-base_args = daac_data_subscriber.create_parser().parse_args(query_arguments)
+base_args = create_parser().parse_args(query_arguments)
 settings = SettingsConf().cfg
 cmr = settings["DAAC_ENVIRONMENTS"][base_args.endpoint]["BASE_URL"]
 edl = settings["DAAC_ENVIRONMENTS"][base_args.endpoint]["EARTHDATA_LOGIN"]
@@ -105,7 +106,7 @@ async def run_query(validation_json):
 
 async def query_and_validate(current_args, test_range, validation_data):
     print("Querying with args: " + " ".join(current_args))
-    args = daac_data_subscriber.create_parser().parse_args(current_args)
+    args = create_parser().parse_args(current_args)
     c_query = cslc_query.CslcCmrQuery(args, token, es_conn, cmr, "job_id", settings,
                                       cslc_utils.DISP_FRAME_BURST_MAP_JSON)
     q_result = await c_query.run_query(args, token, es_conn, cmr, "job_id", settings)

--- a/util/conf_util.py
+++ b/util/conf_util.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 from __future__ import absolute_import
-from builtins import object
+
+import json
+import logging
 import os
 import re
-import json
+from builtins import object
 from typing import Optional
 
 import yaml
-import logging
 
 # Ignore if import fails. Some of our test scripts leverage other classes that are found in this file where yamale
 # isn't needed. Furthermore, yamale is not installed as part of HySDS Core.
@@ -50,8 +51,8 @@ class YamlConf(object):
 
         :param file: filepath to the YAML file.
         """
+        logger.debug("Loading YAML file: {}".format(file))
 
-        logger.info("file: {}".format(file))
         self._file = file
         with open(self._file) as f:
             self._cfg = yaml.safe_load(f)

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -98,7 +98,13 @@ def run_pipeline(job_json_dict: Dict, work_dir: str) -> List[Union[bytes, str]]:
 
     logger.info("Moving input files to input directories.")
     for local_input_filepath in lineage_metadata:
-        shutil.move(local_input_filepath, input_dir)
+        try:
+            shutil.move(local_input_filepath, input_dir)
+        except shutil.Error as err:
+            logger.warning(
+                f"Failed to move {local_input_filepath} to {input_dir}, "
+                f"reason: {str(err)}"
+            )
 
     if pge_name in runconfig_update_functions:
         logger.info("Updating run config for use with PGE.")


### PR DESCRIPTION
## Purpose
- This branch updates the daac_data_subscriber tool to support query and download of CSLC-S1 Static Layer products for use with the DISP-S1 workflow.
- Query of CSLC-S1 Static Layer products works as normal from the command line, just use "OPERA_L2_CSLC-S1-STATIC_V1" as the collection name.
- Download of static layer products is **not** currently supported via the command line. Static layer products are only downloaded as part of the standard CSLC-S1 product download workflow.

## Proposed Changes
- This branch also adds a significant amount of cleanup, refactoring and bug fixes to the data subscriber.
  - Argument parsing code has been moved into its own parser.py module to cut down on  SLOC in the main daac_data_subscriber.py script
  - Enumerations for commonly used string constants has been added to cmr.py and use of the new enumerations has been rolled out where appropriate
  - The run_download and run_query factory functions have been moved into daac_data_subscriber.py to fix circular dependency issues with imports
  - Several fixes made so CSLC-S1 query/download works as expected when using the "full" option
  - Several fixes made to cut down on noisy/redundant logging from modules outside of the data subscriber

## Issues
- Resovles #741 

## Testing
- Branch was tested on a dev cluster by using the daac_data_subscriber.py tool to query and download for all available collection types to try to ensure no regressions were introduced. PGE workflows were allowed to run in simulation mode.
