### PR TITLE
add uat option to validator script and document in readme

### DIFF
--- a/report/dswx-s1-validator/README.md
+++ b/report/dswx-s1-validator/README.md
@@ -58,7 +58,8 @@ This guide provides a quick way to get started with the script.
 2. Optionally, use the `--file` argument to specify a file with granule IDs.
 3. Optionally, use the `--threshold` argument to a threshold percentage to filter MGRS Tile Set coverages by.
 4. Optionally, use the `--timestamp` argument to specify the type of timestamp to query CMR with. Example values: `TEMPORAL|PRODUCTION|REVISION|CREATED`. Default value is `TEMPORAL`. See [CMR documentation](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html) for details. 
-5. Optionally, use the `--verbose` argument to get detailed information like a list of matching bursts and granule IDs
+5. Optionally, use the `--endpoint` argument to specify the CMR endpoint venue. Accepted values are `OPS|UAT`, with `OPS` set as the default value.
+6. Optionally, use the `--verbose` argument to get detailed information like a list of matching bursts and granule IDs
  
 ### Usage Examples
 
@@ -66,7 +67,7 @@ This guide provides a quick way to get started with the script.
 
 ```
 $ python dswx_s1_validator.py --start "2023-12-05T01:00:00Z" --end "2023-12-05T03:59:59Z" --db MGRS_tile_collection_v0.2.sqlite --threshold 50
-Querying CMR for time range 2023-12-05T01:00:00Z to 2023-12-05T03:59:59Z.
+Querying CMR for time range 2023-12-05T01:00:00 to 2023-12-05T03:59:59.
 Querying CMR for 2316 granules.
 
 Fetching granules: 100%|███████████████████████████████████████| 2316/2316 [00:01<00:00, 1660.76it/s]

--- a/report/dswx-s1-validator/dswx_s1_validator.py
+++ b/report/dswx-s1-validator/dswx_s1_validator.py
@@ -105,7 +105,7 @@ def get_burst_id(granule_id):
     """
     burst_id = ''
     if granule_id:
-      match = re.search(r'_T(\d+)-(\d+)-([A-Z]+\d+)_\d+T\d+Z_\d+T\d+Z_S1A_\d+_v\d+\.\d+', granule_id)
+      match = re.search(r'_T(\d+)-(\d+)-([A-Z]+\d+)_\d+T\d+Z_\d+T\d+Z_S1[AB]_\d+_v\d+\.\d+', granule_id)
       if match:
           t_number = match.group(1)
           orbit_number = match.group(2)
@@ -202,6 +202,7 @@ if __name__ == '__main__':
         # Exit with error code if no granules to process
         if (total_granules == 0):
             print(f"Error: no granules to process.")
+            sys.exit(1)
 
         # Optimize page_size and number of workers based on total_granules
         page_size = min(1000, total_granules)

--- a/report/dswx-s1-validator/dswx_s1_validator.py
+++ b/report/dswx-s1-validator/dswx_s1_validator.py
@@ -148,6 +148,7 @@ if __name__ == '__main__':
     parser.add_argument("--file", required=False, help="Optional file path containing granule IDs")
     parser.add_argument("--threshold", required=False, help="Completion threshold minimum to filter results by (percentage format - leave out the %)")
     parser.add_argument("--verbose", action='store_true', help="Verbose and detailed output")
+    parser.add_argument("--endpoint", required=False, choices=['UAT', 'OPS'], default='OPS', help='CMR endpoint venue')
 
     # Parse the command-line arguments
     args = parser.parse_args()
@@ -171,6 +172,8 @@ if __name__ == '__main__':
 
         # Base URL for granule searches
         base_url = "https://cmr.earthdata.nasa.gov/search/granules.umm_json"
+        if args.endpoint == 'UAT':
+            base_url = "https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json"
         params = {
             'provider': 'ASF',
             'ShortName[]': 'OPERA_L2_RTC-S1_V1'


### PR DESCRIPTION
## Purpose
- Update dswx-s1-validator code to address R3 calval use cases
## Proposed Changes
- [ADD] endpoint option to specify OPS or UAT CMR venue
- [UPDATE] README to address new argument
- [UPDATE] README to fix iso timestamps in example

## Testing
- Code has been used with R3 calval data
