### PR TITLE
DISP-S1 v3.0.0-RC2.2 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -389,7 +389,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.1"
-    "disp_s1"  = "3.0.0-rc.2.1"
+    "disp_s1"  = "3.0.0-rc.2.2"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -176,7 +176,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.1"
-    "disp_s1"  = "3.0.0-rc.2.1"
+    "disp_s1"  = "3.0.0-rc.2.2"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -390,7 +390,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.1"
-    "disp_s1"  = "3.0.0-rc.2.1"
+    "disp_s1"  = "3.0.0-rc.2.2"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -34,7 +34,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.1"
-    "disp_s1"  = "3.0.0-rc.2.1"
+    "disp_s1"  = "3.0.0-rc.2.2"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -554,7 +554,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.0-rc.2.1"
-    "disp_s1"  = "3.0.0-rc.2.1"
+    "disp_s1"  = "3.0.0-rc.2.2"
   }
 }
 

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.0-rc.2.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.0-rc.2.1.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.0-rc.2.2",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.0-rc.2.2.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.0-rc.2.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.0-rc.2.1.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.0-rc.2.2",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.0-rc.2.2.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -47,12 +47,12 @@ preconditions:
   - get_product_version
   - get_cnm_version
   - set_daac_product_type
+  - get_disp_s1_polarization
   - get_disp_s1_frame_id
   - get_disp_s1_product_type
   - get_disp_s1_num_workers
   - get_s3_input_filepaths
   - get_static_ancillary_files
-  - get_disp_s1_algorithm_parameters
   #- get_disp_s1_amplitude_dispersion_files
   #- get_disp_s1_amplitude_mean_files
   - get_disp_s1_static_layers_files
@@ -60,6 +60,8 @@ preconditions:
   - get_disp_s1_troposphere_files
   - get_disp_s1_mask_file
   - get_disp_s1_dem
+  - get_disp_s1_algorithm_parameters
+  - instantiate_algorithm_parameters_template
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
@@ -81,15 +83,19 @@ get_static_ancillary_files:
     s3_bucket: "opera-ancillaries"
     s3_key: "disp_frames/disp-s1/0.2.8/opera-s1-disp-frame-to-burst.json"
 
-get_disp_s1_algorithm_parameters:
-  # This S3 path only defines the location of the algorithm parameters files,
-  # an actual file will be selected based on the processing mode of the job (forward vs. historical)
-  s3_bucket: "opera-ancillaries"
-  s3_key: "algorithm_parameters/disp_s1/0.2.8"
-
 get_disp_s1_mask_file:
   s3_bucket: "opera-water-mask"
   s3_key: "v0.3/EPSG4326.vrt"
+
+get_disp_s1_algorithm_parameters:
+  # This S3 path only defines a location pattern of an algorithm parameters template file,
+  # the processing mode (forward vs. historical) will be filled in by the function itself
+  s3_bucket: "opera-ancillaries"
+  s3_key: "algorithm_parameters/disp_s1/0.2.8/algorithm_parameters_{processing_mode}.yaml.tmpl"
+
+instantiate_algorithm_parameters_template:
+  template_mapping:
+    polarization: __POLARIZATION__
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -43,6 +43,7 @@ preconditions:
   - get_dswx_s1_dynamic_ancillary_maps
   - get_dswx_s1_dem
   - get_dswx_s1_num_workers
+  - get_dswx_s1_algorithm_parameters
   - instantiate_algorithm_parameters_template
   # TODO: enable if shoreline files are needed by DSWx-S1 SAS
   #- get_shoreline_shapefiles
@@ -102,9 +103,11 @@ get_shoreline_shapefiles:
     - "GSHHS_f_L1.shp"
     - "GSHHS_f_L1.shx"
 
-instantiate_algorithm_parameters_template:
+get_dswx_s1_algorithm_parameters:
   s3_bucket: "opera-ancillaries"
   s3_key: "algorithm_parameters/dswx_s1/dswx_s1_algorithm_parameters_calval_0.4.2.yaml.tmpl"
+
+instantiate_algorithm_parameters_template:
   template_mapping:
     num_workers: __NUMBER_CPU__
 

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -44,6 +44,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     GET_DSWX_HLS_DEM = "get_dswx_hls_dem"
 
+    GET_DSWX_S1_ALGORITHM_PARAMETERS = "get_dswx_s1_algorithm_parameters"
+
     GET_DSWX_S1_DEM = "get_dswx_s1_dem"
 
     GET_DSWX_S1_DYNAMIC_ANCILLARY_MAPS = "get_dswx_s1_dynamic_ancillary_maps"

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -275,10 +275,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         ionosphere_paths = metadata["product_paths"].get("IONOSPHERE_TEC", [])
 
