### PR TITLE
#1067: Refactored mozart.tf so that deploy_pges.py and deploy_pcm_and…

### DIFF
--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -443,30 +443,7 @@ resource "aws_instance" "mozart" {
     ]
   }
 
-  # sync bach-api and bach-ui code. start bach-ui
-  provisioner "remote-exec" {
-    inline = [<<-EOT
-      while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 10; done
-      set -ex
-      cd ~/mozart/ops
-      if [ "${var.use_artifactory}" = true ]; then
-        ~/download_artifact.sh -m "${var.artifactory_mirror_url}" -b "${var.artifactory_base_url}" "${var.artifactory_base_url}/${var.artifactory_repo}/gov/nasa/jpl/${var.project}/sds/pcm/${var.project}-sds-bach-ui-${var.bach_ui_branch}.tar.gz"
-        tar xfz ${var.project}-sds-bach-ui-${var.bach_ui_branch}.tar.gz
-        ln -s /export/home/hysdsops/mozart/ops/${var.project}-sds-bach-ui-${var.bach_ui_branch} /export/home/hysdsops/mozart/ops/bach-ui
-        rm -rf ${var.project}-sds-bach-ui-${var.bach_ui_branch}.tar.gz
-      else
-        git clone --quiet --single-branch -b ${var.bach_ui_branch} https://${var.git_auth_key}@${var.bach_ui_repo} bach-ui
-      fi
 
-      export PATH=~/conda/bin:$PATH
-
-      cd bach-ui
-      ~/conda/bin/npm install --silent --no-progress
-      sh create_config_simlink.sh ~/.sds/config ~/mozart/ops/bach-ui
-      ~/conda/bin/npm run build --silent
-    EOT
-    ]
-  }
 
   # Copy down latest opera-sds-int and opera-sds-ops repos for convenience
   provisioner "remote-exec" {
@@ -592,6 +569,70 @@ resource "aws_instance" "mozart" {
     ]
   }
 
