### PR TITLE
PGE Smoke Test On-Demand Job

### DIFF
--- a/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
+++ b/cluster_provisioning/modules/common/launch_template_user_data.sh.tmpl
@@ -230,6 +230,12 @@ echo '{
             "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-rcv_cnm_notify.log",
             "timezone": "Local",
             "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
+          },
+          {
+            "file_path": "/home/ops/verdi/log/opera-job_worker-pge_smoke_test.log",
+            "log_group_name": "/opera/sds/${var_project}-${var_venue}-${local_counter}/opera-job_worker-pge_smoke_test.log",
+            "timezone": "Local",
+            "timestamp_format": "%Y-%m-%d %H:%M:%S,%f"
           }
         ]
       }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -519,6 +519,26 @@ variable "queues" {
       "max_size"          = 10
       "total_jobs_metric" = false
     }
+    "opera-job_worker-pge_smoke_test_amd" = {
+      "name"              = "opera-job_worker-pge_smoke_test_amd"
+      "instance_type"     = ["r6a.xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 250
+      "min_size"          = 0
+      "max_size"          = 10
+      "total_jobs_metric" = false
+      "use_private_vpc"   = false
+    }
+    "opera-job_worker-pge_smoke_test_intel" = {
+      "name"              = "opera-job_worker-pge_smoke_test_intel"
+      "instance_type"     = ["r6i.xlarge"]
+      "root_dev_size"     = 50
+      "data_dev_size"     = 250
+      "min_size"          = 0
+      "max_size"          = 10
+      "total_jobs_metric" = false
+      "use_private_vpc"   = false
+    }
   }
 }
 

--- a/docker/hysds-io.json.pge_smoke_test
+++ b/docker/hysds-io.json.pge_smoke_test
@@ -1,0 +1,27 @@
+{
+    "label": "On-demand PGE integration smoke test",
+    "submission_type": "individual",
+    "allowed_accounts": [ "ops" ],
+    "params": [
+        {
+            "name": "pge_name",
+            "from": "submitter",
+            "type": "enum",
+            "enumerables": ["dswx_s1", "disp_s1", "dswx_ni"],
+            "optional": false
+        },
+        {
+            "name": "s3_bucket",
+            "from": "submitter",
+            "placeholder": "e.g. opera-int-lts-fwd",
+            "type": "text",
+            "optional": false
+        },
+        {
+            "name": "_triage_additional_globs",
+            "from": "value",
+            "type": "object",
+            "value": "['tmp*']"
+        }
+    ]
+}

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -1,0 +1,54 @@
+{
+    "command": "/home/ops/verdi/ops/opera-pcm/pge_smoke_test/run_pge_smoke_test.sh",
+    "disk_usage": "100GB",
+    "soft_time_limit": 7200,
+    "time_limit": 7260,
+    "imported_worker_files": {
+        "$HOME/.netrc": "/home/ops/.netrc",
+        "$HOME/.aws": "/home/ops/.aws",
+        "$HOME/verdi/etc/settings.yaml": "/home/ops/verdi/ops/opera-pcm/conf/settings.yaml"
+    },
+    "dependency_images": [
+        {
+          "container_image_name": "opera_pge/dswx_s1:3.0.0-rc.2.2",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0-rc.2.2.tar.gz",
+          "container_mappings": {
+            "$HOME/.netrc": ["/root/.netrc"],
+            "$HOME/.aws": ["/root/.aws", "ro"]
+          }
+        },
+        {
+          "container_image_name": "opera_pge/disp_s1:3.0.0-rc.2.2",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.0-rc.2.2.tar.gz",
+          "container_mappings": {
+            "$HOME/.netrc": ["/root/.netrc"],
+            "$HOME/.aws": ["/root/.aws", "ro"]
+          }
+        },
+        {
+          "container_image_name": "opera_pge/dswx_ni:4.0.0-er.2.0",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_ni-4.0.0-er.2.0.tar.gz",
+          "container_mappings": {
+            "$HOME/.netrc": ["/root/.netrc"],
+            "$HOME/.aws": ["/root/.aws", "ro"]
+          }
+        }
+    ],
+    "recommended-queues": [ "opera-job_worker-pge_smoke_test_amd", "opera-job_worker-pge_smoke_test_intel" ],
+    "post": [ "hysds.triage.triage" ],
+    "params": [
+        {
+            "name": "pge_name",
+            "destination": "positional"
+        },
+        {
+            "name": "s3_bucket",
+            "destination": "positional"
+        },
+        {
+            "name": "_triage_additional_globs",
+            "destination": "context"
+        }
+    ],
+    "enable_dedup": false
+}

