### PR TITLE
DISP-S1 Workflow ECMWF Usage Update

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -154,6 +154,11 @@ DISP_S1:
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 50
 
+  # Set flag this to False to allow a DISP-S1 job to continue if certain
+  # ancillaries are not available (such as troposphere files). If True, any
+  # missing files will result in a RuntimeError, failing the job.
+  STRICT_ANCILLARY_USAGE: !!bool false
+
 DSWX_NI:
   # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)
   ANCILLARY_MARGIN: 50

--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -167,6 +167,20 @@ def parse_cslc_file_name(native_id):
     acquisition_dts = match_product_id.group("acquisition_ts")  # e.g. 20210705T183117Z
     return burst_id, acquisition_dts
 
+
+def parse_compressed_cslc_file_name(native_id):
+    dataset_json = datasets_json_util.DatasetsJson()
+    ccslc_granule_regex = dataset_json.get("L2_CSLC_S1_COMPRESSED")["match_pattern"]
+    match_product_id = re.match(ccslc_granule_regex, native_id)
+
+    if not match_product_id:
+        raise ValueError(f"Compressed CSLC native ID {native_id} could not be parsed with regex from datasets.json")
+
+    burst_id = match_product_id.group("burst_id")  # e.g. T074-157286-IW3
+    acquisition_dts = match_product_id.group("ref_date_time")  # e.g. 20210705
+    return burst_id, acquisition_dts
+
+
 def determine_acquisition_cycle_cslc(acquisition_dts: datetime, frame_number: int, frame_to_bursts):
 
     day_index, seconds = sensing_time_day_index(acquisition_dts, frame_number, frame_to_bursts)

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -21,8 +21,7 @@ runconfig:
     mask_file: __CHIMERA_VAL__
     dem_file: __CHIMERA_VAL__
     ionosphere_files: __CHIMERA_VAL__
-    # TODO: to be supported in next release
-    #troposphere_files: __CHIMERA_VAL__
+    troposphere_files: __CHIMERA_VAL__
   static_ancillary_file_group:
     frame_to_burst_json: __CHIMERA_VAL__
     # TODO: unsure if we have this yet or if it even needs to be provided in production
@@ -55,8 +54,7 @@ preconditions:
   - get_disp_s1_compressed_cslc_files
   - get_disp_s1_static_layers_files
   - get_disp_s1_ionosphere_files
-  # TODO: to be supported in next release
-  #- get_disp_s1_troposphere_files
+  - get_disp_s1_troposphere_files
   - get_disp_s1_mask_file
   - get_disp_s1_dem
   - get_disp_s1_save_compressed_slc
@@ -88,6 +86,13 @@ get_disp_s1_algorithm_parameters:
   # the processing mode (forward vs. historical) will be filled in by the function itself
   s3_bucket: "opera-ancillaries"
   s3_key: "algorithm_parameters/disp_s1/0.4.1/algorithm_parameters_{processing_mode}.yaml.tmpl"
+
+get_disp_s1_troposphere_files:
+  # This S3 path only defines the root location of ECMWF files. Full paths to
+  # the specific files needed for a DISP-S1 job will be determined by the
+  # precondition function itself.
+  s3_bucket: "opera-ancillaries"
+  s3_key: "ecmwf"
 
 instantiate_algorithm_parameters_template:
   template_mapping:

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -44,6 +44,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     GET_DISP_S1_MASK_FILE = "get_disp_s1_mask_file"
 
+    GET_DISP_S1_TROPOSPHERE_FILES = "get_disp_s1_troposphere_files"
+
     GET_DSWX_HLS_DEM = "get_dswx_hls_dem"
 
     GET_DSWX_S1_ALGORITHM_PARAMETERS = "get_dswx_s1_algorithm_parameters"

