### PR TITLE
Disable inclusion of water mask with DISP-S1 workflow

### DIFF
--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -18,7 +18,8 @@ runconfig:
     compressed_cslc_paths: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     static_layers_files: __CHIMERA_VAL__
-    mask_file: __CHIMERA_VAL__
+    # TODO reenable when water mask is corrected
+    #mask_file: __CHIMERA_VAL__
     dem_file: __CHIMERA_VAL__
     ionosphere_files: __CHIMERA_VAL__
     # TODO: to be supported in next release
@@ -57,7 +58,8 @@ preconditions:
   - get_disp_s1_ionosphere_files
   # TODO: to be supported in next release
   #- get_disp_s1_troposphere_files
-  - get_disp_s1_mask_file
+  # TODO reenable when water mask is corrected
+  #- get_disp_s1_mask_file
   - get_disp_s1_dem
   - get_disp_s1_save_compressed_slc
   - get_disp_s1_algorithm_parameters


### PR DESCRIPTION
## Purpose
- This branch disables inclusion of the water mask used with a DISP-S1 job, since the format of the existing water mask seems to be incorrect.

## Testing
- Branch has been tested on a dev cluster to ensure that a DISP-S1 job can get up and running without the water mask present in the RunConfig
