### PR TITLE
DISP-S1 PGE Workflow Compressed CSLC Support

### DIFF
--- a/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
@@ -79,7 +79,7 @@ RunConfig:
         scratch_path: {{ data.product_path_group.scratch_path }}
         sas_output_path: {{ data.product_path_group.product_path }}
         product_version: "{{ data.product_path_group.product_version }}"
-        save_compressed_slc: true
+        save_compressed_slc: {{ data.product_path_group.save_compressed_slc }}
       worker_settings:
         gpu_enabled: false
         threads_per_worker: {{ data.processing.threads_per_worker }}

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -152,18 +152,17 @@ L3_DISP_S1:
       - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DISP)-(?P<source>S1)_(?P<mode>IW)_(?P<frame_id>F\d{5})_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<ref_datetime>\d{8}T\d{6}Z)_(?P<sec_datetime>\d{8}T\d{6}Z)_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))(_BROWSE)?[.](?P<ext>nc|png|iso\.xml)$'
         verify: true
         hash: md5
-      # Pattern for parsing compressed SLC output filenames, such as:
-      # * "OPERA_L2_COMPRESSED-CSLC-S1_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
-        verify: true
-        hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # * "OPERA_L3_DISP-S1_IW_F01234_v0.1_20230101T100506Z.catalog.json"
       - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DISP)-(?P<source>S1)_(?P<mode>IW)_(?P<frame_id>F\d{5})_(?P<product_version>v\d+[.]\d+)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z))[.](?P<ext>log|qa\.log|catalog\.json)$'
         verify: false
-    Optional: []
-      # Pattern for optional output product filenames
+    Optional:
+      # Pattern for parsing Compressed CSLC output filenames, such as:
+      # * "OPERA_L2_COMPRESSED-CSLC-S1_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
+        verify: true
+        hash: md5
 
   Missing_Metadata: {
     # "daac_product_type": "OPERA_L3_DSWX_HLS_0.0"

--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -162,8 +162,10 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
                                                                              self.downloads_dir)
 
             logger.info(f"Uploading Ionosphere files to S3")
+            # TODO: since all ionosphere files now go to the same S3 location,
+            #  it should be possible to do a lookup before redownloading a file
             ionosphere_s3paths.extend(concurrent_s3_client_try_upload_file(bucket=settings["DATASET_BUCKET"],
-                                                                           key_prefix=f"tmp/disp_s1/{batch_id}",
+                                                                           key_prefix=f"tmp/disp_s1/ionosphere",
                                                                            files=ionosphere_paths))
 
             # Delete the files from the file system after uploading to S3
@@ -211,7 +213,21 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
 
                 for ccslc in ccslcs:
                     c_cslc_s3paths.extend(ccslc["_source"]["metadata"]["product_s3_paths"])
+
+        # Now acquire the Ionosphere files for the reference dates of the Compressed CSLC products
+        logger.info(f"Downloading Ionosphere files for Compressed CSLCs")
+        ionosphere_paths = self.download_ionosphere_files_for_cslc_batch(c_cslc_s3paths,
+                                                                         self.downloads_dir)
+
+        logger.info(f"Uploading Ionosphere files for Compressed CSLCs to S3")
+        ionosphere_s3paths.extend(concurrent_s3_client_try_upload_file(bucket=settings["DATASET_BUCKET"],
+                                                                       key_prefix=f"tmp/disp_s1/ionosphere",
+                                                                       files=ionosphere_paths))
         # <------------------------- Compressed CSLC look up
+
+        # Remove potential duplicate ionosphere entries
+        # TODO: rework ionosphere download logic to check for files that have already been downloaded for a previous batch_id
+        ionosphere_s3paths = list(set(ionosphere_s3paths))
 
         # Look up bounding box for frame
         bounding_box = get_bounding_box_for_frame(int(frame_id), self.frame_geo_map)

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -15,6 +15,7 @@
 runconfig:
   input_file_group:
     input_file_paths: __CHIMERA_VAL__