--- a/tests/unit/util/test_ecmwf_util.py
+++ b/tests/unit/util/test_ecmwf_util.py
@@ -1,0 +1,99 @@
+
+from collections import namedtuple
+from datetime import datetime
+from unittest.mock import patch, MagicMock
+
+import botocore.client
+import botocore.exceptions
+import pytest
+
+from util.ecmwf_util import (check_s3_for_ecmwf,
+                             ecmwf_key_for_datetime,
+                             find_ecmwf_for_datetime)
+
+
+def test_check_s3_for_ecmwf(caplog):
+    # Test with valid result from s3_client.head_object()
+    mock_head_object = MagicMock()
+
+    with patch.object(botocore.client.BaseClient, "_make_api_call", mock_head_object):
+        assert check_s3_for_ecmwf("s3://opera-ancillaries/ecmwf/20230202/D02020000020200001.subset.zz.nc")
+        mock_head_object.assert_called()
+
+    # Test with 404 not found result from s3_client.head_object()
+    mock_head_object = MagicMock(
+        side_effect=botocore.exceptions.ClientError({"Error": {"Code": "404"}}, "head_object")
+    )
+
+    with patch.object(botocore.client.BaseClient, "_make_api_call", mock_head_object):
+        assert check_s3_for_ecmwf("s3://opera-ancillaries/ecmwf/20230202/D02020000020200001.subset.zz.nc") == False
+        mock_head_object.assert_called()
+        assert "ECMWF file ecmwf/20230202/D02020000020200001.subset.zz.nc does not exist in bucket opera-ancillaries" in caplog.text
+
+    # Test with an unexpected error result from s3_client.head_object()
+    mock_head_object = MagicMock(side_effect=ValueError("Test Value Error"))
+
+    with patch.object(botocore.client.BaseClient, "_make_api_call", mock_head_object):
+        with pytest.raises(ValueError):
+            check_s3_for_ecmwf("s3://opera-ancillaries/ecmwf/20230202/D02020000020200001.subset.zz.nc")
+
+        mock_head_object.assert_called()
+
+
+def test_ecmwf_key_for_datetime():
+    TestCase = namedtuple('TestCase', ['datetime', 'expected_ecmwf_key'])
+
+    # Setup test cases that hit each 6 hour time quadrant
+    test_cases = [
+        TestCase("20230202T000000", "20230202/D02020000020200001.subset.zz.nc"),
+        TestCase("20230202T031035", "20230202/D02020000020200001.subset.zz.nc"),
+        TestCase("20240101T060000", "20240101/D01010600010106001.subset.zz.nc"),
+        TestCase("20240101T103022", "20240101/D01010600010106001.subset.zz.nc"),
+        TestCase("20220822T120000", "20220822/D08221200082212001.subset.zz.nc"),
+        TestCase("20220822T151515", "20220822/D08221200082212001.subset.zz.nc"),
+        TestCase("20210615T180000", "20210615/D06151800061518001.subset.zz.nc"),
+        TestCase("20211109T212121", "20211109/D11091800110918001.subset.zz.nc")
+    ]
+
+    for test_case in test_cases:
+        dt = datetime.strptime(test_case.datetime, "%Y%m%dT%H%M%S")
+
+        ecmwf_key = ecmwf_key_for_datetime(dt)
+
+        assert ecmwf_key == test_case.expected_ecmwf_key
+
+
+def test_find_ecmwf_for_datetime():
+    TestCase = namedtuple('TestCase', ['datetime', 'expected_ecmwf_uri'])
+
+    # Setup test cases that hit each 6 hour time quadrant
+    test_cases = [
+        TestCase("20230202T000000", "s3://opera-ancillaries/ecmwf/20230202/D02020000020200001.subset.zz.nc"),
+        TestCase("20240101T060000", "s3://opera-ancillaries/ecmwf/20240101/D01010600010106001.subset.zz.nc"),
+        TestCase("20220822T120000", "s3://opera-ancillaries/ecmwf/20220822/D08221200082212001.subset.zz.nc"),
+        TestCase("20210615T180000", "s3://opera-ancillaries/ecmwf/20210615/D06151800061518001.subset.zz.nc"),
+    ]
+
+    # Mock a valid response from s3_client.head_object()
+    mock_head_object = MagicMock()
+
+    with patch.object(botocore.client.BaseClient, "_make_api_call", mock_head_object):
+        for test_case in test_cases:
+            dt = datetime.strptime(test_case.datetime, "%Y%m%dT%H%M%S")
+
+            ecmwf_uri = find_ecmwf_for_datetime(dt)
+
+            assert ecmwf_uri == test_case.expected_ecmwf_uri
+
+    # Mock a 404 not found response from s3_client.head_object()
+    mock_head_object = MagicMock(
+        side_effect=botocore.exceptions.ClientError({"Error": {"Code": "404"}}, "head_object")
+    )
+
+    with patch.object(botocore.client.BaseClient, "_make_api_call", mock_head_object):
+        for test_case in test_cases:
+            dt = datetime.strptime(test_case.datetime, "%Y%m%dT%H%M%S")
+
+            ecmwf_uri = find_ecmwf_for_datetime(dt)
+
+            assert ecmwf_uri is None

