### PR TITLE
1035 reduce disp s1 product metadata grq

### DIFF
--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -277,7 +277,7 @@ def convert(
             logger.info("Reducing lineage string size by truncating basepath of lineage entries")
             logger.info("dataset_met_json keys: " + str(dataset_met_json.keys()))
             if len(dataset_met_json["lineage"]) > 0:
-                dataset_met_json["lienage_base_path"] = '/'.join(dataset_met_json["lineage"][0].split('/')[:-1])
+                dataset_met_json["lineage_basepath"] = '/'.join(dataset_met_json["lineage"][0].split('/')[:-1])
                 lineage_arr = []
                 for l in dataset_met_json["lineage"]:
                     lineage_arr.append(l.split('/')[-1])

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -264,8 +264,8 @@ def convert(
 
         if pge_name == "L3_DISP_S1":
             # Get rid of bunch of data that we don't care about but takes up a lot of space
-            '''dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
-            dataset_met_json["runconfig"]["input_file_group"]["input_file_paths"] = None # This list is the same as lineage so no point in duplicating'''
+            dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
+            dataset_met_json["runconfig"]["input_file_group"]["input_file_paths"] = None # This list is the same as lineage so no point in duplicating
             logger.info("Removing superfluous data from DISP-S1 metadata")
             logger.info(dataset_met_json.keys())
             for file in dataset_met_json["Files"]:

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -230,6 +230,12 @@ def convert(
                     for file in dataset_met_json["Files"]
                 ]
 
+            # Get rid of bunch of data that we don't care about but it taking up a lot of space
+            dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
+            dataset_met_json["runconfig"]["input_file_group"]["input_file_paths"] = None # This list is the same as lineage so no point in duplicating
+            for file in dataset_met_json["Files"]:
+                file["runconfig"] = None # Runconfig for the entire product is already at metadata level so no point in duplicating for each file
+
         elif pge_name == "L3_DSWx_NI":
             dataset_met_json["input_granule_id"] = product_metadata["id"]
             dataset_met_json["mgrs_set_id"] = product_metadata["mgrs_set_id"]

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -264,15 +264,24 @@ def convert(
 
         if pge_name == "L3_DISP_S1":
             # Get rid of bunch of data that we don't care about but takes up a lot of space
+            logger.info("Removing superfluous data from DISP-S1 metadata")
             dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
             dataset_met_json["runconfig"]["input_file_group"]["input_file_paths"] = None # This list is the same as lineage so no point in duplicating
-            logger.info("Removing superfluous data from DISP-S1 metadata")
-            logger.info(dataset_met_json.keys())
+
             for file in dataset_met_json["Files"]:
                 logger.info(file.keys())
                 logger.info("Removing runconfig and lineage from each file")
                 file["runconfig"] = None  # Runconfig for the entire product is already at metadata level so no point in duplicating for each file
                 file["lineage"] = None  # Lineage for the entire product is already at metadata level so no point in duplicating for each file
+
+            logger.info("Reducing lineage string size by truncating basepath of lineage entries")
+            logger.info("dataset_met_json keys: " + str(dataset_met_json.keys()))
+            if len(dataset_met_json["lineage"]) > 0:
+                dataset_met_json["lienage_base_path"] = '/'.join(dataset_met_json["lineage"][0].split('/')[:-1])
+                lineage_arr = []
+                for l in dataset_met_json["lineage"]:
+                    lineage_arr.append(l.split('/')[-1])
+                dataset_met_json["lineage"] = lineage_arr
 
         logger.info(f"Creating combined dataset metadata file {dataset_met_json_path}")
         with open(dataset_met_json_path, 'w') as outfile:

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -73,6 +73,8 @@ def convert(
 
     for output_type in output_types:
         for product in products[output_type].keys():
+            if pge_name == "L3_DISP_S1" and product[-3:] != ".nc": # DISP-S1 generates huge amount of data. We only care for the .nc files
+                continue
             logger.info(f"Converting {product} to a dataset")
 
             dataset_dir = extract.extract(

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -231,10 +231,11 @@ def convert(
                 ]
 
             # Get rid of bunch of data that we don't care about but it taking up a lot of space
-            dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
+            '''dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
             dataset_met_json["runconfig"]["input_file_group"]["input_file_paths"] = None # This list is the same as lineage so no point in duplicating
             for file in dataset_met_json["Files"]:
-                file["runconfig"] = None # Runconfig for the entire product is already at metadata level so no point in duplicating for each file
+                file["runconfig"] = None # Runconfig for the entire product is already at metadata level so no point in duplicating for each file'''
+            logger.info(dataset_met_json.keys())
 
         elif pge_name == "L3_DSWx_NI":
             dataset_met_json["input_granule_id"] = product_metadata["id"]


### PR DESCRIPTION
Reduces great amount of DISP-S1 and Compressed CSLC products metadata that makes way into the GRQ ES. Both of these indices must be stored perpetually in GRQ so data size minimization is paramount.

These changes reduce the size of a single DISP-S1 product ES document size by 80-90% (1mb to 100-200kb) and for Compressed CSLC by 60-80% (100kb to 20-40kb) Will have exact numbers once we perform an INT test.