### PR TITLE
Add support for propagation of soft time out to Sciflo worker

### DIFF
--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"300GB",
   "soft_time_limit": 40000,
   "time_limit": 40060,

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"300GB",
   "soft_time_limit": 40000,
   "time_limit": 40060,

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"300GB",
   "soft_time_limit": 40000,
   "time_limit": 40060,

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"300GB",
   "soft_time_limit": 40000,
   "time_limit": 40060,

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"100GB",
   "soft_time_limit": 30000,
   "time_limit": 30060,

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"100GB",
   "soft_time_limit": 30000,
   "time_limit": 30060,

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"600GB",
   "soft_time_limit": 129600,
   "time_limit": 129660,

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"600GB",
   "soft_time_limit": 129600,
   "time_limit": 129660,

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"25GB",
   "soft_time_limit": 3600,
   "time_limit": 3660,

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_NI
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_NI
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"100GB",
   "soft_time_limit": 14200,
   "time_limit": 14260,

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_S1
@@ -1,5 +1,5 @@
 {
-  "command": "/home/ops/verdi/ops/chimera/chimera/run_sciflo.sh",
+  "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"100GB",
   "soft_time_limit": 14200,
   "time_limit": 14260,

--- a/opera_chimera/run_sciflo.py
+++ b/opera_chimera/run_sciflo.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+"""
+Python entrypoint for execution of a SCIFLO pipeline
+"""
+
+import argparse
+import os
+import json
+import sys
+import subprocess
+from importlib import import_module
+
+from commons.logger import logger
+from chimera.commons.accountability import Accountability
+from chimera.commons.sciflo_util import (
+  __create_placeholder_alt_files,
+  __cleanup_placeholder_alt_files,
+  extract_error,
+  copy_sciflo_work
+)
+
+def run_sciflo(sfl_file, sfl_args, output_dir, timeout):
+    """
+    Run sciflo.
+
+    This function has been adapted from the default version (chimera/run_sciflo.py)
+    to support inclusion of a timeout value when invoking sflExec.py
+    """
+
+    # build paths to executables
+    sflexec_path = os.path.join(os.environ["HOME"], "verdi", "bin", "sflExec.py")
+
+    # create placeholder files
+    __create_placeholder_alt_files()
+
+    # execute sciflo
+    cmd = [
+        sflexec_path,
+        "-s",
+        "-f",
+        "-o",
+        output_dir,
+        "-t",
+        f"{timeout}",
+        "--args",
+        ",".join(sfl_args),
+        sfl_file,
+    ]
+    logger.info("Running sflExec.py command:\n%s", " ".join(cmd))
+    try:
+        proc = subprocess.run(cmd, shell=False, check=True)
+        status = proc.returncode
+    except subprocess.CalledProcessError as err:
+        status = err.returncode
+    logger.info("Exit status is: %d", status)
+    if status != 0:
+        extract_error("%s/sciflo.json" % output_dir)
+        status = 1
+
+    # copy sciflo work and exec dir
+    try:
+        copy_sciflo_work(output_dir)
+    except Exception:
+        pass
+
+    __cleanup_placeholder_alt_files()
+    return status
+
+
+# grabs accountability class if implemented and set in the sciflo jobspecs
+def get_accountability_class(context_file):
+    work_dir = None
+    context = None
+    if isinstance(context_file, str):
+        work_dir = os.path.dirname(context_file)
+        with open(context_file, "r") as f:
+            context = json.load(f)
+    path = context.get("module_path")
+    if "accountability_module_path" in context:
+        path = context.get("accountability_module_path")
+    accountability_class_name = context.get("accountability_class", None)
+    accountability_module = import_module(path, "opera-pcm")
+    if accountability_class_name is None:
+        logger.error("No accountability class specified")
+        return Accountability(context, work_dir)
+    cls = getattr(accountability_module, accountability_class_name)
+    if not issubclass(cls, Accountability):
+        logger.error("accountability class does not extend Accountability")
+        return Accountability(context, work_dir)
+    cls_object = cls(context, work_dir)
+    return cls_object
+
+
+def main(sfl_file, context_file, output_folder):
+    """Main."""
+
+    sfl_file = os.path.abspath(sfl_file)
+    context_file = os.path.abspath(context_file)
+    with open(context_file) as infile:
+        timeout = (
+            json.load(infile).get("job_specification", {}).get("soft_time_limit", 86400)
+        )
+    logger.info("sfl_file: %s", sfl_file)
+    logger.info("context_file: %s", context_file)
+    logger.info("soft_time_limit: %d", timeout)
+    accountability = get_accountability_class(context_file)
+    accountability.create_job_entry()
+    result = run_sciflo(
+        sfl_file, ["sf_context=%s" % context_file], output_folder, timeout
+    )
+    return result
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sfl_file", help="SciFlo workflow")
+    parser.add_argument("context_file", help="HySDS context file")
+    parser.add_argument("output_folder", help="Sciflo output file")
+    args = parser.parse_args()
+    sys.exit(main(args.sfl_file, args.context_file, args.output_folder))

--- a/opera_chimera/run_sciflo.sh
+++ b/opera_chimera/run_sciflo.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+BASE_PATH=$(dirname "${BASH_SOURCE}")
+BASE_PATH=$(cd "${BASE_PATH}"; pwd)
+
+# source PGE env
+export CHIMERA_HOME=$HOME/verdi/ops/opera-pcm/opera_chimera
+export PYTHONPATH=$BASE_PATH:$CHIMERA_HOME:$PYTHONPATH
+export PATH=$BASE_PATH:$PATH
+export PGE=$(basename "${BASE_PATH}")
+export PYTHONDONTWRITEBYTECODE=1
+
+# source environment
+source $HOME/verdi/bin/activate
+
+MODULE_PATH="$1"
+WF_DIR="$2"
+WF_NAME="$3"
+
+export PYTHONPATH=${MODULE_PATH}:$PYTHONPATH
+
+echo "##########################################" 1>&2
+echo -n "Running $PGE run_sciflo.py with params $WF_DIR/$WF_NAME.sf.xml and _context.json: " 1>&2
+date 1>&2
+python $CHIMERA_HOME/run_sciflo.py $WF_DIR/$WF_NAME.sf.xml _context.json sfl_output > run_sciflo_$WF_NAME.log 2>&1
+STATUS=$?
+echo -n "Finished running $PGE run_sciflo.py: " 1>&2
+date 1>&2
+if [ $STATUS -ne 0 ]; then
+  echo "Failed to run $PGE run_sciflo.py" 1>&2
+  cat run_sciflo_$WF_NAME.log 1>&2
+  echo "{}"
+  exit $STATUS
+fi


### PR DESCRIPTION
## Purpose
- This PR adds OPERA-specific versions of the `run_sciflo.sh` and `run_sciflo.py` entrypoint scripts which are normally part of the baseline `chimera` library. Our versions add support for supplying the soft timeout limit from our job-spec files to the Sciflo executor script, so that we override the default timeout of 24 hours.
- All job spec files for PGE Sciflo jobs have been updated to use our version of `run_sciflo.sh` as the entrypoint script.

## Issues
- Resolves #1031 

## Testing
- Changes to PGE Sciflo jobs have been tested on a dev cluster by running the PGEs in simulation mode. Inspection of the `run_sciflo_<PGE name>.log` files shows that the timeout value from the job-spec file is now propagated to the call to `sflExec.py`

For DISP-S1:
<img width="1050" alt="Screenshot 2024-12-05 at 9 06 58 AM" src="https://github.com/user-attachments/assets/0c68408a-c2b1-4d72-9f88-be51d244819d">

For DSWx-HLS:
<img width="737" alt="Screenshot 2024-12-05 at 9 08 04 AM" src="https://github.com/user-attachments/assets/5f59ef58-c01a-4142-805e-170e4469ef30">

