### PR TITLE
Added support for a minimum configurable matching burst count

### DIFF
--- a/report/dswx-s1-validator/README.md
+++ b/report/dswx-s1-validator/README.md
@@ -56,7 +56,7 @@ This guide provides a quick way to get started with the script.
 
 1. Run the script using Python: `python dswx_s1_validator.py --start <start_date> --end <end_date> --db <database_path>`.
 2. Optionally, use the `--file` argument to specify a file with granule IDs.
-3. Optionally, use the `--threshold` argument to a threshold percentage to filter MGRS Tile Set coverages by.
+3. Optionally, use the `--threshold` argument to a threshold percentage to filter MGRS Tile Set coverages by or use the `--matching_burst_count` to specify the minimum number of bursts to expect a match for for filtering. If both are provided, `--threshold` is used and `--matching_burst_count` is ignored. 
 4. Optionally, use the `--timestamp` argument to specify the type of timestamp to query CMR with. Example values: `TEMPORAL|PRODUCTION|REVISION|CREATED`. Default value is `TEMPORAL`. See [CMR documentation](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html) for details. 
 5. Optionally, use the `--endpoint` argument to specify the CMR endpoint venue. Accepted values are `OPS|UAT`, with `OPS` set as the default value.
 6. Optionally, use the `--verbose` argument to get detailed information like a list of matching bursts and granule IDs

--- a/report/dswx-s1-validator/dswx_s1_validator.py
+++ b/report/dswx-s1-validator/dswx_s1_validator.py
@@ -247,7 +247,7 @@ if __name__ == '__main__':
     parser.add_argument("--db", required=True, help="Path to the SQLite database file")
     parser.add_argument("--file", required=False, help="Optional file path containing granule IDs")
     parser.add_argument("--threshold", required=False, help="Completion threshold minimum to filter results by (percentage format - leave out the % sign)")
-    parser.add_argument("--matching_burst_count", required=False, help="Matching burst count to filter results by. Typically 4 or more is advised.")
+    parser.add_argument("--matching_burst_count", required=False, help="Matching burst count to filter results by. Typically four or more is advised. Using this with the --threshold flag makes this flag inactive (only one of '--threshold' or '--matching_burst_count' may be used)")
     parser.add_argument("--verbose", action='store_true', help="Verbose and detailed output")
     parser.add_argument("--endpoint", required=False, choices=['UAT', 'OPS'], default='OPS', help='CMR endpoint venue')
 

--- a/report/dswx-s1-validator/dswx_s1_validator.py
+++ b/report/dswx-s1-validator/dswx_s1_validator.py
@@ -247,6 +247,7 @@ if __name__ == '__main__':
     parser.add_argument("--db", required=True, help="Path to the SQLite database file")
     parser.add_argument("--file", required=False, help="Optional file path containing granule IDs")
     parser.add_argument("--threshold", required=False, help="Completion threshold minimum to filter results by (percentage format - leave out the % sign)")
+    parser.add_argument("--matching_burst_count", required=False, help="Matching burst count to filter results by. Typically 4 or more is advised.")
     parser.add_argument("--verbose", action='store_true', help="Verbose and detailed output")
     parser.add_argument("--endpoint", required=False, choices=['UAT', 'OPS'], default='OPS', help='CMR endpoint venue')
 
@@ -391,10 +392,13 @@ if __name__ == '__main__':
     # Create DataFrame from the collected data to use for fancy stuff
     df = pd.DataFrame(data_for_df)
 
-    # Apply threshold filtering if provided. This is the place for more fancy logic if needed.
+    # Apply threshold filtering if provided or use a minimum burst count match for filtering if provided. This is the place for more fancy logic if needed.
     if args.threshold:
         threshold = float(args.threshold)
         df = df[df['Coverage Percentage'] >= threshold]
+    elif args.matching_burst_count:
+        matching_burst_count = int(args.matching_burst_count)
+        df = df[df['Matching Burst Count'] >= matching_burst_count]
 
     # Pretty print results - adjust tablefmt accordingly (https://github.com/astanin/python-tabulate#table-format)
     print()


### PR DESCRIPTION
## Purpose
- Support for a minimum matching burst count
## Proposed Changes
- [ADD] New command-line argument to support
- [CHANGE] Filtering logic to support new argument
- [CHANGE] README directions for filtering

## Issues
- N/A
## Testing
- Tested successfully with the below case:
```
python dswx_s1_validator.py --start "2023-12-05T01:00:00Z" --end "2023-12-05T03:59:59Z" --db MGRS_tile_collection_v0.3.sqlite --threshold 50

Total granules: 2316
Querying CMR for time range 2023-12-05T01:00:00Z to 2023-12-05T03:59:59Z.

Fetching granules: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2316/2316 [00:04<00:00, 468.24it/s]

Granule fetching complete.

Calculating coverage: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14687/14687 [00:13<00:00, 1122.64it/s]

MGRS Set IDs covered: 34
MGRS Set ID      Coverage Percentage    Matching Burst Count    Total Burst Count
MS_166_30                      70                         28                   40
MS_166_31                     100                         40                   40
MS_166_32                     100                         40                   40
MS_166_33                     100                         40                   40
MS_166_34                     100                         40                   40
MS_166_35                     100                         40                   40
MS_166_36                     100                         41                   41
MS_166_37                     100                         41                   41
MS_166_38                     100                         42                   42
MS_166_39                     100                         42                   42
MS_166_69                      90.24                      37                   41
MS_166_70                     100                         40                   40
MS_166_71                     100                         40                   40
MS_166_72                     100                         39                   39
MS_166_73                     100                         40                   40
MS_166_74                     100                         40                   40
MS_166_75                     100                         40                   40
MS_166_76                     100                         41                   41
MS_166_77                     100                         41                   41
MS_166_78                     100                         41                   41
MS_166_79                     100                         40                   40
MS_166_80                     100                         40                   40
MS_166_81                      50                         20                   40
MS_166_88                     100                         40                   40
MS_166_89                      90                         36                   40
MS_167_68                     100                         41                   41
MS_167_69                     100                         40                   40
MS_167_70                     100                         40                   40
MS_167_71                     100                         39                   39
MS_167_72                     100                         40                   40
MS_167_73                     100                         40                   40
MS_167_74                     100                         39                   39
MS_167_75                     100                         41                   41
MS_167_77                     100                         41                   41
```

Then:

```
python dswx_s1_validator.py --start "2023-12-05T01:00:00Z" --end "2023-12-05T03:59:59Z" --db MGRS_tile_collection_v0.3.sqlite --matching_burst_count 42
Total granules: 2316
Querying CMR for time range 2023-12-05T01:00:00Z to 2023-12-05T03:59:59Z.

Fetching granules: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2316/2316 [00:03<00:00, 730.84it/s]

Granule fetching complete.

Calculating coverage: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 14687/14687 [00:11<00:00, 1237.32it/s]

MGRS Set IDs covered: 2
MGRS Set ID      Coverage Percentage    Matching Burst Count    Total Burst Count
MS_166_38                        100                      42                   42
MS_166_39                        100                      42                   42
```