+  // Snapshot repositories and lifecycles for GRQ mozart and metrics ES, also set shard max
+  // Snapshot schedule is in UTC, 5 AM UTC is 9/10 PM PST, depending on daylight savingss
+  provisioner "remote-exec" {
+    inline = [<<-EOT
+     while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 10; done
+      set -ex
+      source ~/.bash_profile
+      echo // grq
+      ~/mozart/bin/snapshot_es_data.py --es-url ${local.grq_es_url} create-repository --repository snapshot-repository --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/grq --role-arn ${var.es_bucket_role_arn}
+      ~/mozart/bin/snapshot_es_data.py --es-url ${local.grq_es_url} create-lifecycle --repository snapshot-repository --policy-id daily-snapshot --snapshot grq-backup --index-pattern grq_*,*_catalog --schedule="0 0 5 * * ?"
+      curl -XPUT ${local.grq_es_url}/_cluster/settings -H 'Content-type: application/json' --data-binary $'{"transient":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}, "persistent":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}}'
+
+      echo // mozart
+      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.mozart.private_ip}:9200 create-repository --repository snapshot-repository --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/mozart --role-arn ${var.es_bucket_role_arn}
+      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.mozart.private_ip}:9200 create-lifecycle --repository snapshot-repository --policy-id daily-snapshot --snapshot mozart-backup --index-pattern *_status-*,user_rules-*,job_specs,hysds_ios-*,containers --schedule="0 0 5 * * ?"
+      curl -XPUT http://${aws_instance.mozart.private_ip}:9200/_cluster/settings -H 'Content-type: application/json' --data-binary $'{"transient":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}, "persistent":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}}'
+
+      echo // metrics
+      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.metrics.private_ip}:9200 create-repository --repository snapshot-repository --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/metrics --role-arn ${var.es_bucket_role_arn}
+      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.metrics.private_ip}:9200 create-lifecycle --repository snapshot-repository --policy-id daily-snapshot --snapshot metrics-backup --index-pattern logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-* --schedule="0 0 5 * * ?"
+      curl -XPUT http://${aws_instance.metrics.private_ip}:9200/_cluster/settings -H 'Content-type: application/json' --data-binary $'{"transient":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}, "persistent":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}}'
+
+    EOT
+    ]
+  }
+}
+
+resource "null_resource" "bach_and_deploy_pges" {
+  depends_on = [
+    aws_instance.mozart
+  ]
+
+  connection {
+    type = "ssh"
+    host = aws_instance.mozart.private_ip
+    user = "hysdsops"
+    private_key = file(var.private_key_file)
+  }
+
+  # sync bach-api and bach-ui code. start bach-ui
+  provisioner "remote-exec" {
+    inline = [<<-EOT
+      while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 10; done
+      set -ex
+      cd ~/mozart/ops
+      if [ "${var.use_artifactory}" = true ]; then
+        ~/download_artifact.sh -m "${var.artifactory_mirror_url}" -b "${var.artifactory_base_url}" "${var.artifactory_base_url}/${var.artifactory_repo}/gov/nasa/jpl/${var.project}/sds/pcm/${var.project}-sds-bach-ui-${var.bach_ui_branch}.tar.gz"
+        tar xfz ${var.project}-sds-bach-ui-${var.bach_ui_branch}.tar.gz
+        ln -s /export/home/hysdsops/mozart/ops/${var.project}-sds-bach-ui-${var.bach_ui_branch} /export/home/hysdsops/mozart/ops/bach-ui
+        rm -rf ${var.project}-sds-bach-ui-${var.bach_ui_branch}.tar.gz
+      else
+        git clone --quiet --single-branch -b ${var.bach_ui_branch} https://${var.git_auth_key}@${var.bach_ui_repo} bach-ui
+      fi
+
+      export PATH=~/conda/bin:$PATH
+
+      cd bach-ui
+      ~/conda/bin/npm install --silent --no-progress
+      sh create_config_simlink.sh ~/.sds/config ~/mozart/ops/bach-ui
+      ~/conda/bin/npm run build --silent
+    EOT
+    ]
+  }
+
   # deploy PGEs
   provisioner "remote-exec" {
     inline = [<<-EOT
@@ -625,32 +666,6 @@ resource "aws_instance" "mozart" {
       sds -d cloud storage ship_style --bucket ${local.osl_bucket}
       sds -d cloud storage ship_style --bucket ${local.triage_bucket}
       sds -d cloud storage ship_style --bucket ${local.lts_bucket}
-    EOT
-    ]
-  }
-
-  // Snapshot repositories and lifecycles for GRQ mozart and metrics ES, also set shard max
-  // Snapshot schedule is in UTC, 5 AM UTC is 9/10 PM PST, depending on daylight savingss
-  provisioner "remote-exec" {
-    inline = [<<-EOT
-     while [ ! -f /var/lib/cloud/instance/boot-finished ]; do echo 'Waiting for cloud-init...'; sleep 10; done
-      set -ex
-      source ~/.bash_profile
-      echo // grq
-      ~/mozart/bin/snapshot_es_data.py --es-url ${local.grq_es_url} create-repository --repository snapshot-repository --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/grq --role-arn ${var.es_bucket_role_arn}
-      ~/mozart/bin/snapshot_es_data.py --es-url ${local.grq_es_url} create-lifecycle --repository snapshot-repository --policy-id daily-snapshot --snapshot grq-backup --index-pattern grq_*,*_catalog --schedule="0 0 5 * * ?"
-      curl -XPUT ${local.grq_es_url}/_cluster/settings -H 'Content-type: application/json' --data-binary $'{"transient":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}, "persistent":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}}'
-
-      echo // mozart
-      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.mozart.private_ip}:9200 create-repository --repository snapshot-repository --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/mozart --role-arn ${var.es_bucket_role_arn}
-      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.mozart.private_ip}:9200 create-lifecycle --repository snapshot-repository --policy-id daily-snapshot --snapshot mozart-backup --index-pattern *_status-*,user_rules-*,job_specs,hysds_ios-*,containers --schedule="0 0 5 * * ?"
-      curl -XPUT http://${aws_instance.mozart.private_ip}:9200/_cluster/settings -H 'Content-type: application/json' --data-binary $'{"transient":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}, "persistent":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}}'
-
-      echo // metrics
-      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.metrics.private_ip}:9200 create-repository --repository snapshot-repository --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/metrics --role-arn ${var.es_bucket_role_arn}
-      ~/mozart/bin/snapshot_es_data.py --es-url http://${aws_instance.metrics.private_ip}:9200 create-lifecycle --repository snapshot-repository --policy-id daily-snapshot --snapshot metrics-backup --index-pattern logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-* --schedule="0 0 5 * * ?"
-      curl -XPUT http://${aws_instance.metrics.private_ip}:9200/_cluster/settings -H 'Content-type: application/json' --data-binary $'{"transient":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}, "persistent":{"cluster.max_shards_per_node": 6000, "search.max_open_scroll_context": 6000}}'
-
     EOT
     ]
   }


### PR DESCRIPTION
…_pges run in parallel. This saves 20 mins of deploymnt time on dev cluster: 1 hour and 15 mins to 54 mins

## Purpose and Proposed Changes
- In `mozart.tf` pull out `remote_execs` that installs bach_ui and runs `deploy_pges.py` into its own `null_resource`: `bach_and_deploy_pges` to speed up deployment
## Explanation
- The end result is that these two will run in parallel to other mozart terraform resources running, in particular `deploy_pcm_and_pges` This and `deploy_pges.py` are the two longest running resource when deploying Mozart and by allowing them to run in parallel, 20 mins is saves in deployment time: 1 hour and 15 mins to 54 mins on average.
## Issues
- https://github.com/nasa/opera-sds-pcm/issues/1067
## Testing
- Destroyed and deployed in my personal dev cluster twice. Both were successful and both took 54 mins to deploy (as opposed to 1:15 previously)
- Ran all major query, download, SCIFLO, and CNM-S jobs and they all succeeded.
- You can see lines like this now:
`module.common.null_resource.install_pcm_and_pges: Still creating... [16m30s elapsed]`
`module.common.null_resource.bach_and_deploy_pges: Still creating... [16m30s elapsed]`
- And this is the final line output for deploying pges confirming that it was running in parallel and that it took 17 minutes
`module.common.null_resource.bach_and_deploy_pges: Creation complete after 17m14s [id=2647260127362677226]`
`module.common.null_resource.install_pcm_and_pges: Still creating... [17m20s elapsed]` 