### PR TITLE
Data Subscriber RTC Download Code Refactor

### DIFF
--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -70,7 +70,8 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
 
             # Download the files from ASF only if the transfer protocol is HTTPS
             if args.transfer_protocol == "https":
-                cslc_products_to_filepaths: dict[str, set[Path]] = super().run_download(
+                # Need to skip over AsfDaacRtcDownload.run_download() and invoke base DaacDownload.run_download()
+                cslc_products_to_filepaths: dict[str, set[Path]] = super(AsfDaacRtcDownload, self).run_download(
                     new_args, token, es_conn, netloc, username, password, cmr, job_id, rm_downloads_dir=False
                 )
                 self.logger.info(f"Uploading CSLC input files to S3")

--- a/data_subscriber/asf_rtc_download.py
+++ b/data_subscriber/asf_rtc_download.py
@@ -1,13 +1,23 @@
 import concurrent.futures
 import os
-from collections import defaultdict
+import re
+import uuid
+from collections import defaultdict, namedtuple
+from itertools import chain
 from pathlib import PurePath, Path
 
 import requests.utils
+from more_itertools import first
 
 from data_subscriber.catalog import ProductCatalog
 from data_subscriber.download import DaacDownload
+from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.url import _to_urls, _to_https_urls, _rtc_url_to_chunk_id
+from rtc_utils import rtc_product_file_revision_regex
+from util.aws_util import concurrent_s3_client_try_upload_file
+from util.conf_util import SettingsConf
+from util.ctx_util import JobContext
+from util.job_util import is_running_outside_verdi_worker_context
 
 
 class AsfDaacRtcDownload(DaacDownload):
@@ -15,6 +25,127 @@ class AsfDaacRtcDownload(DaacDownload):
     def __init__(self, provider):
         super().__init__(provider)
         self.daac_s3_cred_settings_key = "RTC_DOWNLOAD"
+
+    def run_download(self, args, token, es_conn, netloc, username, password, cmr,
+                     job_id, rm_downloads_dir=True):
+        provider = args.provider  # "ASF-RTC"
+        settings = SettingsConf().cfg
+
+        if not is_running_outside_verdi_worker_context():
+            job_context = JobContext("_context.json").ctx
+            product_metadata = job_context["product_metadata"]
+            self.logger.info(f"{product_metadata=}")
+
+        affected_mgrs_set_id_acquisition_ts_cycle_indexes = args.batch_ids
+        self.logger.info(f"{affected_mgrs_set_id_acquisition_ts_cycle_indexes=}")
+
+        # convert to "batch_id" mapping
+        batch_id_to_products_map = {}
+
+        for affected_mgrs_set_id_acquisition_ts_cycle_index in affected_mgrs_set_id_acquisition_ts_cycle_indexes:
+            es_docs = es_conn.filter_catalog_by_sets([affected_mgrs_set_id_acquisition_ts_cycle_index])
+            batch_id_to_products_map[affected_mgrs_set_id_acquisition_ts_cycle_index] = es_docs
+
+        succeeded = []
+        failed = []
+
+        # create args for downloading products
+        Namespace = namedtuple(
+            "Namespace",
+            ["provider", "transfer_protocol", "batch_ids", "dry_run", "smoke_run"],
+            defaults=[provider, args.transfer_protocol, None, args.dry_run, args.smoke_run]
+        )
+
+        uploaded_batch_id_to_products_map = {}
+        uploaded_batch_id_to_s3paths_map = {}
+
+        for batch_id, product_burstset in batch_id_to_products_map.items():
+            args_for_downloader = Namespace(provider=provider, batch_ids=[batch_id])
+
+            run_download_kwargs = {
+                "token": token,
+                "es_conn": es_conn,
+                "netloc": netloc,
+                "username": username,
+                "password": password,
+                "cmr": cmr,
+                "job_id": job_id
+            }
+
+            product_to_product_filepaths_map: dict[str, set[Path]] = super().run_download(
+                args=args_for_downloader, **run_download_kwargs, rm_downloads_dir=False
+            )
+
+            self.logger.info("Uploading MGRS burst set files to S3")
+            burst_id_to_files_to_upload = defaultdict(set)
+
+            for product_id, fp_set in product_to_product_filepaths_map.items():
+                for fp in fp_set:
+                    match_product_id = re.match(rtc_product_file_revision_regex, product_id)
+                    burst_id = match_product_id.group("burst_id")
+                    burst_id_to_files_to_upload[burst_id].add(fp)
+
+            s3paths: list[str] = []
+
+            for burst_id, filepaths in burst_id_to_files_to_upload.items():
+                s3paths.extend(
+                    concurrent_s3_client_try_upload_file(
+                        bucket=settings["DATASET_BUCKET"],
+                        key_prefix=f"tmp/dswx_s1/{batch_id}/{burst_id}",
+                        files=filepaths
+                    )
+                )
+
+            uploaded_batch_id_to_products_map[batch_id] = product_burstset
+            uploaded_batch_id_to_s3paths_map[batch_id] = s3paths
+
+            self.logger.info(f"Submitting MGRS burst set download job {batch_id=}, num_bursts={len(product_burstset)}")
+
+            # create args for job-submissions
+            args_for_job_submitter = namedtuple(
+                "Namespace",
+                ["chunk_size", "release_version"],
+                defaults=[1, args.release_version]
+            )()
+
+            if args.dry_run:
+                self.logger.info(f"{args.dry_run=}. Skipping job submission. Producing mock job ID")
+                results = [uuid.uuid4()]
+            else:
+                self.logger.info(f"Submitting batches for DSWx-S1 job: {list(uploaded_batch_id_to_s3paths_map)}")
+                job_submission_tasks = submit_dswx_s1_job_submissions_tasks(uploaded_batch_id_to_s3paths_map,
+                                                                            args_for_job_submitter, settings)
+                results = multithread_gather(job_submission_tasks)
+
+            suceeded_batch = [job_id for job_id in results if isinstance(job_id, str)]
+            failed_batch = [e for e in results if isinstance(e, Exception)]
+
+            if suceeded_batch:
+                for product in uploaded_batch_id_to_products_map[batch_id]:
+                    if not product.get("dswx_s1_jobs_ids"):
+                        product["dswx_s1_jobs_ids"] = []
+
+                    product["dswx_s1_jobs_ids"].append(first(suceeded_batch))
+
+                if args.dry_run:
+                    self.logger.info(f"{args.dry_run=}. Skipping marking jobs as downloaded. Producing mock job ID")
+                else:
+                    es_conn.mark_products_as_job_submitted({batch_id: uploaded_batch_id_to_products_map[batch_id]})
+
+                succeeded.extend(suceeded_batch)
+                failed.extend(failed_batch)
+
+                # manual cleanup since we needed to preserve downloads for manual s3 uploads
+                if rm_downloads_dir:
+                    for fp in chain.from_iterable(burst_id_to_files_to_upload.values()):
+                        fp.unlink(missing_ok=True)
+
+                    self.logger.info("Removed downloads from disk")
+
+        return {
+            "success": succeeded,
+            "fail": failed
+        }
 
     def perform_download(self, session: requests.Session, es_conn: ProductCatalog,
                          downloads: list[dict], args, token, job_id):
@@ -94,3 +225,20 @@ class AsfDaacRtcDownload(DaacDownload):
         with open(product_download_path, "wb") as file:
             file.write(asf_response.content)
         return product_download_path.resolve()
+
+
+def multithread_gather(job_submission_tasks):
+    """
+    Given a list of tasks, executes them concurrently and gathers the results.
+    Exceptions are returned as results rather than re-raised.
+    """
+    results = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, os.cpu_count() + 4)) as executor:
+        futures = [executor.submit(job_submission_task) for job_submission_task in job_submission_tasks]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                result = future.result()
+            except Exception as exc:
+                result = exc
+            results.append(result)
+    return results

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -1,19 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
-import asyncio
-import concurrent.futures
-import os
-import re
 import sys
