### PR TITLE
Improve CMR audit capabilities

### DIFF
--- a/tools/ops/cmr_audit/cmr_audit_batch.py
+++ b/tools/ops/cmr_audit/cmr_audit_batch.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta
 import sys
 import logging
 import subprocess
+from cmr_audit_utils import str2bool
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
@@ -41,13 +42,13 @@ def create_parser():
     )
     argparser.add_argument(
         "--do_cslc",
-        type=bool,
+        type=str2bool,
         default=True,
         help=f'Flag to execute CSLC accountability. Defaults to "%(default)s".'
     )
     argparser.add_argument(
         "--do_rtc",
-        type=bool,
+        type=str2bool,
         default=True,
         help=f'Flag to execute RTC accountability. Defaults to "%(default)s".'
     )
@@ -80,19 +81,24 @@ if __name__ == "__main__":
                             ])
 
         elif args.input_product == 'SLC':
-            subprocess.run(['python', 'cmr_audit_slc.py',
-                            "--start-datetime", start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                            "--end-datetime", stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                            "--do_cslc", args.do_cslc,
-                            "--do_rtc", args.do_rtc
-                            ])
+            print(args.do_cslc)
+            print(args.do_rtc)
+            # subprocess.run(['python', 'cmr_audit_slc.py',
+            #                 "--start-datetime", start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            #                 "--end-datetime", stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            #                 "--do_cslc", str(args.do_cslc),
+            #                 "--do_rtc", str(args.do_rtc)
+            #                 ])
 
         else:
             logging.error(f"Invalid input product: {args.input_product}")
             exit(1)
 
         start_datetime = stop_datetime
-        time.sleep(SLEEP_TIME_SECS)
+
+        # wait before next iteration
+        if stop_datetime < end_datetime:
+            time.sleep(SLEEP_TIME_SECS)
 
 
 

