### PR TITLE
DSWx-NI v4.0.0 er.3.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -390,7 +390,7 @@ variable "pge_releases" {
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.0-rc.4.0"
-    "dswx_ni"  = "4.0.0-er.2.0"
+    "dswx_ni"  = "4.0.0-er.3.0"
   }
 }
 

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -177,7 +177,7 @@ variable "pge_releases" {
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.0-rc.4.0"
-    "dswx_ni"  = "4.0.0-er.2.0"
+    "dswx_ni"  = "4.0.0-er.3.0"
   }
 }
 

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -391,7 +391,7 @@ variable "pge_releases" {
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.0-rc.4.0"
-    "dswx_ni"  = "4.0.0-er.2.0"
+    "dswx_ni"  = "4.0.0-er.3.0"
   }
 }
 

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -35,7 +35,7 @@ variable "pge_releases" {
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.0-rc.4.0"
-    "dswx_ni"  = "4.0.0-er.2.0"
+    "dswx_ni"  = "4.0.0-er.3.0"
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -601,7 +601,7 @@ variable "pge_releases" {
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.0-rc.4.0"
-    "dswx_ni"  = "4.0.0-er.2.0"
+    "dswx_ni"  = "4.0.0-er.3.0"
   }
 }
 

--- a/conf/RunConfig.yaml.L3_DSWx_NI.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_NI.jinja2.tmpl
@@ -65,6 +65,7 @@ RunConfig:
             worldcover_file_description: 'ESA WorldCover 10m 2020 v1.0'
             reference_water_file_description: 'JRC Global Surface Water - collection from 1984 to 2021'
             hand_file_description: 'ASF HAND GLO30'
+            glad_classification_file_description: 'GLAD Global Land Cover 2020'
           static_ancillary_file_group:
             static_ancillary_inputs_flag: True
             {%- for type in data.static_ancillary_file_group.keys() %}
@@ -87,5 +88,11 @@ RunConfig:
             save_browse: True
             browse_image_height: 1024
             browse_image_width: 1024
+            flag_collapse_wtr_classes: True
+            exclude_inundated_vegetation: False
+            set_not_water_to_nodata: False
+            set_hand_mask_to_nodata: True
+            set_layover_shadow_to_nodata: True
+            set_ocean_masked_to_nodata: False
             save_tif_to_output: True
           log_file: {{ data.product_path_group.scratch_path }}/dswx-ni.log

--- a/conf/schema/RunConfig_schema.L3_DSWx_NI.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_NI.yaml
@@ -79,6 +79,12 @@ RunConfig:
             # ESA WorldCover map description
             worldcover_file_description: str(required=False)
 
+            # GLAD classification map file
+            glad_classification_file: str(required=False)
+
+            # GLAD classification map file description
+            glad_classification_file_description: str(required=False)
+
             # NOAA GSHHS shapefile
             shoreline_shapefile: str(required=False)
 
@@ -88,7 +94,7 @@ RunConfig:
             # algorithm parameter
             algorithm_parameters: str(required=True)
 
