### PR TITLE
#896: CSLC download job now accepts --processing-mode as a parameter

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -350,7 +350,7 @@ variable "queues" {
       "total_jobs_metric" = true
     }
     "opera-job_worker-sciflo-l3_disp_s1_hist" = {
-      "instance_type"     = ["c7i.4xlarge", "c6a.4xlarge", "c6i.4xlarge"]
+      "instance_type"     = ["r7i.4xlarge", "r6a.4xlarge", "r6i.4xlarge"]
       "root_dev_size"     = 50
       "data_dev_size"     = 600
       "max_size"          = 10

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -249,7 +249,7 @@ def create_parser():
     download_parser = subparsers.add_parser("download",
                                             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     download_parser_arg_list = [verbose, file, endpoint, dry_run, smoke_run, provider,
-                                batch_ids, start_date, end_date, use_temporal,
+                                batch_ids, start_date, end_date, use_temporal, proc_mode,
                                 temporal_start_date, transfer_protocol, release_version]
     _add_arguments(download_parser, download_parser_arg_list)
     _add_arguments(download_parser.add_mutually_exclusive_group(required=False), [coverage_percent, coverage_num])

--- a/docker/hysds-io.json.cslc_download
+++ b/docker/hysds-io.json.cslc_download
@@ -47,7 +47,7 @@
       "optional": true
     },
     {
-      "name": "processing_mode",
+      "name": "proc_mode",
       "from": "submitter",
       "placeholder": "e.g. --processing-mode=forward",
       "optional": true

--- a/docker/hysds-io.json.cslc_download
+++ b/docker/hysds-io.json.cslc_download
@@ -47,6 +47,12 @@
       "optional": true
     },
     {
+      "name": "processing_mode",
+      "from": "submitter",
+      "placeholder": "e.g. --processing-mode",
+      "optional": true
+    },
+    {
       "name": "transfer_protocol",
       "from": "submitter",
       "placeholder": "e.g. --transfer-protocol=auto",

--- a/docker/hysds-io.json.cslc_download
+++ b/docker/hysds-io.json.cslc_download
@@ -49,7 +49,7 @@
     {
       "name": "processing_mode",
       "from": "submitter",
-      "placeholder": "e.g. --processing-mode",
+      "placeholder": "e.g. --processing-mode=forward",
       "optional": true
     },
     {

--- a/docker/job-spec.json.cslc_download
+++ b/docker/job-spec.json.cslc_download
@@ -40,7 +40,7 @@
       "destination": "positional"
     },
     {
-      "name": "processing_mode",
+      "name": "proc_mode",
       "destination": "positional"
     },
     {

--- a/docker/job-spec.json.cslc_download
+++ b/docker/job-spec.json.cslc_download
@@ -40,6 +40,10 @@
       "destination": "positional"
     },
     {
+      "name": "processing_mode",
+      "destination": "positional"
+    },
+    {
       "name": "transfer_protocol",
       "destination": "positional"
     }

--- a/docker/job-spec.json.cslc_download_hist
+++ b/docker/job-spec.json.cslc_download_hist
@@ -40,7 +40,7 @@
       "destination": "positional"
     },
     {
-      "name": "processing_mode",
+      "name": "proc_mode",
       "destination": "positional"
     },
     {

--- a/docker/job-spec.json.cslc_download_hist
+++ b/docker/job-spec.json.cslc_download_hist
@@ -40,6 +40,10 @@
       "destination": "positional"
     },
     {
+      "name": "processing_mode",
+      "destination": "positional"
+    },
+    {
       "name": "transfer_protocol",
       "destination": "positional"
     }


### PR DESCRIPTION
## Purpose
CSLC download job now accepts --processing-mode as a parameter. Query job already passes --processing-mode parameter when submitting download jobs so it did not require changing.