--- a/tools/ops/cmr_audit/cmr_audit_batch.py
+++ b/tools/ops/cmr_audit/cmr_audit_batch.py
@@ -1,0 +1,82 @@
+'''
+Script to invoke cmr_audit-*.py N days at a time.
+'''
+
+import argparse
+import time
+from datetime import datetime, timedelta
+import sys
+import logging
+import subprocess
+logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
+
+# wait time in between cmr_audit.py invocations
+SLEEP_TIME_SECS = 60
+
+
+def create_parser():
+    argparser = argparse.ArgumentParser(add_help=True)
+    argparser.add_argument(
+        "--start-datetime",
+        required=True,
+        help=f'ISO formatted datetime string. Must be compatible with CMR. ex) 2023-08-02T04:00:00'
+    )
+    argparser.add_argument(
+        "--end-datetime",
+        required=True,
+        help=f'ISO formatted datetime string. Must be compatible with CMR. ex) 2023-08-02T04:00:00'
+    )
+    argparser.add_argument(
+        "--input_product",
+        help=f'The input product: HLS or SLC',
+        default='SLC'
+    ),
+    argparser.add_argument(
+        "--interval-days",
+        help=f'The maximum number of days to query at a time',
+        type=int,
+        default=10
+    )
+
+    return argparser
+
+
+if __name__ == "__main__":
+
+    parser = create_parser()
+    args = parser.parse_args(sys.argv[1:])
+    logging.info(args)
+
+    # loop over N days at a time
+    start_datetime = datetime.strptime(args.start_datetime, "%Y-%m-%dT%H:%M:%SZ")
+    end_datetime = datetime.strptime(args.end_datetime, "%Y-%m-%dT%H:%M:%SZ")
+
+    while start_datetime < end_datetime:
+        stop_datetime = start_datetime + timedelta(days=args.interval_days)
+        if stop_datetime > end_datetime:
+            stop_datetime = end_datetime
+
+        # start_datime ==> stop_datetime
+        logging.info(f"Processing from: {start_datetime} to: {stop_datetime}")
+        if args.input_product == 'HLS':
+            script = 'cmr_audit_hls.py'
+        elif args.input_product == 'SLC':
+            script = 'cmr_audit_slc.py'
+        else:
+            logging.error(f"Invalid input product: {args.input_product}")
+            exit(1)
+
+        subprocess.run(['python', script,
+                        "--start-datetime",
+                        start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                        "--end-datetime",
+                        stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")])
+
+        start_datetime = stop_datetime
+        time.sleep(SLEEP_TIME_SECS)
+
+
+
+
+

--- a/tools/ops/cmr_audit/cmr_audit_batch.py
+++ b/tools/ops/cmr_audit/cmr_audit_batch.py
@@ -95,7 +95,7 @@ if __name__ == "__main__":
         start_datetime = stop_datetime
 
         # wait before next iteration
-        if stop_datetime < end_datetime:
+        if start_datetime < end_datetime:
             time.sleep(SLEEP_TIME_SECS)
 
 

--- a/tools/ops/cmr_audit/cmr_audit_batch.py
+++ b/tools/ops/cmr_audit/cmr_audit_batch.py
@@ -16,6 +16,7 @@ SLEEP_TIME_SECS = 60
 
 
 def create_parser():
+
     argparser = argparse.ArgumentParser(add_help=True)
     argparser.add_argument(
         "--start-datetime",
@@ -38,6 +39,18 @@ def create_parser():
         type=int,
         default=10
     )
+    argparser.add_argument(
+        "--do_cslc",
+        type=bool,
+        default=True,
+        help=f'Flag to execute CSLC accountability. Defaults to "%(default)s".'
+    )
+    argparser.add_argument(
+        "--do_rtc",
+        type=bool,
+        default=True,
+        help=f'Flag to execute RTC accountability. Defaults to "%(default)s".'
+    )
 
     return argparser
 
@@ -59,19 +72,24 @@ if __name__ == "__main__":
 
         # start_datime ==> stop_datetime
         logging.info(f"Processing from: {start_datetime} to: {stop_datetime}")
+
         if args.input_product == 'HLS':
-            script = 'cmr_audit_hls.py'
+            subprocess.run(['python', 'cmr_audit_hls.py',
+                            "--start-datetime", start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "--end-datetime", stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")
+                            ])
+
         elif args.input_product == 'SLC':
-            script = 'cmr_audit_slc.py'
+            subprocess.run(['python', 'cmr_audit_slc.py',
+                            "--start-datetime", start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "--end-datetime", stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "--do_cslc", args.do_cslc,
+                            "--do_rtc", args.do_rtc
+                            ])
+
         else:
             logging.error(f"Invalid input product: {args.input_product}")
             exit(1)
-
-        subprocess.run(['python', script,
-                        "--start-datetime",
-                        start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                        "--end-datetime",
-                        stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ")])
 
         start_datetime = stop_datetime
         time.sleep(SLEEP_TIME_SECS)

--- a/tools/ops/cmr_audit/cmr_audit_batch.py
+++ b/tools/ops/cmr_audit/cmr_audit_batch.py
@@ -81,14 +81,12 @@ if __name__ == "__main__":
                             ])
 
         elif args.input_product == 'SLC':
-            print(args.do_cslc)
-            print(args.do_rtc)
-            # subprocess.run(['python', 'cmr_audit_slc.py',
-            #                 "--start-datetime", start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            #                 "--end-datetime", stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            #                 "--do_cslc", str(args.do_cslc),
-            #                 "--do_rtc", str(args.do_rtc)
-            #                 ])
+            subprocess.run(['python', 'cmr_audit_slc.py',
+                            "--start-datetime", start_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "--end-datetime", stop_datetime.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                            "--do_cslc", str(args.do_cslc),
+                            "--do_rtc", str(args.do_rtc)
+                            ])
 
         else:
             logging.error(f"Invalid input product: {args.input_product}")

--- a/tools/ops/cmr_audit/cmr_audit_hls.py
+++ b/tools/ops/cmr_audit/cmr_audit_hls.py
@@ -272,6 +272,9 @@ async def run(argv: list[str]):
         logger.info(f"Writing granule list to file {output_file_missing_cmr_granules!r}")
         with open(output_file_missing_cmr_granules, mode='w') as fp:
             fp.write('\n'.join(missing_cmr_granules_hls))
+        if missing_cmr_granules_hls:
+            with open(output_file_missing_cmr_granules, mode='a') as fp:
+                fp.write('\n')
     elif args.format == "json":
         output_file_missing_cmr_granules = args.output if args.output else f"{outfilename}.json"
         with open(output_file_missing_cmr_granules, mode='w') as fp:

--- a/tools/ops/cmr_audit/cmr_audit_slc.py
+++ b/tools/ops/cmr_audit/cmr_audit_slc.py
@@ -19,6 +19,7 @@ from more_itertools import always_iterable
 
 from geo.geo_util import does_bbox_intersect_north_america
 from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, get_cmr_audit_granules
+from cmr_audit_utils import str2bool
 
 logging.getLogger("compact_json.formatter").setLevel(level=logging.INFO)
 logging.getLogger("geo.geo_util").setLevel(level=logging.WARNING)
@@ -59,13 +60,13 @@ def create_parser():
     )
     argparser.add_argument(
         "--do_cslc",
-        type=bool,
+        type=str2bool,
         default=True,
         help=f'Flag to execute CSLC accountability. Defaults to "%(default)s".'
     )
     argparser.add_argument(
         "--do_rtc",
-        type=bool,
+        type=str2bool,
         default=True,
         help=f'Flag to execute RTC accountability. Defaults to "%(default)s".'
     )

--- a/tools/ops/cmr_audit/cmr_audit_slc.py
+++ b/tools/ops/cmr_audit/cmr_audit_slc.py
@@ -349,12 +349,18 @@ async def run(argv: list[str]):
         logger.info(f"Writing granule list to file {output_file_missing_cmr_granules!r}")
         with open(output_file_missing_cmr_granules, mode='w') as fp:
             fp.write('\n'.join(missing_cmr_granules_slc_cslc))
+        if missing_cmr_granules_slc_cslc:
+            with open(output_file_missing_cmr_granules, mode='a') as fp:
+                fp.write('\n')
         logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
 
         output_file_missing_cmr_granules = args.output if args.output else f"missing_granules_SLC-RTC_{outfilename}.txt"
         logger.info(f"Writing granule list to file {output_file_missing_cmr_granules!r}")
         with open(output_file_missing_cmr_granules, mode='w') as fp:
             fp.write('\n'.join(missing_cmr_granules_slc_rtc))
+        if missing_cmr_granules_slc_rtc:
+            with open(output_file_missing_cmr_granules, mode='a') as fp:
+                fp.write('\n')
         logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
 
     elif args.format == "json":

--- a/tools/ops/cmr_audit/cmr_audit_slc.py
+++ b/tools/ops/cmr_audit/cmr_audit_slc.py
@@ -16,6 +16,7 @@ import aiohttp
 import more_itertools
 from dotenv import dotenv_values
 from more_itertools import always_iterable
+from compact_json import Formatter
 
 from geo.geo_util import does_bbox_intersect_north_america
 from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, get_cmr_audit_granules
@@ -58,6 +59,18 @@ def create_parser():
         help=f'Output file format. Defaults to "%(default)s".'
     )
     argparser.add_argument('--log-level', default='INFO', choices=('DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'))