+    compressed_cslc_paths: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     #amplitude_dispersion_files: __CHIMERA_VAL__
     #amplitude_mean_files: __CHIMERA_VAL__
@@ -55,6 +56,7 @@ preconditions:
   - get_static_ancillary_files
   #- get_disp_s1_amplitude_dispersion_files
   #- get_disp_s1_amplitude_mean_files
+  - get_disp_s1_compressed_cslc_files
   - get_disp_s1_static_layers_files
   - get_disp_s1_ionosphere_files
   - get_disp_s1_troposphere_files

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -32,6 +32,7 @@ runconfig:
     product_version: __CHIMERA_VAL__
     product_path: /home/mamba/output_dir
     scratch_path: /home/mamba/scratch_dir
+    save_compressed_slc: __CHIMERA_VAL__
   processing:
     frame_id: __CHIMERA_VAL__
     algorithm_parameters: __CHIMERA_VAL__
@@ -62,6 +63,7 @@ preconditions:
   - get_disp_s1_troposphere_files
   - get_disp_s1_mask_file
   - get_disp_s1_dem
+  - get_disp_s1_save_compressed_slc
   - get_disp_s1_algorithm_parameters
   - instantiate_algorithm_parameters_template
 

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -142,7 +142,7 @@ localize_groups:
 #######################################################################
 input_file_base_name_regexes:
     - '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV))?_(?P<product_version>v\d+[.]\d+))$'
-sample_input_dataset_id: "OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20230720T213954Z_S1A_VV_v0.1"
+sample_input_dataset_id: "OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20160822T000000Z_S1A_VV_v0.1"
 output_base_name: OPERA_L3_DISP-S1_IW_{frame_id}_{pol}_{ref_datetime}Z_{sec_datetime}Z_{product_version}_{creation_ts}Z
 ancillary_base_name: OPERA_L3_DISP-S1_IW_{frame_id}_{product_version}_{creation_ts}Z
-compressed_cslc_name: OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_{ts_start}T000000Z_{ts_start}T000000Z_{ts_end}T000000Z_{creation_ts}Z_{pol}_{product_version}
+compressed_cslc_name: OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_{ref_date}T000000Z_{first_date}T000000Z_{last_date}T000000Z_{creation_ts}Z_{pol}_{product_version}

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -18,6 +18,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     CNM_VERSION = "CNM_VERSION"
 
+    COMPRESSED_CSLC_PATHS = "compressed_cslc_paths"
+
     DATASET_TYPE = "dataset_type"
 
     DEM_FILE = "dem_file"
@@ -93,6 +95,8 @@ class OperaChimeraConstants(ChimeraConstants):
     MASK_FILE = "mask_file"
 
     L2_CSLC_S1 = "L2_CSLC_S1"
+
+    L2_CSLC_S1_COMPRESSED = "L2_CSLC_S1_COMPRESSED"
 
     L2_RTC_S1 = "L2_RTC_S1"
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -461,6 +461,25 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_disp_s1_save_compressed_slc(self):
+        """
+        Assigns the save_compressed_slc flag based on the value passed to the
+        job from the CSLC download job
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
+
+        save_compressed_cslc = metadata["save_compressed_cslc"]
+
+        rc_params = {
+            "save_compressed_slc": save_compressed_cslc
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def get_disp_s1_static_layers_files(self):
         """
         Derives the S3 paths to the CSLC static layer files to be used with a

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -10,21 +10,24 @@ import json
 import os
 import re
 import traceback
-
 from datetime import datetime
 from pathlib import PurePath
 from typing import Dict, List
 from urllib.parse import urlparse
 
 import boto3
-from chimera.precondition_functions import PreConditionFunctions
 
+from chimera.precondition_functions import PreConditionFunctions
 from commons.constants import product_metadata