-import uuid
-from collections import defaultdict, namedtuple
-from itertools import chain
-from pathlib import Path
 from urllib.parse import urlparse
-
-from more_itertools import first
-from smart_open import open
 
 from commons.logger import configure_library_loggers, get_logger
 from data_subscriber.asf_cslc_download import AsfDaacCslcDownload
@@ -34,17 +23,13 @@ from data_subscriber.hls.hls_query import HlsCmrQuery
 from data_subscriber.lpdaac_download import DaacDownloadLpdaac
 from data_subscriber.parser import create_parser, validate_args
 from data_subscriber.rtc.rtc_catalog import RTCProductCatalog
-from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.rtc.rtc_query import RtcCmrQuery
 from data_subscriber.slc.slc_catalog import SLCProductCatalog
 from data_subscriber.slc.slc_query import SlcCmrQuery
 from data_subscriber.survey import run_survey
-from rtc_utils import rtc_product_file_revision_regex
-from util.aws_util import concurrent_s3_client_try_upload_file
 from util.conf_util import SettingsConf
-from util.ctx_util import JobContext
 from util.exec_util import exec_wrapper
-from util.job_util import supply_job_id, is_running_outside_verdi_worker_context
+from util.job_util import supply_job_id
 
 
 @exec_wrapper
@@ -82,10 +67,7 @@ def run(argv: list[str]):
     if args.subparser_name == "download" or args.subparser_name == "full":
         netloc = urlparse(f"https://{edl}").netloc
 
