### PR TITLE
Add tag to worker instances to filter for them in cost queries

### DIFF
--- a/cluster_provisioning/modules/common/asg.tf
+++ b/cluster_provisioning/modules/common/asg.tf
@@ -104,6 +104,11 @@ resource "aws_autoscaling_group" "autoscaling_group" {
       value               = "pcm"
       propagate_at_launch = true
     },
+    {
+      key                 = "Alfa"
+      value               = "worker"
+      propagate_at_launch = true
+    },
   ]
   mixed_instances_policy {
     instances_distribution {


### PR DESCRIPTION
## Purpose
For ease of getting billed cost data for the job worker instances, add a cost allocation tag to the ASGs that propagate to them. This should allow easy filtering of costs due to workers

## Testing
None done yet, but could test deploy to test dev cluster if desired
