### PR TITLE
R2 PGE v2.1.1 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -386,8 +386,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1"  = "2.1.0"
-    "rtc_s1"   = "2.1.0"
+    "cslc_s1"  = "2.1.1"
+    "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -173,8 +173,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1"  = "2.1.0"
-    "rtc_s1"   = "2.1.0"
+    "cslc_s1"  = "2.1.1"
+    "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -387,8 +387,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1"  = "2.1.0"
-    "rtc_s1"   = "2.1.0"
+    "cslc_s1"  = "2.1.1"
+    "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,8 +31,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1"  = "2.1.0"
-    "rtc_s1"   = "2.1.0"
+    "cslc_s1"  = "2.1.1"
+    "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -551,8 +551,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.2"
-    "cslc_s1"  = "2.1.0"
-    "rtc_s1"   = "2.1.0"
+    "cslc_s1"  = "2.1.1"
+    "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.0"
     "disp_s1"  = "3.0.0-er.5.1"
   }

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -100,6 +100,7 @@ RunConfig:
             product_id:
             rtc_s1_static_validity_start_date: {{ data.product_path_group.data_validity_start_date }}
             product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC"
+            static_layers_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC-STATIC&operaBurstID={burst_id}&end={end_date}"
             save_bursts: True
             save_mosaics: False
             save_browse: True
@@ -117,14 +118,6 @@ RunConfig:
 
             geocoding:
               memory_mode: auto
-
-              bursts_geogrid:
-                top_left:
-                  x:
-                  y:
-                bottom_right:
-                  x:
-                  y:
 
               estimated_geometric_accuracy_bias_x: {{ data.processing.estimated_geometric_accuracy_bias_x }}
               estimated_geometric_accuracy_bias_y: {{ data.processing.estimated_geometric_accuracy_bias_y }}

--- a/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
@@ -100,7 +100,7 @@ RunConfig:
             output_dir: {{ data.product_path_group.product_path }}
             product_id:
             rtc_s1_static_validity_start_date: {{ data.product_path_group.data_validity_start_date }}
-            product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC"
+            product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC-STATIC&operaBurstID={burst_id}&end={end_date}"
             save_bursts: True
             save_mosaics: False
             save_browse: True
@@ -118,14 +118,6 @@ RunConfig:
 
             geocoding:
               memory_mode: auto
-
-              bursts_geogrid:
-                top_left:
-                  x:
-                  y:
-                bottom_right:
-                  x:
-                  y:
 
               estimated_geometric_accuracy_bias_x: {{ data.processing.estimated_geometric_accuracy_bias_x }}
               estimated_geometric_accuracy_bias_y: {{ data.processing.estimated_geometric_accuracy_bias_y }}

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.0.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.0.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.1.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.0.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -24,7 +24,7 @@ runconfig:
   product_path_group:
     product_version: __CHIMERA_VAL__
     product_path: /home/compass_user/output_dir
-    scratch_path: /home/compass_user/scratch
+    scratch_path: /home/compass_user/scratch_dir
     product_specification_version: __CHIMERA_VAL__
   processing:
     polarization: co-pol

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
@@ -24,7 +24,7 @@ runconfig:
   product_path_group:
     static_product_version: __CHIMERA_VAL__
     product_path: /home/compass_user/output_dir
-    scratch_path: /home/compass_user/scratch
+    scratch_path: /home/compass_user/scratch_dir
     data_validity_start_date: __CHIMERA_VAL__
     product_specification_version: __CHIMERA_VAL__
   processing:

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
@@ -23,8 +23,7 @@ runconfig:
   product_path_group:
     product_version: __CHIMERA_VAL__
     product_path: /home/rtc_user/output_dir
-    # Scratch path is defined relative to output_dir to avoid file system permission issues
-    scratch_path: /home/rtc_user/output_dir/scratch_dir
+    scratch_path: /home/rtc_user/scratch_dir
   processing:
     polarization: __CHIMERA_VAL__
     num_workers: __CHIMERA_VAL__

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
@@ -23,8 +23,7 @@ runconfig:
   product_path_group:
     static_product_version: __CHIMERA_VAL__
     product_path: /home/rtc_user/output_dir
-    # Scratch path is defined relative to output_dir to avoid file system permission issues
-    scratch_path: /home/rtc_user/output_dir/scratch_dir
+    scratch_path: /home/rtc_user/scratch_dir
     data_validity_start_date: __CHIMERA_VAL__
   processing:
     polarization: __CHIMERA_VAL__

--- a/tests/opera_chimera/test_precondition_functions.py
+++ b/tests/opera_chimera/test_precondition_functions.py
@@ -796,7 +796,7 @@ class TestOperaPreConditionFunctions(unittest.TestCase):
         context = {
             "product_metadata": {
                 "metadata": {
-                    "batch_id": "88_145"  # Format is <frame_id>_<acquisition_time_index>
+                    "frame_id": "88"
                 }
             }
         }

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -3,10 +3,8 @@ PGE-specific functions for use with the OPERA PGE Wrapper
 """
 import glob
 import os
-from os.path import basename, dirname, splitext
+from os.path import basename, splitext
 from typing import Dict
-
-from commons.logger import logger
 
 def slc_s1_lineage_metadata(context, work_dir):
     """Gathers the lineage metadata for the CSLC-S1 and RTC-S1 PGEs"""
@@ -40,7 +38,7 @@ def slc_s1_lineage_metadata(context, work_dir):
     local_tec_filepaths = glob.glob(os.path.join(work_dir, "JPL*.INX"))
     lineage_metadata.extend(local_tec_filepaths)
 
-    local_burstdb_filepaths = glob.glob(os.path.join(work_dir, "*.sqlite3"))
+    local_burstdb_filepaths = glob.glob(os.path.join(work_dir, "*.sqlite*"))
     lineage_metadata.extend(local_burstdb_filepaths)
 
     return lineage_metadata


### PR DESCRIPTION
## Purpose
- This branch integrates v2.1.1 of the R2 PGEs (CSLC-S1 and RTC-S1). This delivery incorporates SAS Final point releases 6.4 (CSLC-S1) and 5.2 (RTC-S1).

## Proposed Changes
- RunConfig templates for RTC-S1 and RTC-S1-STATIC have been updated to include the template version of the product access/static layer access URLs
- Support for handling the .sqlite extension has been added to the lineage metadata function for SLC products
- Fixed a broken unit test for the `get_disp_s1_frame_id` precondition function

## Issues
- Resolves #772 

## Testing
- Branch was tested using a dev cluster and running the RTC-S1 and CSLC-S1 workflows (including static layer generation) in both simulation and real mode. SLC query timer was enabled and cluster was allowed to run for about 2-3 hours, during which time all jobs completed successfully.