--- a/pge_smoke_test/run_pge_smoke_test.sh
+++ b/pge_smoke_test/run_pge_smoke_test.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+WORKING_DIR=$(pwd)
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+
+export OPERA_HOME=/home/ops/verdi/ops/opera-pcm
+export PYTHONPATH=$BASE_PATH:$OPERA_HOME:$PYTHONPATH
+export PATH=$BASE_PATH:$PATH
+export PYTHONDONTWRITEBYTECODE=1
+export LD_LIBRARY_PATH=/opt/conda/lib:$LD_LIBRARY_PATH
+
+source $HOME/verdi/bin/activate
+
+PGE_NAME=$1
+S3_BUCKET=$2
+PGE_REPO_URL="https://github.com/nasa/opera-sds-pge.git"
+PGE_HOME=/home/ops/verdi/ops/opera-sds-pge
+
+echo "##########################################" 2>&1
+echo -n "Starting PGE integration smoke test for ${PGE_NAME}: " 2>&1
+date 2>&1
+
+echo "Working dir is ${WORKING_DIR}" 2>&1
+
+VERSION_TAG=$(docker images | grep ${PGE_NAME} -m 1 | xargs sh -c 'echo $1') 2>&1
+STATUS=$?
+
+if [ $STATUS -ne 0 ]; then
+  echo "Could not determine version tag for ${PGE_NAME}" 2>&1
+  exit $STATUS
+fi
+
+echo "Version tag for ${PGE_NAME} is ${VERSION_TAG}" 2>&1
+
+echo "Cloning opera-sds-pge repository"
+git clone ${PGE_REPO_URL} ${PGE_HOME} 2>&1
+STATUS=$?
+
+if [ $STATUS -ne 0 ]; then
+  echo "Failed to clone opera-sds-pge repository" 2>&1
+  exit $STATUS
+fi
+
+echo "Running integration smoke test for container ${PGE_NAME}-${VERSION_TAG}" 2>&1
+${PGE_HOME}/.ci/scripts/${PGE_NAME}/test_int_${PGE_NAME}.sh --tag ${VERSION_TAG} --temp-root ${WORKING_DIR} --no-metrics --no-cleanup 2>&1
+STATUS=$?
+
+if [ $STATUS -eq 2 ]; then
+  echo "One or more product comparison failures occurred after running ${PGE_NAME}-${VERSION_TAG}" 2>&1
+elif [ $STATUS -ne 0 ]; then
+  echo "Failed to execute integration test for container ${PGE_NAME}-${VERSION_TAG}" 2>&1
+  exit $STATUS
+fi
+
+TIMESTAMP=$(date +"%Y-%m-%dT%T")
+S3_DESTINATON="s3://${S3_BUCKET}/smoke_test/${PGE_NAME}/${VERSION_TAG}/${TIMESTAMP}/"
+
+echo "Uploading smoke test results to ${S3_DESTINATON}"
+
+aws s3 cp "${WORKING_DIR}/_stderr.txt" "${S3_DESTINATON}" && \
+    aws s3 cp "${WORKING_DIR}/_stdout.txt" "${S3_DESTINATON}" && \
+    aws s3 cp --recursive --include="*" "${PGE_HOME}/test_results/${PGE_NAME}/" "${S3_DESTINATON}"
+
+STATUS=$?
+
+if [ $STATUS -ne 0 ]; then
+  echo "Failed to upload smoke test results to ${S3_DESTINATON}" 2>&1
+  exit $STATUS
+fi


### PR DESCRIPTION
## Purpose
- This branch adds a new on-demand job type to Tosca for executing the PGE/SAS integration test within an OPERA SDS context. The integration test is the same as is run in the PGE Jenkins system, and includes a step for comparing output products to a set of expected "golden" outputs downloaded from S3.
- When configuring the on-demand job, the only required fields are the PGE type (from a dropdown menu) and a name of an S3 bucket to push the test results to:

<img width="746" alt="Screenshot 2024-06-20 at 10 19 09 AM" src="https://github.com/nasa/opera-sds-pcm/assets/72415379/4164ce43-86a2-4bf2-83df-f519ef941794">

- Currently, only the R3 PGEs (DSWx-S1 and DISP-S1) are available. The R1 and R2 PGEs will be supported once new releases are approved via the OPERA Change Control Board.
- Once a smoke test has completed, the results are uploaded to the specified S3 bucket (barring any permission issues), within a `smoke_test/<pge_name>/<pge_version>` key:

<img width="1233" alt="Screenshot 2024-06-20 at 10 23 37 AM" src="https://github.com/nasa/opera-sds-pcm/assets/72415379/274d71f1-f9de-4e50-93de-475e9de7d29b">

- The results of the comparison with the "golden" outputs is easily accessible from the `test_int_<pge_name>_results.html` file within this location:
<img width="1569" alt="Screenshot 2024-06-20 at 10 25 21 AM" src="https://github.com/nasa/opera-sds-pcm/assets/72415379/b42fe2f0-7deb-4bab-8d32-373d47b7c725">

Hopefully this new job can help streamline the smoke test portion of an SDS deployment, as all expected inputs/outputs should already be available from PGE development. If there are any suggestions for additional features or improvements, please provide them in this PR.

## Issues
N/A

## Testing
- New on-demand job has been tested with both of the R3 PGEs, and in both cases the job should complete successfully with passing comparison reports.
