### PR TITLE
Refactored mark_product_as_downloaded function so that it takes an op…

### DIFF
--- a/data_subscriber/hls/hls_catalog.py
+++ b/data_subscriber/hls/hls_catalog.py
@@ -125,19 +125,22 @@ class HLSProductCatalog:
             "revision_date": revision_date_dt
         }
 
-    def mark_product_as_downloaded(self, url, job_id):
+    def mark_product_as_downloaded(self, url, job_id, filesize = None):
         filename = url.split("/")[-1]
+
+        doc = {}
+        doc["downloaded"] = True
+        doc["download_datetime"] = datetime.now()
+        doc["download_job_id"] = job_id
+        if filesize:
+            doc["metadata"] = {"FileSize": filesize}
 
         index = self._get_index_name_for(_id=filename, default=self.generate_es_index_name())
         result = self.es.update_document(
             id=filename,
             body={
                 "doc_as_upsert": True,
-                "doc": {
-                    "downloaded": True,
-                    "download_datetime": datetime.now(),
-                    "download_job_id": job_id,
-                }
+                "doc": doc
             },
             index=index
         )

--- a/data_subscriber/rtc/rtc_catalog.py
+++ b/data_subscriber/rtc/rtc_catalog.py
@@ -74,28 +74,6 @@ class RTCProductCatalog(HLSProductCatalog):
         logging.info(f"Found {len(es_docs)=}")
         return self.filter_query_result(es_docs)
 
-    def mark_product_as_downloaded(self, url, job_id, filesize):
-        filename = url.split("/")[-1]
-
-        index = self._get_index_name_for(_id=filename, default=self.generate_es_index_name())
-        result = self.es.update_document(
-            id=filename,
-            body={
-                "doc_as_upsert": True,
-                "doc": {
-                    "downloaded": True,
-                    "download_datetime": datetime.now(),
-                    "download_job_id": job_id,
-                    "metadata": {
-                        "FileSize": filesize
-                    }
-                }
-            },
-            index=index
-        )
-
-        self.logger.info(f"Document updated: {result}")
-
     def mark_products_as_download_job_submitted(self, batch_id_to_products_map: dict):
         operations = []
         mgrs = mgrs_bursts_collection_db_client.cached_load_mgrs_burst_db(filter_land=True)


### PR DESCRIPTION
Instead of making multiple copies of the same function, refactor it a little bit in the base class. It's now backwards compatible with HLS and ASF downloads but still carry out the new functionality needed by RTC and CSLC downloads.
