### PR TITLE
#1063: Updated consistent db file to 2025-01-22-2016-07-01_to_2024-12…

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -66,7 +66,7 @@ DEFAULT_DISP_S1_QUERY_GRACE_PERIOD_MINUTES: 210
 DISP_S1_K_FETCH_MULTIPLE: 2
 
 # This file contains mapping of frame_id to burst_id and all its sensing times based on real CMR data
-DISP_S1_BURST_DB_S3PATH: "s3://opera-ancillaries/disp_frames/disp_s1_consistent_burst_db/opera-disp-s1-consistent-burst-ids-2024-10-14-2016-07-01_to_2024-09-04.json"
+DISP_S1_BURST_DB_S3PATH: "s3://opera-ancillaries/disp_frames/disp_s1_consistent_burst_db/opera-disp-s1-consistent-burst-ids-2025-01-22-2016-07-01_to_2024-12-31.json"
 
 # This file contains list of blackout date ranges for DISP-S1 processing on a per-frame basis
 DISP_S1_BLACKOUT_DATES_S3PATH: "s3://opera-ancillaries/disp_frames/disp_s1_blackout_dates/sample_disp_s1_blackout.json"

--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -28,14 +28,18 @@ class _HistBursts(object):
         self.sensing_seconds_since_first = []  # Sensing time in seconds since the first sensing time
         self.sensing_datetime_days_index = []  # Sensing time in days since the first sensing time, rounded to the nearest day
 
-def localize_anc_json(settings_field):
-    '''Copy down a file from S3 whose path is defined in settings.yaml by settings_field'''
-
+def get_s3_resource_from_settings(settings_field):
     settings = SettingsConf().cfg
     burst_file_url = urlparse(settings[settings_field])
     s3 = boto3.resource('s3')
     path = burst_file_url.path.lstrip("/")
     file = path.split("/")[-1]
+
+    return s3, path, file, burst_file_url
+def localize_anc_json(settings_field):
+    '''Copy down a file from S3 whose path is defined in settings.yaml by settings_field'''
+
+    s3, path, file, burst_file_url = get_s3_resource_from_settings(settings_field)
     s3.Object(burst_file_url.netloc, path).download_file(file)
 
     return file
@@ -134,10 +138,6 @@ def process_disp_frame_burst_hist(file):
     datetime_to_frames = defaultdict(list)      # List of frame numbers
 
     for frame in j:
-
-        # If sensing time list is empty, skip this frame
-        if len(j[frame]["sensing_time_list"]) == 0:
-            continue
 
         frame_to_bursts[int(frame)].frame_number = int(frame)
 

--- a/tests/data_subscriber/test_cslc_query.py
+++ b/tests/data_subscriber/test_cslc_query.py
@@ -13,7 +13,8 @@ from data_subscriber.cmr import DateTimeRange
 forward_arguments = ["query", "-c", "OPERA_L2_CSLC-S1_V1", "--processing-mode=forward", "--start-date=2021-01-24T23:00:00Z",
                      "--end-date=2021-01-25T00:00:00Z", "--grace-mins=60", "--k=4", "--m=4"]
 
-BURST_MAP = Path(__file__).parent / "opera-disp-s1-consistent-burst-ids-2024-10-14-2016-07-01_to_2024-09-04.json"
+s3, path, file, burst_file_url = cslc_utils.get_s3_resource_from_settings("DISP_S1_BURST_DB_S3PATH")
+BURST_MAP = Path(__file__).parent / file
 frame_to_bursts, burst_to_frames, datetime_to_frames = cslc_utils.process_disp_frame_burst_hist(BURST_MAP)
 
 def test_extend_additional_records():
@@ -40,7 +41,7 @@ def test_reprocessing_by_native_id(caplog):
     c_query = cslc_query.CslcCmrQuery(reproc_args, None, None, None, None,
                                       {"DEFAULT_DISP_S1_QUERY_GRACE_PERIOD_MINUTES": 60},BURST_MAP)
     c_query.query_cmr(None, datetime.utcnow())
-    assert ("native_id='OPERA_L2_CSLC-S1_T027-056778-IW1_20231008T133102Z_20231009T204457Z_S1A_VV_v1.0' is not found in the DISP-S1 Burst ID Database JSON. Nothing to process"
+    assert ("native_id=OPERA_L2_CSLC-S1_T027-056778-IW1_20231008T133102Z_20231009T204457Z_S1A_VV_v1.0 is not found in the DISP-S1 Burst ID Database JSON. Nothing to process"
             in caplog.text)
 
 

--- a/tests/scenarios/cslc_query_test.py
+++ b/tests/scenarios/cslc_query_test.py
@@ -265,3 +265,4 @@ if success:
     logging.info("TEST SUCCESS")
 else:
     logging.error("TEST FAILED")
+    exit(-1)


### PR DESCRIPTION
…-31 version. Fixed a bug where we threw out the entire frame in the db if there are no sensing dates for that frame. Updated and cleaned upunit tests