-        # TODO: hardcoded to empty set of files to bypass ionosphere correction
-        #       until file naming conventions are properly handled by DISP-S1 SAS
         rc_params = {
-            oc_const.IONOSPHERE_FILES: list() #ionosphere_paths
+            oc_const.IONOSPHERE_FILES: ionosphere_paths
         }
 
         logger.info(f"rc_params : {rc_params}")
@@ -410,8 +408,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         Derives the S3 paths to the troposphere files to be used with a DISP-S1
         job.
 
-        TODO: current a stub, implement once CSLC static layer files are downloaded
-              to s3 by query job.
+        TODO: current a stub, implement once ECMWF files are available
         """
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -143,6 +143,9 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         """
         logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
 
+        # get the working directory
+        working_dir = get_working_dir()
+
         processing_mode = self._context["processing_mode"]
 
         # Convert reprocessing mode to forward for sake of selecting a parameter config
@@ -152,8 +155,17 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         s3_bucket = self._pge_config.get(oc_const.GET_DISP_S1_ALGORITHM_PARAMETERS, {}).get(oc_const.S3_BUCKET)
         s3_key = self._pge_config.get(oc_const.GET_DISP_S1_ALGORITHM_PARAMETERS, {}).get(oc_const.S3_KEY)
 
+        # Fill in the processing mode
+        s3_key = s3_key.format(processing_mode=processing_mode)
+
+        output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
+
+        download_object_from_s3(
+            s3_bucket, s3_key, output_filepath, filetype="Algorithm Parameters Template"
+        )
+
         rc_params = {
-            oc_const.ALGORITHM_PARAMETERS: f"s3://{s3_bucket}/{s3_key}/algorithm_parameters_{processing_mode}.yaml"
+            oc_const.ALGORITHM_PARAMETERS: output_filepath
         }
 
         logger.info(f"rc_params : {rc_params}")
@@ -364,6 +376,54 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_disp_s1_polarization(self):
+        """
+        Determines the polarization value of the CSLC-S1 products used with a
+        DISP-S1 job
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        rc_params = {}
+
+        metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
+
+        dataset_type = self._context["dataset_type"]
+
+        product_paths = metadata["product_paths"][dataset_type]
+
+        # Define a regex pattern to match and extract the polarization field from
+        # a CSLC-S1 tif product filename
+        pattern = re.compile(r".*_(?P<pol>VV|VH|HH|HV)_.*\.h5")
+
+        # Filter out all products to just those with a polarization field in the
+        # filename
+        polarization_layers = filter(
+            lambda path: pattern.match(os.path.basename(path)), product_paths
+        )
+
+        # Reduce each product filename to just the polarization field value
+        available_polarizations = map(
+            lambda path: pattern.match(os.path.basename(path)).groupdict()['pol'],
+            list(polarization_layers)
+        )
+
+        # Reduce again to just the unique set of polarization fields
+        unique_polarizations = set(list(available_polarizations))
+
+        # Make sure we are left with only a single polarization value
+        if len(unique_polarizations) == 0:
+            raise ValueError('No polarization fields parsed from input CSLC product set')
+
+        if len(unique_polarizations) > 1:
+            raise ValueError(f'More than one ({len(unique_polarizations)}) polarization values '
+                             f'parsed from set of input CSLC granules')
+
+        rc_params[oc_const.POLARIZATION] = list(unique_polarizations)[0]
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def get_disp_s1_product_type(self):
         """
         Assigns the product type (forward/historical) to the RunConfig for
@@ -521,6 +581,33 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         # Used in conjunction with PGE Config YAML's $.localize_groups and its referenced properties in $.runconfig.
         # Compare key names of $.runconfig entries, referenced indirectly via $.localize_groups, with this dict.
         return {"L2_HLS": product_paths}
+
+    def get_dswx_s1_algorithm_parameters(self):
+        """
+        Downloads the designated algorithm parameters runconfig from S3 for use
+        with a DSWx-S1 job
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        # get the working directory
+        working_dir = get_working_dir()
+
+        s3_bucket = self._pge_config.get(oc_const.GET_DSWX_S1_ALGORITHM_PARAMETERS, {}).get(oc_const.S3_BUCKET)
+        s3_key = self._pge_config.get(oc_const.GET_DSWX_S1_ALGORITHM_PARAMETERS, {}).get(oc_const.S3_KEY)
+
+        output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
+
+        download_object_from_s3(
+            s3_bucket, s3_key, output_filepath, filetype="Algorithm Parameters Template"
+        )
+
+        rc_params = {
+            oc_const.ALGORITHM_PARAMETERS: output_filepath
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
 
     def get_dswx_s1_dem(self):
         """