+    argparser.add_argument(
+        "--do_cslc",
+        type=bool,
+        default=True,
+        help=f'Change to False to disable CSLC auditing'
+    )
+    argparser.add_argument(
+        "--do_rtc",
+        type=bool,
+        default=True,
+        help=f'Change to False to disable RTC auditing'
+    )
 
     return argparser
 
@@ -253,6 +266,43 @@ def cmr_products_native_id_pattern_diff(cmr_products, cmr_native_id_patterns):
         missing_product_native_id_patterns = functools.reduce(set.union, missing_product_native_id_patterns)
     return missing_product_native_id_patterns
 
+def get_output_filename(cmr_start_dt_str, cmr_end_dt_str, product):
+
+    now = datetime.datetime.now()
+    current_dt_str = now.strftime("%Y%m%d-%H%M%S")
+    start_dt_str = cmr_start_dt_str.replace("-","")
+    start_dt_str = start_dt_str.replace("T", "-")
+    start_dt_str = start_dt_str.replace(":", "")
+
+    end_dt_str = cmr_end_dt_str.replace("-", "")
+    end_dt_str = end_dt_str.replace("T", "-")
+    end_dt_str = end_dt_str.replace(":", "")
+    out_filename = f"{start_dt_str}Z_{end_dt_str}Z_{current_dt_str}Z"
+
+    return f"missing_granules_SLC-{product}_{out_filename}"
+
+def write_out_results(missing_cmr_granules_slc_cslc_or_rtc, out_filename, extension):
+
+    if extension == "txt":
+        output_file_missing_cmr_granules = args.output if args.output else f"{out_filename}.txt"
+        logger.info(f"Writing granule list to file {output_file_missing_cmr_granules!r}")
+        with open(output_file_missing_cmr_granules, mode='w') as fp:
+            fp.write('\n'.join(missing_cmr_granules_slc_cslc_or_rtc))
+        if missing_cmr_granules_slc_cslc_or_rtc:
+            with open(output_file_missing_cmr_granules, mode='a') as fp:
+                fp.write('\n')
+        logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
+
+    elif extension == "json":
+        output_file_missing_cmr_granules = args.output if args.output else f"{out_filename}.json"
+        formatter = Formatter(indent_spaces=2, max_inline_length=300, max_compact_list_complexity=0)
+        with open(output_file_missing_cmr_granules, mode='w') as fp:
+            json_str = formatter.serialize(list(missing_cmr_granules_slc_cslc_or_rtc))
+            fp.write(json_str)
+        logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
+
+    else:
+        raise Exception("Unrecognized extension for output file")
 
 #######################################################################
 # CMR AUDIT