-        if args.provider == Provider.ASF_RTC:
-            results["download"] = run_rtc_download(args, token, es_conn, netloc, username, password, cmr, job_id)
-        else:
-            results["download"] = run_download(args, token, es_conn, netloc, username, password, cmr, job_id)
+        results["download"] = run_download(args, token, es_conn, netloc, username, password, cmr, job_id)
 
     logger.info(f"{len(results)=}")
     logger.debug(f"{results=}")
@@ -105,11 +87,8 @@ def run_query(args: argparse.Namespace, token: str, es_conn: ProductCatalog, cmr
         cmr_query = CslcCmrQuery(args, token, es_conn, cmr, job_id, settings)
     elif product_type == ProductType.CSLC_STATIC:
         cmr_query = CslcStaticCmrQuery(args, token, es_conn, cmr, job_id, settings)
-    # RTC is a special case in that it needs to run asynchronously
     elif product_type == ProductType.RTC:
         cmr_query = RtcCmrQuery(args, token, es_conn, cmr, job_id, settings)
-        result = asyncio.run(cmr_query.run_query())
-        return result
     elif product_type == ProductType.NISAR_GCOV:
         cmr_query = NisarGcovCmrQuery(args, token, es_conn, cmr, job_id, settings)
     else:
@@ -135,145 +114,6 @@ def run_download(args, token, es_conn, netloc, username, password, cmr, job_id):
         raise ValueError(f'Unknown product provider "{provider}"')
 
     downloader.run_download(args, token, es_conn, netloc, username, password, cmr, job_id)
-
-
-def run_rtc_download(args, token, es_conn, netloc, username, password, cmr, job_id):
-    logger = get_logger()
-    provider = args.provider  # "ASF-RTC"
-    settings = SettingsConf().cfg
-
-    if not is_running_outside_verdi_worker_context():
-        job_context = JobContext("_context.json").ctx
-        product_metadata = job_context["product_metadata"]
-        logger.info(f"{product_metadata=}")
-
-    affected_mgrs_set_id_acquisition_ts_cycle_indexes = args.batch_ids
-    logger.info(f"{affected_mgrs_set_id_acquisition_ts_cycle_indexes=}")
-
-    es_conn: RTCProductCatalog
-
-    # convert to "batch_id" mapping
-    batch_id_to_products_map = {}
-
-    for affected_mgrs_set_id_acquisition_ts_cycle_index in affected_mgrs_set_id_acquisition_ts_cycle_indexes:
-        es_docs = es_conn.filter_catalog_by_sets([affected_mgrs_set_id_acquisition_ts_cycle_index])
-        batch_id_to_products_map[affected_mgrs_set_id_acquisition_ts_cycle_index] = es_docs
-
-    succeeded = []
-    failed = []
-
-    # create args for downloading products
-    Namespace = namedtuple(
-        "Namespace",
-        ["provider", "transfer_protocol", "batch_ids", "dry_run", "smoke_run"],
-        defaults=[provider, args.transfer_protocol, None, args.dry_run, args.smoke_run]
-    )
-
-    uploaded_batch_id_to_products_map = {}
-    uploaded_batch_id_to_s3paths_map = {}
-
-    for batch_id, product_burstset in batch_id_to_products_map.items():
-        args_for_downloader = Namespace(provider=provider, batch_ids=[batch_id])
-        downloader = AsfDaacRtcDownload(provider)
-
-        run_download_kwargs = {
-            "token": token,
-            "es_conn": es_conn,
-            "netloc": netloc,
-            "username": username,
-            "password": password,
-            "cmr": cmr,
-            "job_id": job_id
-        }
-
-        product_to_product_filepaths_map: dict[str, set[Path]] = downloader.run_download(
-            args=args_for_downloader, **run_download_kwargs, rm_downloads_dir=False)
-
-        logger.info(f"Uploading MGRS burst set files to S3")
-        burst_id_to_files_to_upload = defaultdict(set)
-
-        for product_id, fp_set in product_to_product_filepaths_map.items():
-            for fp in fp_set:
-                match_product_id = re.match(rtc_product_file_revision_regex, product_id)
-                burst_id = match_product_id.group("burst_id")
-                burst_id_to_files_to_upload[burst_id].add(fp)
-
-        s3paths: list[str] = []
-
-        for burst_id, filepaths in burst_id_to_files_to_upload.items():
-            s3paths.extend(
-                concurrent_s3_client_try_upload_file(
-                    bucket=settings["DATASET_BUCKET"],
-                    key_prefix=f"tmp/dswx_s1/{batch_id}/{burst_id}",
-                    files=filepaths
-                )
-            )
-
-        uploaded_batch_id_to_products_map[batch_id] = product_burstset
-        uploaded_batch_id_to_s3paths_map[batch_id] = s3paths
-
-        logger.info(f"Submitting MGRS burst set download job {batch_id=}, num_bursts={len(product_burstset)}")
-
-        # create args for job-submissions
-        args_for_job_submitter = namedtuple(
-            "Namespace",
-            ["chunk_size", "release_version"],
-            defaults=[1, args.release_version]
-        )()
-
-        if args.dry_run:
-            logger.info(f"{args.dry_run=}. Skipping job submission. Producing mock job ID")
-            results = [uuid.uuid4()]
-        else:
-            logger.info(f"Submitting batches for DSWx-S1 job: {list(uploaded_batch_id_to_s3paths_map)}")
-            job_submission_tasks = submit_dswx_s1_job_submissions_tasks(uploaded_batch_id_to_s3paths_map, args_for_job_submitter, settings)
-            results = multithread_gather(job_submission_tasks)
-
-        suceeded_batch = [job_id for job_id in results if isinstance(job_id, str)]
-        failed_batch = [e for e in results if isinstance(e, Exception)]
-
-        if suceeded_batch:
-            for product in uploaded_batch_id_to_products_map[batch_id]:
-                if not product.get("dswx_s1_jobs_ids"):
-                    product["dswx_s1_jobs_ids"] = []
-
-                product["dswx_s1_jobs_ids"].append(first(suceeded_batch))
-
-            if args.dry_run:
-                logger.info(f"{args.dry_run=}. Skipping marking jobs as downloaded. Producing mock job ID")
-            else:
-                es_conn.mark_products_as_job_submitted({batch_id: uploaded_batch_id_to_products_map[batch_id]})
-
-            succeeded.extend(suceeded_batch)
-            failed.extend(failed_batch)
-
-            # manual cleanup since we needed to preserve downloads for manual s3 uploads
-            for fp in chain.from_iterable(burst_id_to_files_to_upload.values()):
-                fp.unlink(missing_ok=True)
-
-            logger.info("Removed downloads from disk")
-
-    return {
-        "success": succeeded,
-        "fail": failed
-    }
-
-
-def multithread_gather(job_submission_tasks):
-    """
-    Given a list of tasks, executes them concurrently and gathers the results.
-    Exceptions are returned as results rather than re-raised.
-    """
-    results = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(8, os.cpu_count() + 4)) as executor:
-        futures = [executor.submit(job_submission_task) for job_submission_task in job_submission_tasks]
-        for future in concurrent.futures.as_completed(futures):
-            try:
-                result = future.result()
-            except Exception as exc:
-                result = exc
-            results.append(result)
-    return results
 
 
 def supply_es_conn(args):

