### PR TITLE
DISP-S1 PGE v3.0.3 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -381,7 +381,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.2"
+    "disp_s1"  = "3.0.3"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -163,7 +163,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.2"
+    "disp_s1"  = "3.0.3"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -382,7 +382,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.2"
+    "disp_s1"  = "3.0.3"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -34,7 +34,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.2"
+    "disp_s1"  = "3.0.3"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -657,7 +657,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.2"
+    "disp_s1"  = "3.0.3"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -77,13 +77,6 @@ DISP_S1_BLACKOUT_DATES_S3PATH: "s3://opera-ancillaries/disp_frames/disp_s1_black
 # This file contains geo boundaries of all DISP-S1 frames
 DISP_S1_FRAME_GEO_SIMPLE: "s3://opera-ancillaries/disp_frames/disp_s1_frame_geo_simple/frame-geometries-simple.geojson"
 
-DISP_S1_NUM_THREADS: 8
-
-# number of workers = available_cpu_cores * FACTOR + CONSTANT
-DISP_S1_NUM_WORKERS:
-  FACTOR: 0.25
-  CONSTANT: 1
-
 # Shortname filtering on input product types. RegEx strings ('.' == any single character)
 SHORTNAME_FILTERS:
   HLSL30:
@@ -173,6 +166,13 @@ DSWX_S1:
 DISP_S1:
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 50
+  # Number of threads to allocate to the "threads_per_worker" field of the DISP-S1 RunConfig
+  NUM_THREADS: 8
+  # Used to calculate the "n_parallel_bursts" field of the DISP-S1 RunConfig
+  # available_cpu_cores * FACTOR + CONSTANT
+  NUM_WORKERS:
+    FACTOR: 0.25
+    CONSTANT: 1
 
 DSWX_NI:
   # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -173,6 +173,15 @@ DISP_S1:
   NUM_WORKERS:
     FACTOR: 0.25
     CONSTANT: 1
+  # S3 path to the frame-to-burst database JSON file to download for all DISP-S1 jobs
+  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.4/opera-s1-disp-0.9.0-frame-to-burst.json"
+  # S3 path to the reference date database JSON file to download for all DISP-S1 jobs
+  REFERENCE_DATE_DATABASE_JSON: "s3://opera-ancillaries/disp_frames/disp_s1_frame_reference_dates/opera-disp-s1-reference-dates-2025-02-13.json"
+  # S3 path to the algorithm parameters YAML file to download for all DISP-S1 jobs
+  # Note that the {processing_mode} placeholder is required, and will be automatically filled in with "forward" or "historical" based on the type of DISP-S1 job triggered
+  ALGORITHM_PARAMETERS_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.4/algorithm_parameters_{processing_mode}.yaml.tmpl"
+  # S3 path to the algorithm parameters override JSON file to download for all DISP-S1 jobs
+  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.4/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
 
 DSWX_NI:
   # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.2",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.2.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.3.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.2",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.2.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.3.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -26,8 +26,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/disp_s1:3.0.2",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.2.tar.gz",