@@ -291,96 +341,56 @@ async def run(argv: list[str]):
                 cmr_granules_slc_na.add(granule_id)
                 cmr_granules_slc_details_na[granule_id] = granule_details
 
-    logger.info(f"Expected CSLC input (granules): {len(cmr_granules_slc_na)=:,}")
-    logger.info(f"Expected RTC input (granules): {len(cmr_granules_slc)=:,}")
-
-    cslc_native_id_patterns = slc_granule_ids_to_cslc_native_id_patterns(
-        cmr_granules_slc_na,
-        input_slc_to_outputs_cslc_map := defaultdict(set),
-        output_cslc_to_inputs_slc_map := defaultdict(set)
-    )
-
-    rtc_native_id_patterns = slc_granule_ids_to_rtc_native_id_patterns(
-        cmr_granules_slc,
-        input_slc_to_outputs_rtc_map := defaultdict(set),
-        output_rtc_to_inputs_slc_map := defaultdict(set)
-    )
-
-    logger.info("Querying CMR for list of expected CSLC granules")
-    cmr_cslc_products = await async_get_cmr_cslc(cslc_native_id_patterns, temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str)
-
-    logger.info("Querying CMR for list of expected RTC granules")
-    cmr_rtc_products = await async_get_cmr_rtc(rtc_native_id_patterns, temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str)
-
-    missing_cslc_native_id_patterns = cmr_products_native_id_pattern_diff(cmr_products=cmr_cslc_products, cmr_native_id_patterns=cslc_native_id_patterns)
-    missing_rtc_native_id_patterns = cmr_products_native_id_pattern_diff(cmr_products=cmr_rtc_products, cmr_native_id_patterns=rtc_native_id_patterns)
-
-    #######################################################################
-    # CMR_AUDIT SUMMARY
-    #######################################################################
-    # logger.debug(f"{pstr(missing_rtc_native_id_patterns)=!s}")
-
-    missing_cmr_granules_slc_cslc = [output_cslc_to_inputs_slc_map[native_id_pattern] for native_id_pattern in missing_cslc_native_id_patterns]
-    missing_cmr_granules_slc_cslc = set(functools.reduce(set.union, missing_cmr_granules_slc_cslc)) if missing_cmr_granules_slc_cslc else set()
-
-    missing_cmr_granules_slc_rtc = [output_rtc_to_inputs_slc_map[native_id_pattern] for native_id_pattern in missing_rtc_native_id_patterns]
-    missing_cmr_granules_slc_rtc = set(functools.reduce(set.union, missing_cmr_granules_slc_rtc)) if missing_cmr_granules_slc_rtc else set()
-
     # logger.debug(f"{pstr(missing_slc)=!s}")
     logger.info(f"Expected input (granules): {len(cmr_granules_slc)=:,}")
-    logger.info(f"Fully published (granules) (CSLC): {len(cmr_cslc_products)=:,}")
-    logger.info(f"Fully published (granules) (RTC): {len(cmr_rtc_products)=:,}")
-    logger.info(f"Missing processed CSLC (granules): {len(missing_cmr_granules_slc_cslc)=:,}")
-    logger.info(f"Missing processed RTC (granules): {len(missing_cmr_granules_slc_rtc)=:,}")
 