--- a/data_subscriber/daac_data_subscriber.py
+++ b/data_subscriber/daac_data_subscriber.py
@@ -33,7 +33,6 @@ from data_subscriber.hls.hls_catalog import HLSProductCatalog
 from data_subscriber.hls.hls_query import HlsCmrQuery
 from data_subscriber.lpdaac_download import DaacDownloadLpdaac
 from data_subscriber.parser import create_parser, validate_args
-from data_subscriber.query import update_url_index
 from data_subscriber.rtc.rtc_catalog import RTCProductCatalog
 from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.rtc.rtc_query import RtcCmrQuery
@@ -63,11 +62,6 @@ def run(argv: list[str]):
     configure_library_loggers()
 
     es_conn = supply_es_conn(args)
-
-    if args.file:
-        with open(args.file, "r") as f:
-            update_url_index(es_conn, f.readlines(), None, None, None)
-        exit(0)
 
     logger.debug(f"daac_data_subscriber.py invoked with {args=}")
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -7,6 +7,7 @@ from typing import Iterable
 import backoff
 import boto3
 import dateutil.parser
+import os
 import requests
 import requests.utils
 import validators
@@ -58,7 +59,7 @@ class DaacDownload:
         )
 
         if rm_downloads_dir:
-            self.logger.info(f"Removing directory tree. {self.downloads_dir}")
+            self.logger.info(f"Removing directory tree {os.path.abspath(self.downloads_dir)}")
             shutil.rmtree(self.downloads_dir)
 
         return product_to_product_filepaths_map

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -23,11 +23,6 @@ def create_parser():
                        "action": "store_true",
                        "help": "Quiet mode, only warning and error level messages will be logged."}}
 
