### PR TITLE
1053 tasks ack late false

### DIFF
--- a/conf/sds/files/celeryconfig.py.tmpl.asg
+++ b/conf/sds/files/celeryconfig.py.tmpl.asg
@@ -5,7 +5,7 @@ task_serializer = "msgpack"
 result_serializer = "msgpack"
 accept_content = ["msgpack", "json"]
 
-task_acks_late = True
+task_acks_late = False
 result_expires = 86400
 worker_prefetch_multiplier = 1
 
@@ -18,11 +18,14 @@ task_queue_max_priority = 10
 
 task_reject_on_worker_lost = True
 
-broker_heartbeat = 120
+broker_heartbeat = 30
 broker_heartbeat_checkrate = 2
 
 broker_pool_limit = None
 broker_transport_options = { "confirm_publish": True }
+
+redis_socket_keepalive = True
+redis_backend_healh_check_interval = 30
 
 imports = [
     "hysds.task_worker",
@@ -74,14 +77,16 @@ TOSCA_URL = "https://{{ GRQ_PVT_IP }}/search/"
 GRQ_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}"
 GRQ_REST_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1"
 GRQ_UPDATE_URL = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.1/grq/dataset/index"
+GRQ_UPDATE_URL_BULK = "http://{{ GRQ_PVT_IP }}:{{ GRQ_PORT }}/api/v0.2/grq/dataset/index"
 
 
 GRQ_AWS_ES = {{ GRQ_AWS_ES or False }}
-GRQ_ES_HOST = "{{ GRQ_ES_PVT_IP_VERDI }}"
+GRQ_ES_HOST = "{{ GRQ_ES_PVT_IP }}"
 GRQ_ES_PORT = {{ GRQ_ES_PORT or 9200 }}
 GRQ_ES_PROTOCOL = "{{ GRQ_ES_PROTOCOL or 'http' }}"
 GRQ_ES_URL = '%s://%s:%d' % (GRQ_ES_PROTOCOL, GRQ_ES_HOST, GRQ_ES_PORT)
 
+CONTAINER_ENGINE = "{{ CONTAINER_ENGINE or 'docker' }}"
 
 DATASET_PROCESSED_QUEUE = "dataset_processed"
 USER_RULES_DATASET_QUEUE = "user_rules_dataset"
@@ -125,3 +130,5 @@ WORKER_MOUNT_BLACKLIST = [
 CONTAINER_REGISTRY = "{{ CONTAINER_REGISTRY }}"
 
 AWS_REGION = "{{ AWS_REGION }}"
+
+ES_CLUSTER_MODE = {{ ES_CLUSTER_MODE or False }}

--- a/conf/sds/files/celeryconfig.py.tmpl.private_verdi
+++ b/conf/sds/files/celeryconfig.py.tmpl.private_verdi
@@ -5,7 +5,7 @@ task_serializer = "msgpack"
 result_serializer = "msgpack"
 accept_content = ["msgpack", "json"]
 
-task_acks_late = True
+task_acks_late = False
 result_expires = 86400
 worker_prefetch_multiplier = 1
 


### PR DESCRIPTION
Changes the rabbitmq behavior to ack immediately for all jobs that get executed by ASG verdi workers. This prevent us from processing the same job multiple times when there's an EC2 interruption. Everything worked as expected and have not observed any ill side effects.

Created a new celeryconfig template file here. This file is a copy of the default file in hySDS (OPERA doesn't have our own) with ```task_acks_late = False```  No other changes were needed, at least for OPERA.
https://github.com/nasa/opera-sds-pcm/blob/1053_tasks_ack_late_false/conf/sds/files/celeryconfig.py.tmpl.asg

This file is then copied over to Mozart .sds/files folder during deployment. This file is applied in these lines and ultimately makes its way into the verdi workers.
https://github.com/sdskit/sdscli/blob/develop/sdscli/adapters/hysds/fabfile.py#L950

I performed the following job actions and they all worked as expected:

1. Created a new jobs and let it start
1.1 Observed that the rabbitmq was acked as soon as the job started.
2. Set the ASG max of that queue to be 0. This moved the job to be in offline state
3. Set ASG max back to 1. Waited 30 mins but the job did not move back into started state on its own. This is the behavior I wanted.
3.1. ASG Desired continued to be 0 because that metric is based on the rabbitmq queue size and not jobs.
4. Retried that offline job, it went into queued state, and started to run.
4.1. Now that we have a job in queue, ASG Desired went back up to 1
5. sshed into that verdi worker EC2 and deleted the job working directory to force it to fail. It failed shortly after that.
6. From the failed state, I retried that job again. It ran to completion.

The end result is a successful job with two manual retries. Previously the actions above would have required just one manual retry.