### PR TITLE
971 survey disp s1 frame only

### DIFF
--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -411,7 +411,7 @@ def parse_cslc_burst_id(native_id):
     burst_id, _ = parse_cslc_file_name(native_id)
     return burst_id
 
-def build_cslc_native_ids(frame, disp_burst_map):
+def build_cslc_native_ids(frame: int, disp_burst_map):
     """Builds the native_id string for a given frame. The native_id string is used in the CMR query."""
 
     native_ids = list(disp_burst_map[frame].burst_ids)

--- a/data_subscriber/survey.py
+++ b/data_subscriber/survey.py
@@ -6,7 +6,6 @@ import backoff
 
 from data_subscriber.cmr import async_query_cmr, CMR_TIME_FORMAT
 from data_subscriber.query import get_query_timerange, DateTimeRange
-from data_subscriber.cslc.cslc_query import CslcCmrQuery
 import cslc_utils
 
 _date_format_str = CMR_TIME_FORMAT
@@ -14,11 +13,16 @@ _date_format_str_cmr = _date_format_str[:-1] + ".%fZ"
 
 
 @backoff.on_exception(backoff.expo, Exception, max_value=13)
-def _query_cmr_backoff(args, token, cmr, settings, query_timerange, now, cslc_query = None, silent=True):
-    if cslc_query is not None:
-        result = cslc_query.query_cmr_by_frame_and_dates(args, token, cmr, settings, query_timerange, now, silent)
-    else:
-        result = asyncio.run(async_query_cmr(args, token, cmr, settings, query_timerange, now, silent))
+def _query_cmr_backoff(args, token, cmr, settings, query_timerange, now, disp_burst_map = None, silent=True):
+
+    # If disp_burst_map is not None, that means we are only querying for a specific frame_id
+    # Restrict CMR query by the burst pattern that make up the DISP-S1 frame
+    if disp_burst_map is not None:
+        count, native_id = cslc_utils.build_cslc_native_ids(int(args.frame_id), disp_burst_map)
+        args.native_id = native_id
+        print(args.native_id)
+
+    result = asyncio.run(async_query_cmr(args, token, cmr, settings, query_timerange, now, silent))
     return result
 
 
@@ -39,11 +43,10 @@ def run_survey(args, token, cmr, settings):
     all_granules = {}
     all_deltas = []
 
-    cslc_query = None
+    disp_burst_map = None
     if args.frame_id is not None:
         logging.info("Querying for DISP-S1 frame_id only: " + str(args.frame_id))
-        cslc_query = CslcCmrQuery(args, token, None, cmr, None, settings,
-                                          cslc_utils.DISP_FRAME_BURST_MAP_HIST)
+        disp_burst_map, _, _ = cslc_utils.localize_disp_frame_burst_hist()
 
     while start_dt < end_dt:
 
@@ -58,7 +61,7 @@ def run_survey(args, token, cmr, settings):
 
         query_timerange: DateTimeRange = get_query_timerange(args, now, silent=True)
 
-        granules = _query_cmr_backoff(args, token, cmr, settings, query_timerange, now, cslc_query, silent=True)
+        granules = _query_cmr_backoff(args, token, cmr, settings, query_timerange, now, disp_burst_map, silent=True)
 
         count = 0
         for granule in granules:


### PR DESCRIPTION
```daac_data_subscriber``` ```survey``` for CSLC data can now survey for a specific DISP-S1 frame only.
