### PR TITLE
1095 1096 cslc download fixes

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -526,12 +526,24 @@ variable "queues" {
     }
     "opera-job_worker-cslc_data_download" = {
       "name"              = "opera-job_worker-cslc_data_download"
-      "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
+      "instance_type"     = ["m6a.large", "m5.large", "m5ad.large", "m6i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
-      "data_dev_size"     = 250
+      "data_dev_size"     = 50
       "min_size"          = 0
       "max_size"          = 10
+      "total_jobs_metric" = true
+      "use_private_vpc"   = false
+      "use_on_demand"     = false
+    }
+    "opera-job_worker-cslc_data_download_hist" = {
+      "name"              = "opera-job_worker-cslc_data_download_hist"
+      "instance_type"     = ["m6a.large", "m5.large", "m5ad.large", "m6i.large"]
+      "user_data"         = "launch_template_user_data.sh.tmpl"
+      "root_dev_size"     = 50
+      "data_dev_size"     = 50
+      "min_size"          = 0
+      "max_size"          = 25
       "total_jobs_metric" = true
       "use_private_vpc"   = false
       "use_on_demand"     = false
@@ -556,18 +568,6 @@ variable "queues" {
       "data_dev_size"     = 100
       "min_size"          = 0
       "max_size"          = 10
-      "total_jobs_metric" = true
-      "use_private_vpc"   = false
-      "use_on_demand"     = false
-    }
-    "opera-job_worker-cslc_data_download_hist" = {
-      "name"              = "opera-job_worker-cslc_data_download_hist"
-      "instance_type"     = ["c5n.2xlarge", "m5dn.2xlarge"]
-      "user_data"         = "launch_template_user_data.sh.tmpl"
-      "root_dev_size"     = 50
-      "data_dev_size"     = 250
-      "min_size"          = 0
-      "max_size"          = 25
       "total_jobs_metric" = true
       "use_private_vpc"   = false
       "use_on_demand"     = false

--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -88,12 +88,13 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
             # For s3 we can use the files directly so simply copy over the paths
             else: # s3 or auto
                 self.logger.info("Skipping download CSLC bursts and instead using ASF S3 paths for direct SCIFLO PGE ingestion")
-                downloads = self.get_downloads(args, es_conn)
-                cslc_s3paths = [download["s3_url"] for download in downloads]
-                if len(cslc_s3paths) == 0:
+                downloads = self.get_downloads(new_args, es_conn)
+                batch_cslc_s3paths = [download["s3_url"] for download in downloads]
+                cslc_s3paths.extend(batch_cslc_s3paths)
+                if len(batch_cslc_s3paths) == 0:
                     raise Exception(f"No s3_path found for {batch_id}. You probably should specify https transfer protocol.")
 
-                for p in cslc_s3paths:
+                for p in batch_cslc_s3paths:
                     # Split the following into bucket name and key
                     # 's3://asf-cumulus-prod-opera-products/OPERA_L2_CSLC-S1/OPERA_L2_CSLC-S1_T122-260026-IW3_20231214T011435Z_20231215T075814Z_S1A_VV_v1.0/OPERA_L2_CSLC-S1_T122-260026-IW3_20231214T011435Z_20231215T075814Z_S1A_VV_v1.0.h5'
                     parsed_url = urllib.parse.urlparse(p)
@@ -111,7 +112,7 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
 
                     granule_sizes.append((granule_id, file_size))
 
-                cslc_files_to_upload = [Path(p) for p in cslc_s3paths] # Need this for querying static CSLCs
+                cslc_files_to_upload = [Path(p) for p in batch_cslc_s3paths] # Need this for querying static CSLCs
 
                 cslc_products_to_filepaths = {} # Dummy when trying to delete files later in this function
 

--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -337,6 +337,7 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
         cslc_query_args.native_id = query_native_id
         cslc_query_args.no_schedule_download = True
         cslc_query_args.collection = Collection.CSLC_S1_STATIC_V1.value
+        cslc_query_args.provider = None # This will be set in the query function looked up by collection
         cslc_query_args.bbox = "-180,-90,180,90"
         cslc_query_args.start_date = None
         cslc_query_args.end_date = None

--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -129,14 +129,14 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
 
             self.logger.info(f"Querying CSLC-S1 Static Layer products for {batch_id}")
             cslc_static_granules = self.query_cslc_static_files_for_cslc_batch(
-                cslc_files_to_upload, args, token, job_id, settings
+                cslc_files_to_upload, new_args, token, job_id, settings
             )
 
             # Download the files from ASF only if the transfer protocol is HTTPS
             if args.transfer_protocol == "https":
                 self.logger.info(f"Downloading CSLC Static Layer products for {batch_id}")
                 cslc_static_products_to_filepaths: dict[str, set[Path]] = self.download_cslc_static_files_for_cslc_batch(
-                    cslc_static_granules, args, token, netloc,
+                    cslc_static_granules, new_args, token, netloc,
                     username, password, job_id
                 )
 

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -55,6 +55,7 @@ class ProductType(str, Enum):
 
 CMR_TIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
+# maps a collection shortname to the appropriate provider attr in the CMR query
 COLLECTION_TO_PROVIDER_MAP = {
     Collection.HLSL30: Provider.LPCLOUD.value,
     Collection.HLSS30: Provider.LPCLOUD.value,
@@ -66,6 +67,8 @@ COLLECTION_TO_PROVIDER_MAP = {
     Collection.NISAR_GCOV_BETA_V1: Provider.ASF.value
 }
 
+# PROVIDER_TYPE means provider and product type.
+# TODO: change this to COLLECTION_TO_PROVIDER_PRODUCT_TYPE_MAP so it's less confusing w COLLECTION_TO_PROVIDER_MAP
 COLLECTION_TO_PROVIDER_TYPE_MAP = {
     Collection.HLSL30: Provider.LPCLOUD.value,
     Collection.HLSS30: Provider.LPCLOUD.value,

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -32,7 +32,6 @@ def create_parser():
     provider = {"positionals": ["-p", "--provider"],
                 "kwargs": {"dest": "provider",
                            "choices": [provider.value for provider in Provider],
-                           "default": Provider.LPCLOUD.value,
                            "help": "Specify a provider for collection search."}}
 
     collection = {

--- a/docker/job-spec.json.cslc_download
+++ b/docker/job-spec.json.cslc_download
@@ -1,8 +1,8 @@
 {
   "command":"/home/ops/verdi/ops/opera-pcm/data_subscriber/cslc/cslc_download.sh",
-  "disk_usage":"200GB",
-  "soft_time_limit": 7200,
-  "time_limit": 7260,
+  "disk_usage":"1GB",
+  "soft_time_limit": 2000,
+  "time_limit": 2060,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/docker/job-spec.json.cslc_download_hist
+++ b/docker/job-spec.json.cslc_download_hist
@@ -1,8 +1,8 @@
 {
   "command":"/home/ops/verdi/ops/opera-pcm/data_subscriber/cslc/cslc_download.sh",
-  "disk_usage":"200GB",
-  "soft_time_limit": 7200,
-  "time_limit": 7260,
+  "disk_usage":"1GB",
+  "soft_time_limit": 2000,
+  "time_limit": 2060,
   "imported_worker_files": {
     "$HOME/.netrc": "/home/ops/.netrc",
     "$HOME/.aws": "/home/ops/.aws",

--- a/util/job_submitter.py
+++ b/util/job_submitter.py
@@ -6,7 +6,7 @@ import backoff
 from hysds_commons.job_utils import submit_mozart_job as submit_job
 
 
-def try_submit_mozart_job(*, product: dict, job_queue: str, rule_name, params: list[dict[str, str]], job_spec: str, job_type: Optional[str] = None, job_name) -> str:
+def try_submit_mozart_job(*, product: dict, job_queue: str, rule_name, params: list[dict[str, str]], job_spec: str, job_type: Optional[str] = None, job_name, payload_hash=None) -> str:
     """
     Submits a HySDS job. Must be executed within a HySDS cluster.
 
@@ -22,12 +22,13 @@ def try_submit_mozart_job(*, product: dict, job_queue: str, rule_name, params: l
             "job-specification": job_spec
         },
         # job_type=job_type,
-        job_name=job_name
+        job_name=job_name,
+        payload_hash=payload_hash
     )
 
 
 @backoff.on_exception(backoff.expo, exception=Exception, max_tries=3, jitter=None)
-def _try_submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, rule_name, hysdsio: dict, job_name) -> str:
+def _try_submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, rule_name, hysdsio: dict, job_name, payload_hash=None) -> str:
     """
     Submits a mozart job with the minimal number of required parameters.
     Clients should note that jobs are submitted with enable_dedup=true.
@@ -37,11 +38,12 @@ def _try_submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, r
         job_queue=job_queue,
         rule_name=rule_name,
         hysdsio=hysdsio,
-        job_name=job_name
+        job_name=job_name,
+        payload_hash=payload_hash
     )
 
 
-def _submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, rule_name, hysdsio: dict, job_name) -> str:
+def _submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, rule_name, hysdsio: dict, job_name, payload_hash=None) -> str:
     """Do not call directly. See wrapper with @backoff decorator for usage"""
     return submit_job(
         product=product or {},
@@ -55,7 +57,7 @@ def _submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, rule_
         hysdsio=hysdsio,
         queue=None,
         job_name=job_name,
-        payload_hash=None,
+        payload_hash=payload_hash,
         enable_dedup=None,
         soft_time_limit=None,
         time_limit=None
@@ -63,18 +65,19 @@ def _submit_mozart_job_minimal(*, product: Optional[dict], job_queue: str, rule_
 
 
 @backoff.on_exception(backoff.expo, exception=Exception, max_tries=3, jitter=None)
-def _try_submit_mozart_job_by_rule_minimal(*, product: Optional[dict], rule_name, job_type: str, job_queue: str, job_name) -> str:
+def _try_submit_mozart_job_by_rule_minimal(*, product: Optional[dict], rule_name, job_type: str, job_queue: str, job_name, payload_hash=None) -> str:
     """Submits a mozart job with hysdsio specified by an existing rule, rather than a given hysdsio specification."""
     return _submit_mozart_job_by_rule_minimal(
         product=product,
         rule_name=rule_name,
         job_type=job_type,
         job_queue=job_queue,
-        job_name=job_name
+        job_name=job_name,
+        payload_hash=payload_hash
     )
 
 
-def _submit_mozart_job_by_rule_minimal(*, product: Optional[dict], rule_name, job_type: str, job_queue: str, job_name) -> str:
+def _submit_mozart_job_by_rule_minimal(*, product: Optional[dict], rule_name, job_type: str, job_queue: str, job_name, payload_hash=None) -> str:
     """Do not call directly. See wrapper with @backoff decorator for usage"""
     return submit_job(
         product=product or {},
@@ -89,7 +92,7 @@ def _submit_mozart_job_by_rule_minimal(*, product: Optional[dict], rule_name, jo
         hysdsio=None,  # setting None forces lookup based on rule and component.
         queue=None,
         job_name=job_name,
-        payload_hash=None,
+        payload_hash=payload_hash,
         enable_dedup=None,
         soft_time_limit=None,
         time_limit=None,


### PR DESCRIPTION
## Purpose
- Eliminated the rare cases of duplicate DISP-S1 SCIFLO job triggering by formulating custom payload_hash in the CSLC download job.
- Fixed CSLC-STATIC query issue that was introduced as a side-effect of another bug fix.
- Vastly optimized CSLC download code and reduced the run-time from 40 mins to 6 mins. Reduced the EC2 instance size to lower per hour cost from up to 20 cents to 2 cents. Reduced unnecessarily large EBS provision.

## Issues
- https://github.com/nasa/opera-sds-pcm/issues/1095
- https://github.com/nasa/opera-sds-pcm/issues/1096
## Testing
- Ran HLS, SLC, RTC forward timer over 12 hrs to process all.
- Been running DISP-S1 historical processing on frames `11115` and `11116` over 24 hrs and will continue to run over the weekend