-    now = datetime.datetime.now()
-    current_dt_str = now.strftime("%Y%m%d-%H%M%S")
-    start_dt_str = cmr_start_dt_str.replace("-","")
-    start_dt_str = start_dt_str.replace("T", "-")
-    start_dt_str = start_dt_str.replace(":", "")
+    if args.do_cslc:
+        logger.info(f"Expected CSLC input (granules): {len(cmr_granules_slc_na)=:,}")
+        cslc_native_id_patterns = slc_granule_ids_to_cslc_native_id_patterns(
+            cmr_granules_slc_na,
+            input_slc_to_outputs_cslc_map := defaultdict(set),
+            output_cslc_to_inputs_slc_map := defaultdict(set)
+        )
+        logger.info("Querying CMR for list of expected CSLC granules")
+        cmr_cslc_products = await async_get_cmr_cslc(cslc_native_id_patterns,
+                                                     temporal_date_start=cmr_start_dt_str,
+                                                     temporal_date_end=cmr_end_dt_str)
+        missing_cslc_native_id_patterns = cmr_products_native_id_pattern_diff(
+            cmr_products=cmr_cslc_products, cmr_native_id_patterns=cslc_native_id_patterns)
 
-    end_dt_str = cmr_end_dt_str.replace("-", "")
-    end_dt_str = end_dt_str.replace("T", "-")
-    end_dt_str = end_dt_str.replace(":", "")
-    outfilename = f"{start_dt_str}Z_{end_dt_str}Z_{current_dt_str}Z"
+        missing_cmr_granules_slc_cslc = [output_cslc_to_inputs_slc_map[native_id_pattern] for
+                                         native_id_pattern in missing_cslc_native_id_patterns]
+        missing_cmr_granules_slc_cslc = set(functools.reduce(set.union,
+                                            missing_cmr_granules_slc_cslc)) if missing_cmr_granules_slc_cslc else set()
 
-    if args.format == "txt":
-        output_file_missing_cmr_granules = args.output if args.output else f"missing_granules_SLC-CSLC_{outfilename}.txt"
-        logger.info(f"Writing granule list to file {output_file_missing_cmr_granules!r}")
-        with open(output_file_missing_cmr_granules, mode='w') as fp:
-            fp.write('\n'.join(missing_cmr_granules_slc_cslc))
-        if missing_cmr_granules_slc_cslc:
-            with open(output_file_missing_cmr_granules, mode='a') as fp:
-                fp.write('\n')
-        logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
+        logger.info(f"Fully published (granules) (CSLC): {len(cmr_cslc_products)=:,}")
+        logger.info(f"Missing processed CSLC (granules): {len(missing_cmr_granules_slc_cslc)=:,}")
 
-        output_file_missing_cmr_granules = args.output if args.output else f"missing_granules_SLC-RTC_{outfilename}.txt"
-        logger.info(f"Writing granule list to file {output_file_missing_cmr_granules!r}")
-        with open(output_file_missing_cmr_granules, mode='w') as fp:
-            fp.write('\n'.join(missing_cmr_granules_slc_rtc))
-        if missing_cmr_granules_slc_rtc:
-            with open(output_file_missing_cmr_granules, mode='a') as fp:
-                fp.write('\n')
-        logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
+        out_filename = get_output_filename(cmr_start_dt_str, cmr_end_dt_str, "CSLC")
+        write_out_results(missing_cmr_granules_slc_cslc, out_filename, args.format)
 
-    elif args.format == "json":
-        output_file_missing_cmr_granules = args.output if args.output else f"missing_granules_SLC-CSLC_{outfilename}.json"
-        with open(output_file_missing_cmr_granules, mode='w') as fp:
-            from compact_json import Formatter
-            formatter = Formatter(indent_spaces=2, max_inline_length=300, max_compact_list_complexity=0)
-            json_str = formatter.serialize(list(missing_cmr_granules_slc_cslc))
-            fp.write(json_str)
-        logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
+    if args.do_rtc:
+        logger.info(f"Expected RTC input (granules): {len(cmr_granules_slc)=:,}")
+        rtc_native_id_patterns = slc_granule_ids_to_rtc_native_id_patterns(
+            cmr_granules_slc,
+            input_slc_to_outputs_rtc_map := defaultdict(set),
+            output_rtc_to_inputs_slc_map := defaultdict(set)
+        )
+        logger.info("Querying CMR for list of expected RTC granules")
+        cmr_rtc_products = await async_get_cmr_rtc(rtc_native_id_patterns,
+                                                   temporal_date_start=cmr_start_dt_str,
+                                                   temporal_date_end=cmr_end_dt_str)
+        missing_rtc_native_id_patterns = cmr_products_native_id_pattern_diff(cmr_products=cmr_rtc_products, cmr_native_id_patterns=rtc_native_id_patterns)
 