@@ -691,7 +778,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         logger.info(f"Allocating {num_workers} core(s) out of {available_cores} available")
 
         rc_params = {
-            "num_workers": num_workers
+            "num_workers": str(num_workers)
         }
 
         logger.info(f"rc_params : {rc_params}")
@@ -1443,18 +1530,9 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         logger.info("working_dir : {}".format(working_dir))
 
-        # Download the configured template file to disk so we can replace patterns
-        # in memory
-        s3_bucket = self._pge_config.get(
-            oc_const.INSTANTIATE_ALGORITHM_PARAMETERS_TEMPLATE, {}).get(oc_const.S3_BUCKET)
-        s3_key = self._pge_config.get(
-            oc_const.INSTANTIATE_ALGORITHM_PARAMETERS_TEMPLATE, {}).get(oc_const.S3_KEY)
-
-        output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
-
-        download_object_from_s3(
-            s3_bucket, s3_key, output_filepath, filetype="Algorithm Parameters Template"
-        )
+        # Get the path to the templated parameters file which should have already been
+        # downloaded at this point
+        output_filepath = self._job_params[oc_const.ALGORITHM_PARAMETERS]
 
         with open(output_filepath, 'r') as infile:
             template_contents = infile.read()
@@ -1474,7 +1552,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
                 raise RuntimeError(f'No value for parameter {parameter} in _job_params')
 
             logger.info(f'Replacing pattern {pattern} with value {value}')
-            instantiated_contents = instantiated_contents.replace(pattern, json.dumps(value))
+            instantiated_contents = instantiated_contents.replace(pattern, str(value))
 
         # Strip the .tmpl suffix to derive the instantiated output filename
         output_filepath = output_filepath.replace(".tmpl", "")
@@ -1482,8 +1560,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         with open(output_filepath, 'w') as outfile:
             outfile.write(instantiated_contents)
 
-        # Return path to the instantiated template so it can be written to the
-        # runconfig
+        # Return the updated path to the instantiated template, so it can be
+        # written to the runconfig used with the PGE job
         rc_params = {
             oc_const.ALGORITHM_PARAMETERS: output_filepath
         }


### PR DESCRIPTION
## Purpose
- This branch integrates DISP-S1 PGE v3.0.0-rc2.2 with OPERA PCM. This version wraps the v4.2 delivery of the corresponding SAS, and fixes several issues related to use of CSLC products that have file name conventions already applied.
- This branch also introduces a fix for #827 such that the chimera workflow for DISP-S1 determines the correct polarization to assign into the algorithm parameters runconfig, based on the polarization of the input CSLC products.

## Issues
- Resolves #858 
- Fixes #827 

## Testing
- Unit tests for OPERA precondition functions have been updated to accommodate changes to algorithm parameter runconfig instantiation
- This branch was tested on a dev cluster with the following commands:
  - General DISP-S1 test: `python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query  --collection-shortname=OPERA_L2_CSLC-S1_V1  --endpoint=OPS --k=4 --m=1 --job-queue=opera-job_worker-cslc_data_download  --chunk-size=1 --processing-mode=reprocessing --transfer-protocol=auto --native-id=OPERA_L2_CSLC-S1_T042-088905-IW1_20240301T140753Z_20240302T185554Z_S1A_VV_v1.0`
  - To test fix for #827: `python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query --collection-shortname=OPERA_L2_CSLC-S1_V1 --endpoint=OPS --k=4 --m=1 --job-queue=opera-job_worker-cslc_data_download  --chunk-size=1 --processing-mode=reprocessing --transfer-protocol=auto --native-id=OPERA_L2_CSLC-S1_T171-365954-IW3_20240403T102412Z_20240419T041432Z_S1A_HH_v1.1`
  - Regression test for DSWx-S1: `python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query --collection-shortname=OPERA_L2_RTC-S1_V1 --endpoint=OPS --release-version=$branch --job-queue=opera-job_worker-rtc_data_download --chunk-size=1 --transfer-protocol=auto --native-id=OPERA_L2_RTC-S1_T027-057677-IW3_20240405T141220Z_20240406T014932Z_S1A_30_v1.0`
