### PR TITLE
DSWx-S1 PGE v3.0.1 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -388,7 +388,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
-    "dswx_s1"  = "3.0.0"
+    "dswx_s1"  = "3.0.1"
     "disp_s1"  = "3.0.0-rc.3.0"
     "dswx_ni"  = "4.0.0-er.2.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -175,7 +175,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
-    "dswx_s1"  = "3.0.0"
+    "dswx_s1"  = "3.0.1"
     "disp_s1"  = "3.0.0-rc.3.0"
     "dswx_ni"  = "4.0.0-er.2.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -389,7 +389,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
-    "dswx_s1"  = "3.0.0"
+    "dswx_s1"  = "3.0.1"
     "disp_s1"  = "3.0.0-rc.3.0"
     "dswx_ni"  = "4.0.0-er.2.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -33,7 +33,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
-    "dswx_s1"  = "3.0.0"
+    "dswx_s1"  = "3.0.1"
     "disp_s1"  = "3.0.0-rc.3.0"
     "dswx_ni"  = "4.0.0-er.2.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -599,7 +599,7 @@ variable "pge_releases" {
     "dswx_hls" = "1.0.2"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
-    "dswx_s1"  = "3.0.0"
+    "dswx_s1"  = "3.0.1"
     "disp_s1"  = "3.0.0-rc.3.0"
     "dswx_ni"  = "4.0.0-er.2.0"
   }

--- a/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
@@ -47,6 +47,7 @@ RunConfig:
               {%- for input in data.input_file_group.input_file_paths %}
               - {{ input }}
               {%- endfor %}
+            input_mgrs_collection_id: {{ data.input_file_group.input_mgrs_collection_id }}
           dynamic_ancillary_file_group:
             {%- for type in data.dynamic_ancillary_file_group.keys() %}
             {%- if data.dynamic_ancillary_file_group[ type ] is not none %}

--- a/conf/schema/RunConfig_schema.L3_DSWx_S1.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_S1.yaml
@@ -49,6 +49,9 @@ RunConfig:
             # REQUIRED - list of RTC products (directory or files)
             input_file_path: list(str(), min=1)
 
+            # Specify the MGRS tile collection ID
+            input_mgrs_collection_id: str(required=False)
+
           dynamic_ancillary_file_group:
             # Digital elevation model
             dem_file: str(required=True)

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_s1:3.0.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_s1:3.0.1",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.1.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -10,8 +10,8 @@
     },
     "dependency_images": [
         {
-          "container_image_name": "opera_pge/dswx_s1:3.0.0",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.0.tar.gz",
+          "container_image_name": "opera_pge/dswx_s1:3.0.1",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.1.tar.gz",
           "container_mappings": {
             "$HOME/.netrc": ["/root/.netrc"],
             "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -15,6 +15,7 @@
 runconfig:
   input_file_group:
     input_file_paths: __CHIMERA_VAL__
+    input_mgrs_collection_id: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file:  __CHIMERA_VAL__
     hand_file: __CHIMERA_VAL__
@@ -39,6 +40,7 @@ preconditions:
   - set_daac_product_type
   - get_s3_input_filepaths
   - get_static_ancillary_files
+  - get_dswx_s1_mgrs_collection_id
   - get_dswx_s1_dynamic_ancillary_maps
   - get_dswx_s1_dem
   - get_dswx_s1_num_workers

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -86,6 +86,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     INPUT_FILE_PATHS = "input_file_paths"
 
+    INPUT_MGRS_COLLECTION_ID = "input_mgrs_collection_id"
+
     INSTANTIATE_ALGORITHM_PARAMETERS_TEMPLATE = "instantiate_algorithm_parameters_template"
 
     INUNDATED_VEGETATION_ENABLED = "inundated_vegetation_enabled"

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -851,6 +851,25 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_dswx_s1_mgrs_collection_id(self):
+        """
+        Inserts the MGRS collection ID from the job metadata into the RunConfig
+        for use with a DSWx-S1 job.
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        rc_params = {}
+
+        metadata: Dict[str, str] = self._context["product_metadata"]["metadata"]
+
+        mgrs_set_id = metadata["mgrs_set_id"]
+
+        rc_params[oc_const.INPUT_MGRS_COLLECTION_ID] = mgrs_set_id
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def get_dswx_s1_num_workers(self):
         """
         Determines the number of workers/cores to assign to an DSWx-S1 job as a


### PR DESCRIPTION
## Purpose
- This branch integrates the DSWx-S1 PGE v3.0.1 with OPERA PCM. This release incorporates the Final v1.1 delivery of the corresponding SAS, which corrects an issue where the SAS could produce the incorrect MGRS tile set for certain regions of the globe.

## Issues
- Resolves #957 

## Testing
- Branch has been tested on dev cluster, specifically to test the fix for MGRS tile set generate describe above. The following commands were used to verify the fix:

- `python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query     --collection-shortname=OPERA_L2_RTC-S1_V1     --endpoint=OPS   --job-queue=opera-job_worker-rtc_data_download     --chunk-size=1     --transfer-protocol=auto     --native-id=OPERA_L2_RTC-S1_T114-243333-IW1_20240728T122706Z_20240728T164508Z_S1A_30_v1.0`
   - This job should now correctly create the following MGRS tile set (MS_114_52):
['16XDK', '16XEK', '16XEL', '17XME', '17XMF', '17XNE', '17XNF', '18XVK', '18XVL', '18XWL']
    Note that `18XWL` may not be created due to unavailable RTC bursts for this time range.
- `python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query --collection-shortname=OPERA_L2_RTC-S1_V1 --endpoint=OPS --start-date=2024-02-14T15:36:00Z --end-date=2024-02-14T15:46:00Z --job-queue=opera-job_worker-rtc_data_download --chunk-size=1 --max-revision=1000 --use-temporal --transfer-protocol=auto`
   - This job should now correctly create the following MGRS tile set (MS_160_1): ['37NCB', '37NDA', '37NDB', '37NEA', '37NEB', '37NFA', '37NFB', '37NGA']
