### PR TITLE
DSWx-S1 PGE RC2.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -388,7 +388,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.0"
     "rtc_s1"   = "2.1.0"
-    "dswx_s1"  = "3.0.0-rc.1.0"
+    "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }
 }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -175,7 +175,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.0"
     "rtc_s1"   = "2.1.0"
-    "dswx_s1"  = "3.0.0-rc.1.0"
+    "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }
 }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -389,7 +389,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.0"
     "rtc_s1"   = "2.1.0"
-    "dswx_s1"  = "3.0.0-rc.1.0"
+    "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }
 }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -33,7 +33,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.0"
     "rtc_s1"   = "2.1.0"
-    "dswx_s1"  = "3.0.0-rc.1.0"
+    "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }
 }

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -577,10 +577,10 @@ resource "aws_instance" "mozart" {
       pip install '.[audit]'
       pip install '.[cmr_audit]'
       pip install --progress-bar off -e .
-	  
+
       # For daac_data_subscriber utility tool
       mkdir ~/Downloads/
-      aws s3 cp  s3://opera-ancillaries/MGRS_tile_collection_v0.2.sqlite ~/Downloads/
+      aws s3 cp  s3://opera-ancillaries/mgrs_tiles/dswx_s1/MGRS_tile_collection_v0.3.sqlite ~/Downloads/
     EOT
     ]
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -335,7 +335,7 @@ variable "queues" {
     }
     "opera-job_worker-sciflo-l3_dswx_s1" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_s1"
-      "instance_type"     = ["r6a.large", "r6i.large"]
+      "instance_type"     = ["c5.4xlarge"]
       "root_dev_size"     = 50
       "data_dev_size"     = 100
       "min_size"          = 0

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -553,7 +553,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.0"
     "rtc_s1"   = "2.1.0"
-    "dswx_s1"  = "3.0.0-rc.1.0"
+    "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }
 }

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -34,7 +34,7 @@ DISP_S1_PRODUCT_VERSION: "0.1"
 DSWX_S1_COVERAGE_TARGET: 99
 # Force DSWx-S1 processing of pending burst sets after X minutes, rather than waiting for additional data
 DSWX_S1_COLLECTION_GRACE_PERIOD_MINUTES: 210
-MGRS_TILE_COLLECTION_DB_S3PATH: "s3://opera-ancillaries/MGRS_tile_collection_v0.2.sqlite"
+MGRS_TILE_COLLECTION_DB_S3PATH: "s3://opera-ancillaries/mgrs_tiles/dswx_s1/MGRS_tile_collection_v0.3.sqlite"
 
 # The minimum coverage, defined as the percent of bursts in a bursts set, required to run DISP_S1
 #  Must be a number in the closed interval [0, 99].

--- a/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
+++ b/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
@@ -70,7 +70,7 @@ def load_mgrs_burst_db_raw(filter_land=True) -> GeoDataFrame:
     # vector_gdf = vector_gdf.overlay(na_gdf, how="intersection")
     logger.info(f"{len(vector_gdf)=}")
     if filter_land:
-        vector_gdf = vector_gdf[vector_gdf["land_ocean_flag"] == "water/land"]  # filter out water (water == no relevant data)
+        vector_gdf = vector_gdf[vector_gdf["land_ocean_flag"] in ["water/land", "land"]]   # filter out water (water == no relevant data)
         logger.info(f"{len(vector_gdf)=}")
 
     return vector_gdf

--- a/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
+++ b/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
@@ -54,7 +54,7 @@ def load_mgrs_burst_db(filter_land=True):
 
 def load_mgrs_burst_db_raw(filter_land=True) -> GeoDataFrame:
     """Loads the MGRS Tile Collection Database. On AWS environments, this will localize from a known S3 location."""
-    mtc_local_filepath = Path("~/Downloads/MGRS_tile_collection_v0.2.sqlite").expanduser()
+    mtc_local_filepath = Path("~/Downloads/MGRS_tile_collection_v0.3.sqlite").expanduser()
     if mtc_local_filepath.exists():
         vector_gdf = gpd.read_file(mtc_local_filepath, crs="EPSG:4326")  # , bbox=(-230, 0, -10, 90))  # bbox=(-180, -90, 180, 90)  # global
     else:

--- a/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
+++ b/data_subscriber/rtc/mgrs_bursts_collection_db_client.py
@@ -70,7 +70,7 @@ def load_mgrs_burst_db_raw(filter_land=True) -> GeoDataFrame:
     # vector_gdf = vector_gdf.overlay(na_gdf, how="intersection")
     logger.info(f"{len(vector_gdf)=}")
     if filter_land:
-        vector_gdf = vector_gdf[vector_gdf["land_ocean_flag"] in ["water/land", "land"]]   # filter out water (water == no relevant data)
+        vector_gdf = vector_gdf[vector_gdf["land_ocean_flag"].isin(["water/land", "land"])]  # filter out water (water == no relevant data)
         logger.info(f"{len(vector_gdf)=}")
 
     return vector_gdf

--- a/docker/hysds-io.json.SCIFLO_L2_CSLC_S1
+++ b/docker/hysds-io.json.SCIFLO_L2_CSLC_S1
@@ -72,6 +72,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/hysds-io.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -72,6 +72,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/hysds-io.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -72,6 +72,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/hysds-io.json.SCIFLO_L2_CSLC_S1_hist
@@ -72,6 +72,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L2_RTC_S1
+++ b/docker/hysds-io.json.SCIFLO_L2_RTC_S1
@@ -72,6 +72,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/hysds-io.json.SCIFLO_L2_RTC_S1_STATIC
@@ -72,6 +72,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L3_DISP_S1
+++ b/docker/hysds-io.json.SCIFLO_L3_DISP_S1
@@ -86,6 +86,13 @@
       "default": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/hysds-io.json.SCIFLO_L3_DISP_S1_hist
@@ -86,6 +86,13 @@
       "default": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_HLS
@@ -67,6 +67,13 @@
       "value": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
@@ -91,7 +91,7 @@
       "from": "value",
       "type": "text",
       "value": "/home/dswx_user",
-      "default": "/home/dswx_user"
+      "default": "/home/dswx_user/scratch"
     }
   ]
 }

--- a/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
+++ b/docker/hysds-io.json.SCIFLO_L3_DSWx_S1
@@ -80,6 +80,13 @@
       "default": "pge_output_dir"
     },
     {
+      "name": "pge_scratch_dir",
+      "from": "value",
+      "type": "text",
+      "value": "pge_scratch_dir",
+      "default": "pge_scratch_dir"
+    },
+    {
       "name": "container_home",
       "from": "value",
       "type": "text",

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -80,6 +80,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -76,6 +76,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -76,6 +76,10 @@
       "destination": "context"
     },
     {
+      "name": "pge_scratch_dir",
+      "destination": "context"
+    },
+    {
       "name": "container_home",
       "destination": "context"
     },

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_s1:3.0.0-rc.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0-rc.1.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_s1:3.0.0-rc.2.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0-rc.2.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -27,9 +27,8 @@ runconfig:
     mgrs_collection_database_file: __CHIMERA_VAL__
   product_path_group:
     product_version: __CHIMERA_VAL__
-    product_path: output_dir
-    # Scratch path is defined relative to output_dir to avoid file system permission issues
-    scratch_path: output_dir/scratch_dir
+    product_path: /home/dswx_user/output_dir
+    scratch_path: /home/dswx_user/scratch_dir
   processing:
     algorithm_parameters: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
@@ -43,7 +42,7 @@ preconditions:
   - get_static_ancillary_files
   - get_dswx_s1_dynamic_ancillary_maps
   - get_dswx_s1_dem
-  - get_dswx_s1_inundated_vegetation_enabled
+  - get_dswx_s1_num_workers
   - instantiate_algorithm_parameters_template
   # TODO: enable if shoreline files are needed by DSWx-S1 SAS
   #- get_shoreline_shapefiles
@@ -105,9 +104,9 @@ get_shoreline_shapefiles:
 
 instantiate_algorithm_parameters_template:
   s3_bucket: "opera-ancillaries"
-  s3_key: "algorithm_parameters/dswx_s1/dswx_s1_algorithm_parameters_gamma_0.3.yaml.tmpl"
+  s3_key: "algorithm_parameters/dswx_s1/dswx_s1_algorithm_parameters_calval_0.4.yaml.tmpl"
   template_mapping:
-    inundated_vegetation_enabled: __INUNDATED_VEGETATION_ENABLED__
+    num_workers: __NUMBER_CPU__
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -66,7 +66,7 @@ get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DSWx-S1
   mgrs_database_file:
     s3_bucket: "opera-ancillaries"
-    s3_key: "mgrs_tiles/dswx_s1/MGRS_tile_v0.2.1.sqlite"
+    s3_key: "mgrs_tiles/dswx_s1/MGRS_tile_v0.3.sqlite"
   mgrs_collection_database_file:
     s3_bucket: "opera-ancillaries"
     s3_key: "mgrs_tiles/dswx_s1/MGRS_tile_collection_v0.3.sqlite"

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -131,7 +131,8 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
 
             # set additional files to triage
             self._context["_triage_additional_globs"] = [
-                "output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir"
+                "output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir",
+                "pge_output_dir", "pge_scratch_dir"
             ]
 
             # set force publish (disable no-clobber)

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -616,6 +616,29 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_dswx_s1_num_workers(self):
+        """
+        Determines the number of workers/cores to assign to an DSWx-S1 job as a
+        function of the total available.
+
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        available_cores = os.cpu_count()
+
+        # Use one less than the available cores for standard processing
+        num_workers = max(available_cores - 1, 1)
+
+        logger.info(f"Allocating {num_workers} core(s) out of {available_cores} available")
+
+        rc_params = {
+            "num_workers": num_workers
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def get_gpu_enabled(self):
         logger.info(
             "Calling {} pre-condition function".format(oc_const.GPU_ENABLED))

--- a/tools/ops/README.md
+++ b/tools/ops/README.md
@@ -73,7 +73,7 @@ See `data_subscriber/data_subscriber_client.py --help`, documentation comments, 
 1. Python (see `.python-version`).
 1. A clone of the `opera-sds-pcm` repo.
 1. data_subscriber_client.py requires GDAL to be natively installed on the host machine. Installation instructions vary by operating system, but macOS users with Homebrew installed may install it using `brew install gdal` or as otherwise noted in `setup.py` in the `cmr_audit` dependency section. NOTE: native `gdal` is distinct from the `GDAL` python package dependency.
-1. data_subscriber_client.py requires the MGRS collection DB file to be present in `~/Downloads/MGRS_tile_collection_v0.2.sqlite` This file is found in the ancillary S3 and may also be in the opera-pcm repo.
+1. data_subscriber_client.py requires the latest MGRS collection DB file (currently `MGRS_tile_collection_v0.3.sqlite`) to be present in `~/Downloads/` This file is found in the ancillary S3 and may also be in the opera-pcm repo.
 
 ### Installation
 

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -58,7 +58,7 @@ def main(job_json_file: str, workdir: str):
     # set additional files to triage
     jc.set(
         '_triage_additional_globs',
-        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir"]
+        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir", "pge_scratch_dir"]
     )
 
     # Disable no-clobber errors for published files. Either the file naming conventions
@@ -83,7 +83,7 @@ def run_pipeline(job_json_dict: Dict, work_dir: str) -> List[Union[bytes, str]]:
     logger.info(f"Preparing Working Directory: {work_dir}")
     logger.debug(f"{list(Path(work_dir).iterdir())=}")
 
-    input_dir, output_dir, runconfig_dir = create_required_directories(work_dir, job_json_dict)
+    input_dir, output_dir, scratch_dir, runconfig_dir = create_required_directories(work_dir, job_json_dict)
 
     run_config: Dict = job_json_dict.get("run_config")
     pge_config: Dict = job_json_dict.get("pge_config")
@@ -134,7 +134,8 @@ def run_pipeline(job_json_dict: Dict, work_dir: str) -> List[Union[bytes, str]]:
             work_dir=work_dir,
             input_dir=input_dir,
             runconfig_dir=runconfig_dir,
-            output_dir=output_dir
+            output_dir=output_dir,
+            scratch_dir=scratch_dir
         )
     logger.debug(f"{os.listdir(output_dir)=}")
 
@@ -154,7 +155,7 @@ def run_pipeline(job_json_dict: Dict, work_dir: str) -> List[Union[bytes, str]]:
     return created_datasets
 
 
-def create_required_directories(work_dir: str, context: Dict) -> Tuple[str, str, str]:
+def create_required_directories(work_dir: str, context: Dict) -> Tuple[str, str, str, str]:
     """Creates the requisite directories per the PGE-PCM ICS"""
     logger.info("Creating directories for PGE.")
 
@@ -167,7 +168,10 @@ def create_required_directories(work_dir: str, context: Dict) -> Tuple[str, str,
     output_dir = os.path.join(work_dir, job_param_by_name(context, "pge_output_dir"))
     os.makedirs(output_dir, 0o755, exist_ok=True)
 
-    return input_dir, output_dir, runconfig_dir
+    scratch_dir = os.path.join(work_dir, job_param_by_name(context, "pge_scratch_dir"))
+    os.makedirs(scratch_dir, 0o755, exist_ok=True)
+
+    return input_dir, output_dir, scratch_dir, runconfig_dir
 
 
 def job_param_by_name(context: Dict, name: str):
@@ -183,7 +187,7 @@ def job_param_by_name(context: Dict, name: str):
     raise Exception(f"param ({name}) not found in _context.json")
 
 
-def exec_pge_command(context: Dict, work_dir: str, input_dir: str, runconfig_dir: str, output_dir: str):
+def exec_pge_command(context: Dict, work_dir: str, input_dir: str, runconfig_dir: str, output_dir: str, scratch_dir: str):
     logger.info("Preparing PGE docker command.")
 
     # get dependency image
@@ -219,6 +223,7 @@ def exec_pge_command(context: Dict, work_dir: str, input_dir: str, runconfig_dir
         f"-v {runconfig_dir}:{container_home}/runconfig:ro",
         f"-v {input_dir}:{container_home}/input_dir:ro",
         f"-v {output_dir}:{container_home}/output_dir",
+        f"-v {scratch_dir}:{container_home}/scratch_dir",
         dep_img_name,
         f"--file {container_home}/runconfig/RunConfig.yaml",
     ]

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -85,15 +85,6 @@ def dswx_s1_lineage_metadata(context, work_dir):
         local_input_filepath = os.path.join(work_dir, basename(s3_input_filepath))
         lineage_metadata.append(local_input_filepath)
 
-        # TODO: kludge to support current version of DSWx-S1 SAS, which wants
-        #  a "_layover_shadow_mask.tif" file, remove for next patch release
-        mask_files = glob.glob(os.path.join(local_input_filepath, "*_mask.tif"))
-        mask_file = mask_files[0]
-        old_name = mask_file
-        new_name = mask_file.replace("_mask.tif", "_layover_shadow_mask.tif")
-        logger.info(f"Renaming {old_name} to {new_name}")
-        os.rename(old_name, new_name)
-
     # Copy the ancillaries downloaded for this job to the pge input directory
     local_dem_filepaths = glob.glob(os.path.join(work_dir, "dem*.*"))
     lineage_metadata.extend(local_dem_filepaths)


### PR DESCRIPTION
## Purpose
- This branch integrates v3.0.0-rc.2.0 of the DSWx-S1 PGE, which incorporates the CalVal delivery of the corresponding SAS

## Proposed Changes
- The designated instance type for DSWx-S1 workers is now set to c5.4xlarge
- References to the MGRS tile collection database have been updated to use the newest version with the CalVal delivery. All usages now reference a single location in S3
- The DSWx-S1 workflow now assigns the number of available CPU to 1 less than the total (15 for c5.4xlarge)
- This branch also updates the opera_pge_wrapper.py script to create a distinct scratch directory and mount it into the docker container. This directory will also be collected when triaging a failed job. All existing PGE job-specs have been updated to support this change.

## Issues
- Resolves #755 

## Testing
- Branch was tested on a dev cluster by submitting a single DSWx-S1 job with the following command:
```
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query --collection-shortname=OPERA_L2_RTC-S1_V1 --endpoint=OPS --start-date=2024-01-29T00:00:00Z --end-date=2024-01-29T00:15:00Z --release-version=issue_755_dswx_s1_rc2.0_integration --job-queue=opera-job_worker-rtc_data_download --chunk-size=1 --max-revision=1000 --temporal-start-date=2023-12-28T00:00:00Z --transfer-protocol=auto
```
Both simulation mode and real mode were tested.
- Testing is also ongoing with the SDS in forward processing mode
