### PR TITLE
1076 1077 disp s1 sciflo num processes and asg celery late ack

### DIFF
--- a/conf/sds/files/celeryconfig.py.tmpl.asg
+++ b/conf/sds/files/celeryconfig.py.tmpl.asg
@@ -5,7 +5,7 @@ task_serializer = "msgpack"
 result_serializer = "msgpack"
 accept_content = ["msgpack", "json"]
 
-task_acks_late = False
+task_acks_late = True
 result_expires = 86400
 worker_prefetch_multiplier = 1
 

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -77,6 +77,13 @@ DISP_S1_BLACKOUT_DATES_S3PATH: "s3://opera-ancillaries/disp_frames/disp_s1_black
 # This file contains geo boundaries of all DISP-S1 frames
 DISP_S1_FRAME_GEO_SIMPLE: "s3://opera-ancillaries/disp_frames/disp_s1_frame_geo_simple/frame-geometries-simple.geojson"
 
+DISP_S1_NUM_THREADS: 8
+
+# number of workers = available_cpu_cores * FACTOR + CONSTANT
+DISP_S1_NUM_WORKERS:
+  FACTOR: 0.25
+  CONSTANT: 1
+
 # Shortname filtering on input product types. RegEx strings ('.' == any single character)
 SHORTNAME_FILTERS:
   HLSL30:

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -376,10 +376,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         available_cores = os.cpu_count()
 
-        # Use all available cores for threads_per_worker
-
         try:
-            threads_per_worker = self._settings.get("DISP_S1_NUM_THREADS")
+            threads_per_worker = self._settings["DISP_S1_NUM_THREADS"]
         except:
             threads_per_worker = available_cores
             logger.error(f"DISP_S1_NUM_THREADS not found in settings.yaml. Using default {threads_per_worker=}")
@@ -387,8 +385,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         logger.info(f"Allocating {threads_per_worker=} out of {available_cores} available")
 
         try:
-            parallel_factor = self._settings.get("DISP_S1_NUM_WORKERS").get("FACTOR")
-            parallel_constant = self._settings.get("DISP_S1_NUM_WORKERS").get("CONSTANT")
+            parallel_factor = self._settings["DISP_S1_NUM_WORKERS"]["FACTOR"]
+            parallel_constant = self._settings["DISP_S1_NUM_WORKERS"]["CONSTANT"]
         except:
             parallel_factor = 0.25
             parallel_constant = 1

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -380,7 +380,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
             threads_per_worker = self._settings["DISP_S1_NUM_THREADS"]
         except:
             threads_per_worker = available_cores
-            logger.error(f"DISP_S1_NUM_THREADS not found in settings.yaml. Using default {threads_per_worker=}")
+            logger.warning(f"DISP_S1_NUM_THREADS not found in settings.yaml. Using default {threads_per_worker=}")
 
         logger.info(f"Allocating {threads_per_worker=} out of {available_cores} available")
 
@@ -390,7 +390,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         except:
             parallel_factor = 0.25
             parallel_constant = 1
-            logger.error(f"DISP_S1_NUM_WORKERS not found in settings.yaml. Using defaults {parallel_factor=}, {parallel_constant=}")
+            logger.warning(f"DISP_S1_NUM_WORKERS not found in settings.yaml. Using defaults {parallel_factor=}, {parallel_constant=}")
 
         # This number is the number of python proceses to run when processing in the wrapped stage. We want 1 minimum.
         # These processes are both memory and CPU intensive so we definite want less than the number of cores we have on the system by some factor

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -377,13 +377,26 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         available_cores = os.cpu_count()
 
         # Use all available cores for threads_per_worker
-        threads_per_worker = available_cores
+
+        try:
+            threads_per_worker = self._settings.get("DISP_S1_NUM_THREADS")
+        except:
+            threads_per_worker = available_cores
+            logger.error(f"DISP_S1_NUM_THREADS not found in settings.yaml. Using default {threads_per_worker=}")
 
         logger.info(f"Allocating {threads_per_worker=} out of {available_cores} available")
 
-        # Use (1/2 + 1) of the available cores for parallel burst processing
-        n_parallel_bursts = max(int(round(available_cores / 2)) + 1, 1)
+        try:
+            parallel_factor = self._settings.get("DISP_S1_NUM_WORKERS").get("FACTOR")
+            parallel_constant = self._settings.get("DISP_S1_NUM_WORKERS").get("CONSTANT")
+        except:
+            parallel_factor = 0.25
+            parallel_constant = 1
+            logger.error(f"DISP_S1_NUM_WORKERS not found in settings.yaml. Using defaults {parallel_factor=}, {parallel_constant=}")
 
+        # This number is the number of python proceses to run when processing in the wrapped stage. We want 1 minimum.
+        # These processes are both memory and CPU intensive so we definite want less than the number of cores we have on the system by some factor
+        n_parallel_bursts = max(int(round(available_cores * parallel_factor)) + parallel_constant, 1)
         logger.info(f"Allocating {n_parallel_bursts=} out of {available_cores} available")
 
         rc_params = {


### PR DESCRIPTION
## Purpose
- This PR addresses two tickets at once: 1076 and 1077. I put them into one branch for quicker testing because time is of essence for these changes today.
## Proposed Changes
- Change back `task_acks_late` to be `True`
- Parameterize num process determination for DISP-S1 SCIFLO PGE

## Issues
- https://github.com/nasa/opera-sds-pcm/issues/1076
- https://github.com/nasa/opera-sds-pcm/issues/1077
## Testing
- I ran DISP-S1 with n_procs = 9 instead of 17 we'd been using. Idea is to reduce the number of processes to reduce memory usage so that we are not thrashing on swap memory. I wanted to make sure that taking that approach wouldn't slow us down. It actually seems to have improved running time on average by 5%. There is some randomness to it but there is overall trend. Run time is in seconds. The run-time also encompasses ALL machine activity including downloading all input files and copying them out to S3 which happen outside of the SAS container.
- This should basically be an apples-to-apples comparison. Used the exact same EC2 type and ran through the exact same frames and sensing datetime range. These were the first k=15 set for each frame so theoretically these should be one of the faster runs for that frame.
- Also verified that late_ack behavior is what we expected and all jobs were being scheduled to run as opposed to being in unacked state and queued.
- Verified that the values in `settings.yaml` were being logged and used by DISP-S1 SCIFLO PGE

![image](https://github.com/user-attachments/assets/d3b5f1fc-e3ce-45a3-9bcc-19640a43fe13)