-            # placeholder for inundated vegettion
+            # placeholder for inundated vegetation
             mean_backscattering: str(required=False)
             standard_deviation_backscattering: str(required=False)
 

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_NI
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_NI
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_ni:4.0.0-er.2.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_ni-4.0.0-er.2.0.tar.gz",
+      "container_image_name": "opera_pge/dswx_ni:4.0.0-er.3.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_ni-4.0.0-er.3.0.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -26,8 +26,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/dswx_ni:4.0.0-er.2.0",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_ni-4.0.0-er.2.0.tar.gz",
+          "container_image_name": "opera_pge/dswx_ni:4.0.0-er.3.0",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_ni-4.0.0-er.3.0.tar.gz",
           "container_mappings": {
             "$HOME/.netrc": ["/root/.netrc"],
             "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_NI.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_NI.yaml
@@ -21,6 +21,7 @@ runconfig:
     hand_file: __CHIMERA_VAL__
     worldcover_file: __CHIMERA_VAL__
     reference_water_file: __CHIMERA_VAL__
+    glad_classification_file: __CHIMERA_VAL__
   static_ancillary_file_group:
     mgrs_database_file: __CHIMERA_VAL__
     mgrs_collection_database_file: __CHIMERA_VAL__

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -633,7 +633,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         working_dir = get_working_dir()
 
         s3_bucket = "operasds-dev-pge"
-        s3_key = "dswx_ni/dswx_ni_interface_0.1_expected_input.zip"
+        s3_key = "dswx_ni/dswx_ni_beta_0.2_expected_input.zip"
 
         output_filepath = os.path.join(working_dir, os.path.basename(s3_key))
 
@@ -648,8 +648,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
             zip_contents = list(filter(lambda x: not x.endswith('.DS_Store'), zip_contents))
             myzip.extractall(path=working_dir, members=zip_contents)
 
-        rtc_data_dir = os.path.join(working_dir, 'dswx_ni_interface_0.1_expected_input', 'input_dir', 'RTC')
-        ancillary_data_dir = os.path.join(working_dir, 'dswx_ni_interface_0.1_expected_input', 'input_dir', 'ancillary_data')
+        rtc_data_dir = os.path.join(working_dir, 'dswx_ni_beta_0.2_expected_input', 'input_dir', 'RTC')
+        ancillary_data_dir = os.path.join(working_dir, 'dswx_ni_beta_0.2_expected_input', 'input_dir', 'ancillary_data')
 
         rtc_files = os.listdir(rtc_data_dir)
 
@@ -661,6 +661,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
             'hand_file': os.path.join(ancillary_data_dir, 'hand.tif'),
             'worldcover_file': os.path.join(ancillary_data_dir, 'worldcover.tif'),
             'reference_water_file': os.path.join(ancillary_data_dir, 'reference_water.tif'),
+            'glad_classification_file': os.path.join(ancillary_data_dir, 'glad_classification.tif'),
             'algorithm_parameters': os.path.join(ancillary_data_dir, 'algorithm_parameter_ni.yaml'),
             'mgrs_database_file': os.path.join(ancillary_data_dir, 'MGRS_tile.sqlite'),
             'mgrs_collection_database_file': os.path.join(ancillary_data_dir, 'MGRS_collection_db_DSWx-NI_v0.1.sqlite'),

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -116,13 +116,13 @@ def dswx_ni_lineage_metadata(context, work_dir):
     lineage_metadata = []
 
     # TODO: update paths as necessary as sample inputs are phased out
-    rtc_data_dir = os.path.join(work_dir, 'dswx_ni_interface_0.1_expected_input', 'input_dir', 'RTC')
+    rtc_data_dir = os.path.join(work_dir, 'dswx_ni_beta_0.2_expected_input', 'input_dir', 'RTC')
 
     lineage_metadata.extend(
         [os.path.join(rtc_data_dir, rtc_file) for rtc_file in os.listdir(rtc_data_dir)]
     )
 
-    ancillary_data_dir = os.path.join(work_dir, 'dswx_ni_interface_0.1_expected_input', 'input_dir', 'ancillary_data')
+    ancillary_data_dir = os.path.join(work_dir, 'dswx_ni_beta_0.2_expected_input', 'input_dir', 'ancillary_data')
 
     lineage_metadata.extend(
         [os.path.join(ancillary_data_dir, ancillary) for ancillary in os.listdir(ancillary_data_dir)]
@@ -302,7 +302,7 @@ def update_dswx_ni_runconfig(context, work_dir):
 
     container_home: str = container_home_param['value']
     container_home_prefix = f'{container_home}/input_dir'
-    rtc_data_prefix = os.path.join(work_dir, 'dswx_ni_interface_0.1_expected_input', 'input_dir', 'RTC')
+    rtc_data_prefix = os.path.join(work_dir, 'dswx_ni_beta_0.2_expected_input', 'input_dir', 'RTC')
 
     input_file_paths = run_config["input_file_group"]["input_file_paths"]
     input_file_paths = list(map(lambda x: x.replace(rtc_data_prefix, container_home_prefix), input_file_paths))
@@ -314,6 +314,7 @@ def update_dswx_ni_runconfig(context, work_dir):
     run_config["dynamic_ancillary_file_group"]["hand_file"] = f'{container_home_prefix}/hand.tif'
     run_config["dynamic_ancillary_file_group"]["worldcover_file"] = f'{container_home_prefix}/worldcover.tif'
     run_config["dynamic_ancillary_file_group"]["reference_water_file"] = f'{container_home_prefix}/reference_water.tif'
+    run_config["dynamic_ancillary_file_group"]["glad_classification_file"] = f'{container_home_prefix}/glad_classification.tif'
 
     run_config["static_ancillary_file_group"]["mgrs_database_file"] = f'{container_home_prefix}/MGRS_tile.sqlite'
     run_config["static_ancillary_file_group"]["mgrs_collection_database_file"] = f'{container_home_prefix}/MGRS_collection_db_DSWx-NI_v0.1.sqlite'


### PR DESCRIPTION
## Purpose
- This branch integrates the DSWx-NI PGE v4.0.0-er.3.0 with OPERA PCM
- This release incorporates the beta delivery of the DSWx-NI SAS
- The method for executing this PGE has not changed since the previous version. It can be run by submitting an on-demand SCIFLO_L3_DSWx_NI job via Tosca, and will use the latest sample data provided with the beta SAS delivery.

## Issues
- Resolves #994 

## Testing
- Branch has been tested on a dev cluster by submitting a SCIFLO_L3_DSWx_NI job using both real and simulated PGE mode
- The on-demand PGE smoke test was also run using the AMD-based worker queue. All product comparisons passed.