-from commons.logger import logger
 from commons.logger import LogLevels
+from commons.logger import logger
 from opera_chimera.constants.opera_chimera_const import (
     OperaChimeraConstants as oc_const,
 )
+from tools.stage_ancillary_map import main as stage_ancillary_map
+from tools.stage_dem import main as stage_dem
+from tools.stage_ionosphere_file import VALID_IONOSPHERE_TYPES
+from tools.stage_worldcover import main as stage_worldcover
 from util import datasets_json_util
 from util.common_util import get_working_dir
 from util.geo_util import bounding_box_from_slc_granule
@@ -32,10 +35,6 @@ from util.pge_util import (download_object_from_s3,
                            get_disk_usage,
                            get_input_hls_dataset_tile_code,
                            write_pge_metrics)
-from tools.stage_ancillary_map import main as stage_ancillary_map
-from tools.stage_dem import main as stage_dem
-from tools.stage_ionosphere_file import VALID_IONOSPHERE_TYPES
-from tools.stage_worldcover import main as stage_worldcover
 
 
 class OperaPreConditionFunctions(PreConditionFunctions):
@@ -200,6 +199,25 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         rc_params = {
             oc_const.AMPLITUDE_MEAN_FILES: list()
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
+    def get_disp_s1_compressed_cslc_files(self):
+        """
+        Derives the list of S3 paths to the ionosphere files to be used with a
+        DISP-S1 job.
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        metadata = self._context["product_metadata"]["metadata"]
+
+        c_cslc_paths = metadata["product_paths"].get(oc_const.L2_CSLC_S1_COMPRESSED, [])
+
+        rc_params = {
+            oc_const.COMPRESSED_CSLC_PATHS: c_cslc_paths
         }
 
         logger.info(f"rc_params : {rc_params}")

--- a/tests/unit/util/test_pge_util.py
+++ b/tests/unit/util/test_pge_util.py
@@ -430,9 +430,9 @@ def test_simulate_disp_s1_pge():
     )
 
     creation_ts = pge_util.get_time_for_filename()
-    expected_output_basename = 'OPERA_L3_DISP-S1_IW_F01234_VV_20190101T232711Z_20190906T232711Z_v0.1_{creation_ts}Z'
-    expected_ancillary_basename = 'OPERA_L3_DISP-S1_IW_F01234_v0.1_{creation_ts}Z'
-    expected_compressed_cslc_basename = 'OPERA_L2_COMPRESSED-CSLC-S1_T042-088905-IW1_20221119T000000Z_20221119T000000Z_20221213T000000Z_{creation_ts}Z_VV_v0.1'
+    expected_output_basename = 'OPERA_L3_DISP-S1_IW_F10859_VV_20160705T000000Z_20160822T000000Z_v0.1_{creation_ts}Z'
+    expected_ancillary_basename = 'OPERA_L3_DISP-S1_IW_F10859_v0.1_{creation_ts}Z'
+    expected_compressed_cslc_basename = 'OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_20160705T000000Z_20160822T000000Z_20160915T000000Z_{creation_ts}Z_VV_v0.1'
 
     try:
         assert Path(f'/tmp/{expected_output_basename.format(creation_ts=creation_ts)}.nc').exists()
@@ -441,7 +441,9 @@ def test_simulate_disp_s1_pge():
         assert Path(f'/tmp/{expected_ancillary_basename.format(creation_ts=creation_ts)}.catalog.json').exists()
         assert Path(f'/tmp/{expected_ancillary_basename.format(creation_ts=creation_ts)}.log').exists()
         assert Path(f'/tmp/{expected_ancillary_basename.format(creation_ts=creation_ts)}.qa.log').exists()
-        assert Path(f'/tmp/{expected_compressed_cslc_basename.format(creation_ts=creation_ts)}.h5').exists()
+
+        for burst_id in pge_util.CCSLC_BURST_IDS:
+            assert Path(f'/tmp/{expected_compressed_cslc_basename.format(burst_id=burst_id, creation_ts=creation_ts)}.h5').exists()
     finally:
         for path in glob.iglob('/tmp/OPERA_L3_DISP-S1*.*'):
             Path(path).unlink(missing_ok=True)

--- a/tools/stage_ionosphere_file.py
+++ b/tools/stage_ionosphere_file.py
@@ -206,11 +206,8 @@ def parse_start_date_from_cslc(input_cslc_file):
     # Parse the CSLC file name with the following regex, derived from the
     # official naming conventions
     cslc_regex_pattern = (
-        r"(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-"
-        r"(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_"
-        r"(?P<acquisition_ts>\d{8}T\d{6})Z_(?P<creation_ts>\d{8}T\d{6})Z_"
-        r"(?P<sensor>S1A|S1B)(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV))?_"
-        r"(?P<product_version>v\d+[.]\d+)(_BROWSE)?$"
+        r"OPERA_L2_(COMPRESSED-)?CSLC-S1_(?P<burst_id>\w{4}-\w{6}-\w{3})_"
+        r"(?P<acquisition_ts>\d{8}T\d{6})Z_.*"
     )
     cslc_regex = re.compile(cslc_regex_pattern)
     match = cslc_regex.match(cslc_filename)

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -44,6 +44,17 @@ RTC_BURST_IDS = ['T069-147170-IW1', 'T069-147170-IW3', 'T069-147171-IW1',
                  'T069-147172-IW2', 'T069-147172-IW3', 'T069-147173-IW1']
 """List of sample burst ID's to simulate RTC-S1 multi-product output"""
 
+CCSLC_BURST_IDS = [
+'T041-086865-IW1', 'T041-086865-IW2', 'T041-086865-IW3', 'T041-086866-IW1',
+'T041-086866-IW2', 'T041-086866-IW3', 'T041-086867-IW1', 'T041-086867-IW2',
+'T041-086867-IW3', 'T041-086868-IW1', 'T041-086868-IW2', 'T041-086868-IW3',
+'T041-086869-IW1', 'T041-086869-IW2', 'T041-086869-IW3', 'T041-086870-IW1',
+'T041-086870-IW2', 'T041-086870-IW3', 'T041-086871-IW1', 'T041-086871-IW2',
+'T041-086871-IW3', 'T041-086872-IW1', 'T041-086872-IW2', 'T041-086872-IW3',
+'T041-086873-IW1', 'T041-086873-IW2', 'T041-086873-IW3'
+]
+"""List of sample burst ID's to simulate multiple Compressed CSLC outputs"""
+
 DSWX_TILES = ['T18MVA', 'T18MVT', 'T18MVU', 'T18MVV', 'T18MWA', 'T18MWT',
               'T18MWU', 'T18MWV', 'T18MXA', 'T18MXT', 'T18MXU', 'T18MXV']
 """List of sample MGRS tile ID's to simulate DSWx-S1/NI multi-product output"""
@@ -577,10 +588,10 @@ def get_disp_s1_simulated_output_filenames(dataset_match, pge_config, extension)
 
     if extension.endswith('nc') or extension.endswith('iso.xml'):
         base_name = base_name_template.format(
-            frame_id="F01234",
+            frame_id="F10859",
             pol="VV",
-            ref_datetime="20190101T232711",
-            sec_datetime="20190906T232711",
+            ref_datetime="20160705T000000",
+            sec_datetime="20160822T000000",
             product_version=dataset_match.groupdict()['product_version'],
             creation_ts=creation_time
         )
@@ -588,29 +599,31 @@ def get_disp_s1_simulated_output_filenames(dataset_match, pge_config, extension)
         output_filenames.append(f'{base_name}.{extension}')
     elif extension.endswith('png'):
         base_name = base_name_template.format(
-            frame_id="F01234",
+            frame_id="F10859",
             pol="VV",
-            ref_datetime="20190101T232711",
-            sec_datetime="20190906T232711",
+            ref_datetime="20160705T000000",
+            sec_datetime="20160822T000000",
             product_version=dataset_match.groupdict()['product_version'],
             creation_ts=creation_time
         )
 
         output_filenames.append(f'{base_name}_BROWSE.{extension}')
     elif extension.endswith('h5'):
-        base_name = compressed_cslc_template.format(
-            burst_id="T042-088905-IW1",
-            ts_start="20221119",
-            ts_end="20221213",
-            creation_ts=creation_time,
-            pol="VV",
-            product_version=dataset_match.groupdict()['product_version']
-        )
+        for burst_id in CCSLC_BURST_IDS:
+            base_name = compressed_cslc_template.format(
+                burst_id=burst_id,
+                ref_date="20160705",
+                first_date="20160822",
+                last_date="20160915",
+                creation_ts=creation_time,
+                pol="VV",
+                product_version=dataset_match.groupdict()['product_version']
+            )
 
-        output_filenames.append(f'{base_name}.{extension}')
+            output_filenames.append(f'{base_name}.{extension}')
     else:
         base_name = ancillary_name_template.format(
-            frame_id="F01234",
+            frame_id="F10859",
             product_version=dataset_match.groupdict()['product_version'],
             creation_ts=creation_time
         )

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -140,8 +140,11 @@ def disp_s1_lineage_metadata(context, work_dir):
 
     lineage_metadata = []
 
+    input_file_group = run_config["input_file_group"]
+    s3_input_filepaths = input_file_group["input_file_paths"] + input_file_group["compressed_cslc_paths"]
+
     # Reassign all S3 URI's in the runconfig to where the files now reside on the local worker
-    for s3_input_filepath in run_config["input_file_group"]["input_file_paths"]:
+    for s3_input_filepath in s3_input_filepaths:
         local_input_filepath = os.path.join(work_dir, basename(s3_input_filepath))
 
         if os.path.isdir(local_input_filepath):


### PR DESCRIPTION
## Purpose
- This branch incorporates usage of the the list of Compressed CSLC products provided to a DISP-S1 SCIFLO job. In addition to including the CCSLCs in the RunConfig for a DISP-S1 job, this branch also adds the following:
  - CSLC download job now obtains the Ionosphere file(s) corresponding to the reference date of the CCSLCs to be used.
  - Fixed a bug where the incorrect S3 URLs where assigned to the ES metadata for Compressed CSLC products
  - The DISP-S1 workflow now utilizes the `save_compressed_slcs` flag provided to the job to assign the same field within the RunConfig
  - Simulation mode for DISP-S1 now generates a realistic number of Compressed CSLC products (27), and the sample filenames have been updated to be more realistic to the actual workflow.

## Issues
- Resolves #911 

## Testing
- Branch has been tested on a dev cluster using DISP-S1 in both real and simulation mode. To test usage of the Compressed CSLCs and Ionosphere file staging, the following commands can be used from mozart:
`python ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -c OPERA_L2_CSLC-S1_V1 --start-date=2016-07-05T00:00:00Z --end-date=2016-07-30T00:00:00Z --frame-id=10859 --use-temporal --chunk-size=1 --job-queue=opera-job_worker-cslc_data_download --processing-mode=historical --k=2 --m=1`
This first job will not utilize any CCSLCs, but will create some to be used by the next job. Let the first job **run to completion**, then run:
`python ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -c OPERA_L2_CSLC-S1_V1 --start-date=2016-08-22T00:00:00Z --end-date=2016-09-16T00:00:00Z --frame-id=10859 --use-temporal --chunk-size=1 --job-queue=opera-job_worker-cslc_data_download --processing-mode=historical --k=2 --m=2`
This job will utilize the CCSLCs created by the first job.