--- a/util/ecmwf_util.py
+++ b/util/ecmwf_util.py
@@ -1,0 +1,137 @@
+
+"""
+==============
+ecmwf_util.py
+==============
+
+Contains utility functions for working with ECMWF (Troposphere) weather files.
+
+"""
+
+from datetime import datetime
+from urllib.parse import urlparse
+
+from commons.logger import logger
+
+import botocore
+import boto3
+
+s3_client = boto3.client("s3")
+
+
+
+def check_s3_for_ecmwf(ecmwf_s3_uri: str):
+    """
+    Checks for the existence of an ECMWF (troposphere) file in S3.
+
+    Parameters
+    ----------
+    ecmwf_s3_uri : str
+        S3 URI to ECMWF file to locate. Should begin with s3://
+
+    Returns
+    -------
+    True if the file exists in S3, False otherwise
+
+    Raises
+    ------
+    ValueError
+        If the provided URI cannot be parsed as-expected.
+
+    """
+    try:
+        parsed_uri = urlparse(ecmwf_s3_uri)
+    except ValueError as err:
+        logger.error("Failed to parse ECMWF S3 URI %s, reason: %s", ecmwf_s3_uri, str(err))
+        raise
+
+    bucket = parsed_uri.netloc
+    key = parsed_uri.path
+
+    # Strip leading forward slash
+    if key.startswith("/"):
+        key = key[1:]
+
+    try:
+        s3_client.head_object(Bucket=bucket, Key=key)
+    except botocore.exceptions.ClientError as e:
+        if e.response["Error"]["Code"] == "404":
+            # File does not exist
+            logger.warning("ECMWF file %s does not exist in bucket %s", key, bucket)
+            return False
+        else:
+            # Some kind of unexpected error
+            raise
+
+    # If here, the file exists in S3
+    return True
+
+def ecmwf_key_for_datetime(dt : datetime):
+    """
+    Derives the expected S3 key of an ECMWF file corresponding to the provided
+    datetime. This does not include a bucket name, or any key portions that
+    occur prior to the date (YYYYMMDD) of the ECMWF file.
+
+    Parameters
+    ----------
+    dt : datetime
+        The datetime object to derive the ECMWF key path for.
+
+    Returns
+    -------
+    ecmwf_key : str
+        The S3 key to the location of the ECMWF file that corresponds to the
+        provided datetime.
+
+    """
+    # Derive the YYYYMMDD key prefix
+    prefix = dt.strftime("%Y%m%d")
+
+    # Determine the 6-hour time window quadrant that corresponds to the provided hour
+    if 0 <= dt.hour < 6:
+        hour = "00"
+    elif 6 <= dt.hour < 12:
+        hour = "06"
+    elif 12 <= dt.hour < 18:
+        hour = "12"
+    else:
+        hour = "18"
+
+    key_template = "{prefix}/D{month}{day}{hour}00{month}{day}{hour}001.subset.zz.nc"
+
+    return key_template.format(
+        prefix=prefix, month=dt.strftime("%m"), day=dt.strftime("%d"), hour=hour
+    )
+
+
+def find_ecmwf_for_datetime(dt : datetime, s3_prefix="s3://opera-ancillaries/ecmwf"):
+    """
+    Returns the S3 path to an ECMWF file corresponding to the provided datetime,
+    if it exists.
+
+    Parameters
+    ----------
+    dt : datetime.datetime
+        Datetime object corresponding to the ECMWF file to find.
+    s3_prefix : str, optional
+        Prefix to be appended to the datetime-specific portion of the S3 URI.
+        Should always start with "s3://". Defaults to s3://opera-ancillaries/ecmwf.
+
+    Returns
+    -------
+    S3 URI for the location of the desired ECMWF file, if it exists. None otherwise.
+
+    Raises
+    ------
+    ValueError
+        If the provided s3_prefix does not begin with "s3://"
+
+    """
+    if not s3_prefix.startswith("s3://"):
+        raise ValueError(f"Invalid S3 prefix ({s3_prefix}) provided. Must begin with \"s3://\"")
+
+    ecmwf_key = ecmwf_key_for_datetime(dt)
+
+    ecmwf_s3_path = "/".join([s3_prefix, ecmwf_key])
+
+    return ecmwf_s3_path if check_s3_for_ecmwf(ecmwf_s3_path) else None


### PR DESCRIPTION
## Purpose
- This branch represents an initial integration of support for ECMWF (Troposphere) file usage with the DISP-S1 PGE workflow. A precondition function in the Chimera workflow for DISP-S1 will now derive the set of ECMWF files for use with a DISP-S1 job based on the CSLC products (compressed and standard) staged for the job. Note that further refinements may be required to this branch once a sufficient number of subset/compressed ECMWF files are available for further testing.
- A flag to control the behavior of the precondition function has also been added to settings.yaml, named `STRICT_ANCILLARY_USAGE`. If this flag is set to True, then any expected ECMWF files that are not available in S3 will result in a failed DISP-S1 job. If set to False, then any missing files will result in a DISP-S1 job with **no troposphere files provided**. This was added to allow testing to continue while the back catalog of subset and compressed ECMWF files is still being populated. When in production, the `STRICT_ANICLLARY_USAGE` flag should be set to True.
- Lastly, a new utility module, `ecmwf_utils.py`, has been added to collect the functions used to derive ECMWF S3 paths, and check for their availability. One function in particular, `find_ecmwf_for_datetime()`, has been added for use with the CSLC file staging logic to ensure that all ECMWF files are available before triggering a DISP-S1 job.

## Issues
- Resolves #967 

## Testing
- Unit tests have been added for both the new `ecmwf_utils.py` module, as well as the new precondition function used to assign ECMWF files to the DISP-S1 RunConfig.
- This branch was also tested on a dev cluster using both simulation and real mode for DISP-S1, as well as with the `STRICT_ANCILLARY_USAGE` flag enabled and disabled.