-        output_file_missing_cmr_granules = args.output if args.output else f"missing_granules_SLC-RTC_{outfilename}.json"
-        with open(output_file_missing_cmr_granules, mode='w') as fp:
-            from compact_json import Formatter
-            formatter = Formatter(indent_spaces=2, max_inline_length=300, max_compact_list_complexity=0)
-            json_str = formatter.serialize(list(missing_cmr_granules_slc_rtc))
-            fp.write(json_str)
-        logger.info(f"Finished writing to file {output_file_missing_cmr_granules!r}")
-    else:
-        raise Exception()
+        missing_cmr_granules_slc_rtc = [output_rtc_to_inputs_slc_map[native_id_pattern] for native_id_pattern in missing_rtc_native_id_patterns]
+        missing_cmr_granules_slc_rtc = set(functools.reduce(set.union,
+                                            missing_cmr_granules_slc_rtc)) if missing_cmr_granules_slc_rtc else set()
+
+        logger.info(f"Fully published (granules) (RTC): {len(cmr_rtc_products)=:,}")
+        logger.info(f"Missing processed RTC (granules): {len(missing_cmr_granules_slc_rtc)=:,}")
+
+        out_filename = get_output_filename(cmr_start_dt_str, cmr_end_dt_str, "RTC")
+        write_out_results(missing_cmr_granules_slc_rtc, out_filename, args.format)
 
 
 if __name__ == "__main__":

--- a/tools/ops/cmr_audit/cmr_audit_utils.py
+++ b/tools/ops/cmr_audit/cmr_audit_utils.py
@@ -133,3 +133,13 @@ def pstr(o):
     pprint(o, stream=sio)
     sio.seek(0)
     return sio.read()
+
+def str2bool(v):
+    if isinstance(v, bool):
+        return v
+    if v.lower() in ('yes', 'true', 't', 'y', '1'):
+        return True
+    elif v.lower() in ('no', 'false', 'f', 'n', '0'):
+        return False
+    else:
+        raise Exception('Boolean value expected.')

--- a/tools/ops/cmr_audit/cmr_audit_utils.py
+++ b/tools/ops/cmr_audit/cmr_audit_utils.py
@@ -91,7 +91,7 @@ def request_body_supplier(collection_short_name, temporal_date_start: str, tempo
         return (
             "provider=LPCLOUD"
             f"&short_name[]={collection_short_name}"
-            "&bounding_box=-180,-90,180,90"
+            "&bounding_box=-180,-60,180,90"
             "&sort_key=-start_date"
             # f"&revision_date[]={revision_date_start},{revision_date_end}"  # DEV: left for documentation purposes
             f"&temporal[]={urllib.parse.quote(temporal_date_start, safe='/:')},{urllib.parse.quote(temporal_date_end, safe='/:')}"
@@ -103,7 +103,7 @@ def request_body_supplier(collection_short_name, temporal_date_start: str, tempo
         return (
             "provider=ASF"
             f"&short_name[]={collection_short_name}"
-            "&bounding_box=-180,-90,180,90"
+            "&bounding_box=-180,-60,180,90"
             "&sort_key=-start_date"
             # f"&revision_date[]={revision_date_start},{revision_date_end}"  # DEV: left for documentation purposes
             f"&temporal[]={urllib.parse.quote(temporal_date_start, safe='/:')},{urllib.parse.quote(temporal_date_end, safe='/:')}"


### PR DESCRIPTION
## Purpose

This PR is meant to improve the usability of cmr_audit.py in the following respects:
- Support the ability to run for a long date-time interval, but break up the queries in N days each
- Fix the current bug in the bounding box (missing SLC inputs are currently found in Antartica, i.e. the script returns false positives)
- Have the ability to disable CSLC or RTC accountability (to run faster)
- Add a newline at the end of the output files, to allow easy concatenation

## Proposed Changes
- [ADD] A new cmr_audit_batch.py script to execute cmr_audit_X.py in chunks of N days
- [CHANGE] Refactor some of the functionality to prevent repetition of code
- [FIX] Bounding box that exclude Antartica from the query region

## Issues
- https://github.com/nasa/opera-sds-pcm/issues/1054

## Testing
- I have been using the modified version of the package successfully to execute accountability for RTC and CSLC for several days.