+          "container_image_name": "opera_pge/disp_s1:3.0.3",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.3.tar.gz",
           "container_mappings": {
             "$HOME/.netrc": ["/root/.netrc"],
             "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -72,14 +72,11 @@ set_daac_product_type:
 get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DISP-S1
   frame_to_burst_json:
-    s3_bucket: "opera-ancillaries"
-    s3_key: "disp_frames/disp-s1/0.5.3/opera-s1-disp-0.7.0-frame-to-burst.json"
+    settings_key: "DISP_S1.FRAME_TO_BURST_JSON"
   reference_date_database_json:
-    s3_bucket: "opera-ancillaries"
-    s3_key: "disp_frames/disp_s1_frame_reference_dates/opera-disp-s1-reference-dates-2025-01-15-minimal.json"
+    settings_key: "DISP_S1.REFERENCE_DATE_DATABASE_JSON"
   algorithm_parameters_overrides_json:
-    s3_bucket: "opera-ancillaries"
-    s3_key: "algorithm_parameters/disp_s1/0.5.3/opera-disp-s1-algorithm-parameters-overrides-2025-01-09.json"
+    settings_key: "DISP_S1.ALGORITHM_PARAMETERS_OVERRIDES_JSON"
     download: true
 
 get_disp_s1_mask_file:
@@ -89,8 +86,7 @@ get_disp_s1_mask_file:
 get_disp_s1_algorithm_parameters:
   # This S3 path only defines a location pattern of an algorithm parameters template file,
   # the processing mode (forward vs. historical) will be filled in by the function itself
-  s3_bucket: "opera-ancillaries"
-  s3_key: "algorithm_parameters/disp_s1/0.5.3/algorithm_parameters_{processing_mode}.yaml.tmpl"
+  settings_key: "DISP_S1.ALGORITHM_PARAMETERS_YAML"
 
 instantiate_algorithm_parameters_template:
   template_mapping:

--- a/opera_chimera/constants/opera_chimera_const.py
+++ b/opera_chimera/constants/opera_chimera_const.py
@@ -136,6 +136,8 @@ class OperaChimeraConstants(ChimeraConstants):
 
     SAFE_FILE_PATH = "safe_file_path"
 
+    SETTINGS_KEY = "settings_key"
+
     SET_DAAC_PRODUCT_TYPE = "set_daac_product_type"
 
     SET_EXTRA_PGE_OUTPUT_METADATA = "set_extra_pge_output_metadata"

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -377,20 +377,20 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         available_cores = os.cpu_count()
 
         try:
-            threads_per_worker = self._settings["DISP_S1_NUM_THREADS"]
-        except:
+            threads_per_worker = self._settings["DISP_S1"]["NUM_THREADS"]
+        except KeyError:
             threads_per_worker = available_cores
-            logger.warning(f"DISP_S1_NUM_THREADS not found in settings.yaml. Using default {threads_per_worker=}")
+            logger.warning(f"DISP_S1.NUM_THREADS not found in settings.yaml. Using default {threads_per_worker=}")
 
         logger.info(f"Allocating {threads_per_worker=} out of {available_cores} available")
 
         try:
-            parallel_factor = self._settings["DISP_S1_NUM_WORKERS"]["FACTOR"]
-            parallel_constant = self._settings["DISP_S1_NUM_WORKERS"]["CONSTANT"]
-        except:
+            parallel_factor = self._settings["DISP_S1"]["NUM_WORKERS"]["FACTOR"]
+            parallel_constant = self._settings["DISP_S1"]["NUM_WORKERS"]["CONSTANT"]
+        except KeyError:
             parallel_factor = 0.25
             parallel_constant = 1
-            logger.warning(f"DISP_S1_NUM_WORKERS not found in settings.yaml. Using defaults {parallel_factor=}, {parallel_constant=}")
+            logger.warning(f"DISP_S1.NUM_WORKERS not found in settings.yaml. Using defaults {parallel_factor=}, {parallel_constant=}")
 
         # This number is the number of python proceses to run when processing in the wrapped stage. We want 1 minimum.
         # These processes are both memory and CPU intensive so we definite want less than the number of cores we have on the system by some factor


### PR DESCRIPTION
## Purpose
- This branch integrates the DISP-S1 PGE v3.0.3 with OPERA-PCM. This version incorporates the SAS "final" delivery v0.5.4.
- Additionally, this branch adds the ability to specify S3 paths to the static ancillary inputs used by DISP-S1 within settings.yaml

![Untitled](https://github.com/user-attachments/assets/f81af00a-b663-4302-871d-3733ca9f08a3)

Note that the parameters related to calculating the number of cores/threads to use for a DISP-S1 job have also been moved under the `DISP_S1` key to keep things organized.

## Issues
- Resolves #1100

## Testing
- Unit tests have been added to test the ability to pull S3 paths from settings.yaml for certain precondition functions
- This branch has been deployed on a dev cluster and tested using the DISP-S1 PGE in both simulation and real mode.
- The PGE integration smoke test for DISP-S1 was also run

To trigger test DISP-S1 jobs, the sample **historical** commands from the [wiki](https://wiki.jpl.nasa.gov/display/operasds/DAAC+Data+Subscriber+Real+Usage+Examples) should be utilized.

To verify that the usage of settings.yaml to pull the static ancillary inputs for DISP-S1 is working as expected, you can inspect the SCIFLO log for a DISP-S1 job:

<img width="1458" alt="Screenshot 2025-03-06 at 12 03 12 PM" src="https://github.com/user-attachments/assets/1b687578-1991-47dd-b9a9-fe327222e046" />

After making changes to and redeploying settings.yaml:

<img width="1441" alt="Screenshot 2025-03-06 at 12 43 50 PM" src="https://github.com/user-attachments/assets/e6184e90-54cf-41e0-ad86-f5249a4e5677" />


