### PR TITLE
#1086: Added LPCLOUDUAT to the list of providers. Use explicitly pass…

### DIFF
--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -37,6 +37,7 @@ class Endpoint(str, Enum):
 
 class Provider(str, Enum):
     LPCLOUD = "LPCLOUD"
+    LPCLOUDUAT = "LPCLOUDUAT"
     ASF = "ASF"
     ASF_SLC = "ASF-SLC"
     ASF_RTC = "ASF-RTC"
@@ -127,7 +128,7 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
 
     params = {
         "sort_key": "-start_date",
-        "provider": COLLECTION_TO_PROVIDER_MAP[args.collection],
+        "provider": args.provider if args.provider else COLLECTION_TO_PROVIDER_MAP[args.collection],
         "ShortName[]": [args.collection],
         "token": token,
         "bounding_box": bounding_box

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -180,7 +180,7 @@ async def async_query_cmr(args, token, cmr, settings, timerange, now: datetime, 
             logger.debug("Using args.temporal_start_date=%s", args.temporal_start_date)
             params["temporal"] = dateutil.parser.isoparse(args.temporal_start_date).strftime(CMR_TIME_FORMAT)
 
-    logger.info(f"Querying CMR.")
+    logger.info(f"Querying CMR. endpoint: %s  provider: %s", args.endpoint, args.provider)
     logger.debug("request_url=%s", request_url)
     logger.debug("params=%s", params)
 

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -237,7 +237,7 @@ def create_parser():
 
     query_parser = subparsers.add_parser("query",
                                          formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    query_parser_arg_list = [verbose, quiet, endpoint, collection, start_date, end_date,
+    query_parser_arg_list = [verbose, quiet, endpoint, provider, collection, start_date, end_date,
                              bbox, minutes, k, m, grace_mins,
                              dry_run, smoke_run, no_schedule_download,
                              release_version, job_queue, chunk_size, max_revision,


### PR DESCRIPTION
…-in provider instead of mapping

Tested on INT cluster and works for both UAT and non-UAT CMR queries on HLS data.