### PR TITLE
DSWx-HLS PGE v1.0.3 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -377,7 +377,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.2"
+    "dswx_hls" = "1.0.3"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -159,7 +159,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.2"
+    "dswx_hls" = "1.0.3"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -378,7 +378,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.2"
+    "dswx_hls" = "1.0.3"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -30,7 +30,7 @@ variable "pge_snapshots_date" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.2"
+    "dswx_hls" = "1.0.3"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -613,7 +613,7 @@ variable "lambda_log_retention_in_days" {
 variable "pge_releases" {
   type = map(string)
   default = {
-    "dswx_hls" = "1.0.2"
+    "dswx_hls" = "1.0.3"
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"

--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -21,7 +21,7 @@ RunConfig:
         ScratchPath: {{ data.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DSWX_HLS
-        ProductVersion: {{ data.product_path_group.product_version }}
+        ProductVersion: "{{ data.product_path_group.product_version }}"
         ProgramPath: python3
         ProgramOptions:
           - /home/conda/proteus-1.0.1/bin/dswx_hls.py
@@ -29,6 +29,7 @@ RunConfig:
         ErrorCodeBase: 100000
         SchemaPath: /home/conda/opera/pge/dswx_hls/schema/dswx_hls_sas_schema.yaml
         IsoTemplatePath: /home/conda/opera/pge/dswx_hls/templates/OPERA_ISO_metadata_L3_DSWx_HLS_template.xml.jinja2
+        IsoMeasuredParameterDescriptions: /home/conda/opera/pge/dswx_hls/templates/dswx_hls_measured_parameters.yaml
       QAExecutable:
         Enabled: False
         ProgramPath:

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -108,14 +108,14 @@ L3_DSWx_HLS:
       # Pattern for parsing output image filenames, such as:
       # * "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v0.1_B01_WTF.tif"
       # * "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v0.1_B09_CLOUD.tif"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tif|tiff)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|S2C|S2D|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tif|tiff)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # * "OPERA_L3_DSWx-HLS_T22VEQ_20210905T143156Z_20220105T143156Z_L8_30_v2.0.catalog.json"
       # * "OPERA_L3_DSWx-HLS_T15SXR_20210907T163901Z_20220207T163901Z_S2A_30_v2.0.iso.xml"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>log|png|tif|qa\.log|iso\.xml|catalog\.json)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|S2C|S2D|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>log|png|tif|qa\.log|iso\.xml|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames

--- a/conf/schema/RunConfig_schema.L3_DSWx_HLS.yaml
+++ b/conf/schema/RunConfig_schema.L3_DSWx_HLS.yaml
@@ -10,7 +10,7 @@ RunConfig:
         InputFilePaths: list(str(), min=1, required=True)
 
       DynamicAncillaryFilesGroup:
-        AncillaryFileMap: map(str(), key=str(), min=0)
+        AncillaryFileMap: map(key=str(), min=0)
 
       ProductPathGroup:
         OutputProductPath: str(required=True)
@@ -18,7 +18,7 @@ RunConfig:
 
       PrimaryExecutable:
         ProductIdentifier: str(required=False)
-        ProductVersion: num(required=False)
+        ProductVersion: any(str(), num(), required=False)
         CompositeReleaseID: str(required=False)
         ProgramPath: str(required=True)
         ProgramOptions: list(str(), min=0, required=False)
@@ -26,6 +26,7 @@ RunConfig:
         SchemaPath: str(required=True)
         AlgorithmParametersSchemaPath: str(required=False)
         IsoTemplatePath: str(required=False)
+        IsoMeasuredParameterDescriptions: str(required=False)
         DataValidityStartDate: int(min=20000101, max=21991231, required=False)
 
       QAExecutable:

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L3_DSWx_HLS",
       "level": "L3",
       "type": "L3_DSWx_HLS",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|S2C|S2D|L8|L9)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -268,7 +268,7 @@
       "ipath": "hysds::data/L3_DSWx_HLS",
       "level": "L3",
       "type": "L3_DSWx_HLS",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S2A|S2B|S2C|S2D|L8|L9)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -84,7 +84,7 @@ SHORTNAME_FILTERS:
 #   - S1 # Sentinel-1
     - S2A # Sentinel-2A
     - S2B # Sentinel-2B
-#   - S2C # Sentinel-2C
+    - S2C # Sentinel-2C
 
 GEOJSON_BUCKET: "opera-ancillaries"
 

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -337,7 +337,7 @@ PRODUCT_TYPES:
         # This pattern groups the metadata information in the filename using named groups.
         #
         # Note: POSIX character class "[[:alnum:]]" is not supported in python's re, and so has been replaced with "[^\W_]" here.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tif|tiff)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L3)_(?P<product_type>DSWx)-(?P<source>HLS)_(?P<tile_id>T[^\W_]{5})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S2A|S2B|S2C|S2D|L8|L9)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))_(?P<band_index>B\d{2})_(?P<band_name>WTR|BWTR|CONF|DIAG|WTR-1|WTR-2|LAND|SHAD|CLOUD|DEM)[.](?P<ext>tif|tiff)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:

--- a/docker/hysds-io.json.pge_smoke_test
+++ b/docker/hysds-io.json.pge_smoke_test
@@ -7,7 +7,7 @@
             "name": "pge_name",
             "from": "submitter",
             "type": "enum",
-            "enumerables": ["dswx_s1", "disp_s1", "dswx_ni"],
+            "enumerables": ["dswx_hls", "dswx_s1", "disp_s1", "dswx_ni"],
             "optional": false
         },
         {

--- a/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
+++ b/docker/job-spec.json.SCIFLO_L3_DSWx_HLS
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dswx_hls:1.0.2",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.2.tar.gz",
+      "container_image_name": "opera_pge/dswx_hls:1.0.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.3.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -10,6 +10,14 @@
     },
     "dependency_images": [
         {
+          "container_image_name": "opera_pge/dswx_hls:1.0.3",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_hls-1.0.3.tar.gz",
+          "container_mappings": {
+            "$HOME/.netrc": ["/root/.netrc"],
+            "$HOME/.aws": ["/root/.aws", "ro"]
+          }
+        },
+        {
           "container_image_name": "opera_pge/dswx_s1:3.0.2",
           "container_image_url": "$CODE_BUCKET_URL/opera_pge-dswx_s1-3.0.2.tar.gz",
           "container_mappings": {


### PR DESCRIPTION
## Purpose
- This branch integrates DSWx-HLS PGE v1.0.3 with OPERA PCM. This version includes a fix to support processing of HLS granules derived from Sentinel-2C. The On-demand PGE smoke test job now also supports DSWx-HLS.

**Note**: we may need to hold off on merging this branch until a new deployment for DSWx-HLS has been approved by the CCB 

## Issues
- Resolves #1070

## Testing
- Branch has been tested on a dev cluster using both the real and simulated PGE mode. On demand smoke test for DSWx-HLS has also been tested.
- The HLSS30 download timer was also enabled to ensure we can process newly incoming HLS granules derived from S2C.
- To test this branch using a Sentinel-2C derived HLS granule:
`python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -c HLSS30 --job-queue=opera-job_worker-hls_data_download --chunk-size=1 --native-id=HLS.S30.T35UQR.2025024T091321*`
