### PR TITLE
feat(opensearch): remove mock that breaks unit tests

### DIFF
--- a/data_subscriber/rtc/rtc_catalog.py
+++ b/data_subscriber/rtc/rtc_catalog.py
@@ -7,8 +7,8 @@ import elasticsearch.helpers
 from more_itertools import last, chunked
 
 from data_subscriber.catalog import ProductCatalog
+from data_subscriber.rtc import mgrs_bursts_collection_db_client
 from util.grq_client import get_body
-from . import mgrs_bursts_collection_db_client
 
 
 class RTCProductCatalog(ProductCatalog):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -75,10 +75,6 @@ mock_commons_es_connection = types.ModuleType('commons.es_connection')
 sys.modules['commons.es_connection'] = mock_commons_es_connection
 mock_commons_es_connection.get_grq_es = lambda *args, **kwargs: None
 
-mock_mgrs_bursts_collection_db_client = types.ModuleType('data_subscriber.rtc.mgrs_bursts_collection_db_client')
-sys.modules['data_subscriber.rtc.mgrs_bursts_collection_db_client'] = mock_mgrs_bursts_collection_db_client
-mock_mgrs_bursts_collection_db_client.cached_load_mgrs_burst_db = mock_load_mgrs_burst_db_raw
-
 
 @pytest.fixture(autouse=True)
 def deny_network_requests(monkeypatch):

--- a/tests/unit/data_subscriber/test_catalog.py
+++ b/tests/unit/data_subscriber/test_catalog.py
@@ -231,7 +231,12 @@ def test_slc_spatial_product_catalog():
     assert isinstance(slc_spatial_product_catalog.generate_es_index_name(), str)
     assert slc_spatial_product_catalog.generate_es_index_name().startswith("slc_spatial_catalog-")
 
-def test_rtc_product_catalog():
+
+@patch("data_subscriber.rtc.rtc_catalog.mgrs_bursts_collection_db_client")
+def test_rtc_product_catalog(patch_mgrs_bursts_collection_db_client):
+    from tests.unit.conftest import mock_load_mgrs_burst_db_raw
+    patch_mgrs_bursts_collection_db_client.cached_load_mgrs_burst_db = mock_load_mgrs_burst_db_raw
+
     """Tests for functionality specific to the RTCProductCatalog class"""
     rtc_product_catalog = RTCProductCatalog()
 


### PR DESCRIPTION
Refs #1005

## Purpose
mitigate AttributeError in Jenkins
## Proposed Changes
- [CHANGE] import and mocking of mgrs burst collection database

## Issues
- #1005 
## Testing
- tested locally