-    file = {"positionals": ["-f", "--file"],
-            "kwargs": {"dest": "file",
-                       "help": "Path to file with newline-separated URIs to "
-                               "ingest into data product ES index (to be downloaded later)."}}
-
     endpoint = {"positionals": ["--endpoint"],
                 "kwargs": {"dest": "endpoint",
                            "choices": [endpoint.value for endpoint in Endpoint],
@@ -217,7 +212,7 @@ def create_parser():
                           "help": "The protocol used for retrieving data, "
                                   "HTTPS or S3 or AUTO."}}
 
-    parser_arg_list = [verbose, quiet, file]
+    parser_arg_list = [verbose, quiet]
     _add_arguments(parser, parser_arg_list)
 
     survey_parser = subparsers.add_parser("survey",
@@ -254,7 +249,7 @@ def create_parser():
 
     download_parser = subparsers.add_parser("download",
                                             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    download_parser_arg_list = [verbose, quiet, file, endpoint, dry_run, smoke_run, provider,
+    download_parser_arg_list = [verbose, quiet, endpoint, dry_run, smoke_run, provider,
                                 batch_ids, start_date, end_date, use_temporal, proc_mode,
                                 temporal_start_date, transfer_protocol, release_version]
     _add_arguments(download_parser, download_parser_arg_list)

--- a/data_subscriber/rtc/rtc_query.py
+++ b/data_subscriber/rtc/rtc_query.py
@@ -35,7 +35,12 @@ class RtcCmrQuery(CmrQuery):
     def __init__(self, args, token, es_conn, cmr, job_id, settings):
         super().__init__(args, token, es_conn, cmr, job_id, settings)
 
-    async def run_query(self):
+    def run_query(self):
+        # RTC is a special case in that it needs to run asynchronously
+        result = asyncio.run(self.run_query_async())
+        return result
+
+    async def run_query_async(self):
         query_dt = datetime.now()
         now = datetime.utcnow()
         query_timerange: DateTimeRange = get_query_timerange(self.args, now)


### PR DESCRIPTION
## Purpose
- This branch introduces some light refactoring of the code used for RTC-S1 product download and DSWx-S1 job triggering. The primary goal is to consolidate all RTC download code to the `AsfDaacRtcDownload` to make the class more suitable for future extension and reuse when download/triggering is implemented for DSWx-NI.

## Proposed Changes
- The `run_rtc_download` function (and associated helper functions) within `daac_data_subscriber.py` has been refactored into the `run_download` implementation within the `AsfDaacRtcDownload` class. This also simplifies the logic of the factory functions within `daac_data_subscriber.py`
- The superclass call to `DaacDownload.run_download()` in `AsfDaacCslcDownload.run_download()` has been modified to bypass the version now implemented in `AsfDaacRtcDownload`
- The `--file` argument has been removed from the `daac_data_subscriber.py` argparser since it was unused.
- To further simplify the logic within the factory functions in `daac_data_subscriber.py`, a `run_query` method has been added to `RtcCmrQuery` that wraps the asynchronous version (now called `run_query_async`)

## Testing
- Branch has been deployed and tested on development cluster with all PGEs running in simulation mode.
- Updates to download logic has been tested by enabling the download triggers and letting the cluster run for about ~8 hours
- Downloads have also been tested by submitting a few ad-hoc queries directly from mozart
