### PR TITLE
DISP-S1 historical processing query and download job final improvements

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -502,7 +502,7 @@ variable "queues" {
     }
     "opera-job_worker-cslc_data_query" = {
       "name"              = "opera-job_worker-cslc_data_query"
-      "instance_type"     = ["t3a.medium", "t3.medium", "t2.medium", "c6i.large", "t3a.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.xlarge", "m6a.xlarge", "c6a.xlarge", "c5a.xlarge", "r7i.xlarge", "c7i.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -514,12 +514,12 @@ variable "queues" {
     }
     "opera-job_worker-cslc_data_query_hist" = {
       "name"              = "opera-job_worker-cslc_data_query_hist"
-      "instance_type"     = ["t3a.medium", "t3.medium", "t2.medium", "c6i.large", "t3a.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.2xlarge", "c6a.2xlarge", "c5a.2xlarge", "c7i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
       "min_size"          = 0
-      "max_size"          = 1
+      "max_size"          = 3
       "total_jobs_metric" = false
       "use_private_vpc"   = false
       "use_on_demand"     = false

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -518,7 +518,7 @@ variable "queues" {
       "root_dev_size"     = 50
       "data_dev_size"     = 25
       "min_size"          = 0
-      "max_size"          = 3
+      "max_size"          = 5
       "total_jobs_metric" = false
       "use_private_vpc"   = false
       "use_on_demand"     = false

--- a/data_subscriber/asf_cslc_download.py
+++ b/data_subscriber/asf_cslc_download.py
@@ -7,6 +7,8 @@ from os.path import basename
 from pathlib import PurePath, Path
 import boto3
 import hashlib
+import backoff
+import elasticsearch
 
 from data_subscriber import ionosphere_download
 from data_subscriber.asf_rtc_download import AsfDaacRtcDownload
@@ -324,6 +326,7 @@ class AsfDaacCslcDownload(AsfDaacRtcDownload):
 
         return all_downloads
 
+    @backoff.on_exception(backoff.expo, exception=elasticsearch.exceptions.ConflictError, max_tries=5, jitter=None)
     def query_cslc_static_files_for_cslc_batch(self, cslc_files, args, token, job_id, settings):
         cslc_query_args = copy.deepcopy(args)
 

--- a/data_subscriber/cslc/cslc_query.py
+++ b/data_subscriber/cslc/cslc_query.py
@@ -384,27 +384,10 @@ since the first CSLC file for the batch was ingested which is greater than the g
             all_granules = self.query_cmr_by_frame_and_dates(frame_id, self.args, self.token, self.cmr, self.settings, now, timerange)
 
             # Get rid of any granules that aren't in the historical database sensing_datetime_days_index
-            CMR_TIME_FORMAT = int(self.args.frame_id)
             all_granules = [granule for granule in all_granules
                             if granule["acquisition_cycle"] in self.disp_burst_map_hist[frame_id].sensing_datetime_days_index]
 
-            # Validate to make sure that all granules needed to process this frame at this processing run are present
-            # 1. Make sure we got all acq cycles
-            # 2. For each acq cycle make sure we got all burst_ids
-            #TODO: This section of code is not yet complete and has not been tested --------->
-            acq_cycles_and_bursts = defaultdict(set())
-            for g in all_granules:
-                acq_cycles_and_bursts[g["acquisition_cycle"]].add(g["burst_id"])
-
-            _, start_search_date = get_nearest_sensing_datetime(self.disp_burst_map_hist[frame_id].sensing_datetimes,
-                                                                datetime.strptime(timerange.start_date, CMR_TIME_FORMAT))
-            _, end_search_date = get_nearest_sensing_datetime(self.disp_burst_map_hist[frame_id].sensing_datetimes,
-                                                                datetime.strptime(timerange.end_date, CMR_TIME_FORMAT))
-            all_acq_cyles_found = set(acq_cycles_and_bursts.keys())
-
-            for acq_cycle, bursts in acq_cycles_and_bursts.items():
-                assert bursts.issuperset(self.disp_burst_map_hist[frame_id].burst_ids) == True, f"Missing at least one burst_id for frame_id={frame_id} acq_cycle={acq_cycle}"
-            # TODO <------------------------------------------
+            self.validate_historical_query_result(frame_id, timerange, all_granules)
 
         # TODO: How do we handle partial frames when querying by date? Make them all whole or only process the full frames?
         # Reprocessing can be done by specifying either a native_id or a date range
@@ -463,6 +446,33 @@ since the first CSLC file for the batch was ingested which is greater than the g
 
         chunk_batch_ids.extend(list(self.k_batch_ids[chunk_batch_ids[0]]))
         return super().create_download_job_params(query_timerange, chunk_batch_ids)
+
+    def validate_historical_query_result(self, frame_id, timerange, all_granules):
+        '''Validate to make sure that all granules needed to process this frame at this processing run are present.
+        Note that sensing times within the acq cycle for the frame can range within a minute and there are 27 of them. So
+        one may think that the timerange.start_date may get caught within that range. This will not be the case because
+        the timerange originates from run_disp_s1_historical_processing.py and it assigns 30 min buffer either direction
+        '''
+
+        # 1. Make sure we got all acq cycles
+        # 2. For each acq cycle make sure we got all burst_ids
+        acq_cycles_and_bursts = defaultdict(set)
+        for g in all_granules:
+            acq_cycles_and_bursts[g["acquisition_cycle"]].add(g["burst_id"])
+
+        start_days_index, _ = get_nearest_sensing_datetime(self.disp_burst_map_hist[frame_id].sensing_datetimes,
+                                                           datetime.strptime(timerange.start_date, CMR_TIME_FORMAT))
+        end_days_index, _ = get_nearest_sensing_datetime(self.disp_burst_map_hist[frame_id].sensing_datetimes,
+                                                         datetime.strptime(timerange.end_date, CMR_TIME_FORMAT))
+        all_acq_cyles_found = set(acq_cycles_and_bursts.keys())
+        all_acq_cyles_needed = set(self.disp_burst_map_hist[frame_id].sensing_datetime_days_index[start_days_index:end_days_index])
+        assert all_acq_cyles_found == all_acq_cyles_needed, (f"Acquisition cycles returned from CMR does not match what's expected \
+        from the consistency databse file for frame_id={frame_id}. This indicates a rare error with CMR, usually transient, so try this job again. \
+        Expected: {all_acq_cyles_needed} Found: {all_acq_cyles_found}")
+
+        for acq_cycle, bursts in acq_cycles_and_bursts.items():
+            assert bursts.issuperset(self.disp_burst_map_hist[
+                                         frame_id].burst_ids) == True, f"Missing at least one burst_id for frame_id={frame_id} acq_cycle={acq_cycle}"
 
     def eliminate_duplicate_granules(self, granules):
         """For CSLC granules revision_id is always one. Instead, we correlate the granules by the unique_id

--- a/data_subscriber/cslc/cslc_query.py
+++ b/data_subscriber/cslc/cslc_query.py
@@ -387,6 +387,7 @@ since the first CSLC file for the batch was ingested which is greater than the g
             all_granules = [granule for granule in all_granules
                             if granule["acquisition_cycle"] in self.disp_burst_map_hist[frame_id].sensing_datetime_days_index]
 
+            # Validate that we got all the granules we needed for hist: all acq cycles and all bursts within each cycle
             self.validate_historical_query_result(frame_id, timerange, all_granules)
 
         # TODO: How do we handle partial frames when querying by date? Make them all whole or only process the full frames?
@@ -472,7 +473,9 @@ since the first CSLC file for the batch was ingested which is greater than the g
 
         for acq_cycle, bursts in acq_cycles_and_bursts.items():
             assert bursts.issuperset(self.disp_burst_map_hist[
-                                         frame_id].burst_ids) == True, f"Missing at least one burst_id for frame_id={frame_id} acq_cycle={acq_cycle}"
+                                         frame_id].burst_ids) == True, (f"Missing at least one burst_id for frame_id={frame_id} acq_cycle={acq_cycle}. \
+This indicates a rare error with CMR, usually transient, so try this job again. \
+Missing burst(s): {self.disp_burst_map_hist[frame_id].burst_ids - bursts}")
 
     def eliminate_duplicate_granules(self, granules):
         """For CSLC granules revision_id is always one. Instead, we correlate the granules by the unique_id

--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -4,6 +4,7 @@ from collections import defaultdict
 from datetime import datetime
 from functools import cache
 from urllib.parse import urlparse
+import backoff
 
 import boto3
 import dateutil
@@ -19,7 +20,6 @@ PENDING_CSLC_DOWNLOADS_ES_INDEX_NAME = "grq_1_l2_cslc_s1_pending_downloads"
 PENDING_TYPE_CSLC_DOWNLOAD = "cslc_download"
 _C_CSLC_ES_INDEX_PATTERNS = "grq_1_l2_cslc_s1_compressed*"
 
-
 class _HistBursts(object):
     def __init__(self):
         self.frame_number = None
@@ -28,6 +28,7 @@ class _HistBursts(object):
         self.sensing_seconds_since_first = []  # Sensing time in seconds since the first sensing time
         self.sensing_datetime_days_index = []  # Sensing time in days since the first sensing time, rounded to the nearest day
 
+@backoff.on_exception(backoff.expo, Exception, max_time=30)
 def get_s3_resource_from_settings(settings_field):
     settings = SettingsConf().cfg
     burst_file_url = urlparse(settings[settings_field])

--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -37,6 +37,8 @@ def get_s3_resource_from_settings(settings_field):
 
     return s3, path, file, burst_file_url
 
+logger = get_logger()
+
 @backoff.on_exception(backoff.expo, Exception, max_time=30)
 def localize_anc_json(settings_field):
     '''Copy down a file from S3 whose path is defined in settings.yaml by settings_field'''
@@ -48,7 +50,6 @@ def localize_anc_json(settings_field):
 
 @cache
 def localize_disp_frame_burst_hist():
-    logger = get_logger()
 
     try:
         file = localize_anc_json("DISP_S1_BURST_DB_S3PATH")
@@ -61,7 +62,6 @@ def localize_disp_frame_burst_hist():
 
 @cache
 def localize_frame_geo_json():
-    logger = get_logger()
 
     try:
         file = localize_anc_json("DISP_S1_FRAME_GEO_SIMPLE")
@@ -100,6 +100,9 @@ def get_nearest_sensing_datetime(frame_sensing_datetimes, sensing_time):
     the number of sensing datetimes until that datetime.
     It's a linear search in a sorted list but no big deal because there will only ever be a few hundred elements'''
 
+    if len(frame_sensing_datetimes) == 0:
+        return 0, None
+
     for i, dt in enumerate(frame_sensing_datetimes):
         if dt > sensing_time:
             return i, frame_sensing_datetimes[i-1]
@@ -115,6 +118,7 @@ def calculate_historical_progress(frame_states: dict, end_date, frame_to_bursts,
     last_processed_datetimes = {}
 
     for frame, state in frame_states.items():
+        logger.debug(f"Calculating percentage progress for {frame=}")
         frame = int(frame)
         num_sensing_times, _ = get_nearest_sensing_datetime(frame_to_bursts[frame].sensing_datetimes, end_date)
 
@@ -132,7 +136,6 @@ def calculate_historical_progress(frame_states: dict, end_date, frame_to_bursts,
 @cache
 def process_disp_frame_burst_hist(file):
     '''Process the disp frame burst map json file intended and return 3 dictionaries'''
-    logger = get_logger()
 
     try:
         j = json.load(open(file))["data"]

--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -28,7 +28,6 @@ class _HistBursts(object):
         self.sensing_seconds_since_first = []  # Sensing time in seconds since the first sensing time
         self.sensing_datetime_days_index = []  # Sensing time in days since the first sensing time, rounded to the nearest day
 
-@backoff.on_exception(backoff.expo, Exception, max_time=30)
 def get_s3_resource_from_settings(settings_field):
     settings = SettingsConf().cfg
     burst_file_url = urlparse(settings[settings_field])
@@ -37,6 +36,8 @@ def get_s3_resource_from_settings(settings_field):
     file = path.split("/")[-1]
 
     return s3, path, file, burst_file_url
+
+@backoff.on_exception(backoff.expo, Exception, max_time=30)
 def localize_anc_json(settings_field):
     '''Copy down a file from S3 whose path is defined in settings.yaml by settings_field'''
 

--- a/tests/data_subscriber/test_cslc_util.py
+++ b/tests/data_subscriber/test_cslc_util.py
@@ -35,6 +35,8 @@ def test_burst_map():
     assert len(disp_burst_map_hist[46799].burst_ids) == 16
     assert len(disp_burst_map_hist[46799].sensing_datetimes) == 0
 
+    assert len(disp_burst_map_hist[8885].sensing_datetimes) == 240
+
     assert len(disp_burst_map_hist[28498].burst_ids) == 18
 
 def test_split_download_batch_id():
@@ -281,7 +283,7 @@ def test_calculate_historical_progress():
 
     progress, frame_completion, last_processed_datetimes \
         = cslc_utils.calculate_historical_progress(frame_states, end_date, disp_burst_map_hist, k)
-    assert progress == 69
+    assert progress == 83
     assert frame_completion == {'46288': 71, '46289': 71, '26690': 100, '26691': 100, '38500': 0}
     assert last_processed_datetimes == {'46288': datetime(2018, 1, 29, 13, 43, 14),
                                         '46289': datetime(2018, 1, 29, 13, 43, 36),

--- a/tests/data_subscriber/test_cslc_util.py
+++ b/tests/data_subscriber/test_cslc_util.py
@@ -279,12 +279,12 @@ def test_nearest_sensing_datetime():
 def test_calculate_historical_progress():
     k = 15
     end_date = dateutil.parser.isoparse("2018-07-01T00:00:00")
-    frame_states = {'46288': 30, '46289': 30, '26690': 45, '26691': 45, '38500': 0}
+    frame_states = {'46288': 30, '46289': 30, '26690': 45, '26691': 45, '38500': 0, '18899': 15}
 
     progress, frame_completion, last_processed_datetimes \
         = cslc_utils.calculate_historical_progress(frame_states, end_date, disp_burst_map_hist, k)
     assert progress == 83
-    assert frame_completion == {'46288': 71, '46289': 71, '26690': 100, '26691': 100, '38500': 0}
+    assert frame_completion == {'46288': 100, '46289': 100, '26690': 100, '26691': 100, '38500': 0, '18899': 15}
     assert last_processed_datetimes == {'46288': datetime(2018, 1, 29, 13, 43, 14),
                                         '46289': datetime(2018, 1, 29, 13, 43, 36),
                                         '26690': datetime(2018, 6, 17, 13, 35, 45),

--- a/tools/disp_s1_burst_db_tool.py
+++ b/tools/disp_s1_burst_db_tool.py
@@ -227,7 +227,7 @@ elif args.subparser_name == "frame":
     if args.k:
         k = int(args.k)
         for i in range(0, len_sensing_times, k):
-            end = i+k if i+k < len_sensing_times else len_sensing_times - 1
+            end = i+k if i+k < len_sensing_times else len_sensing_times
             print(f"K-cycle {math.ceil(i/k)}", [t.isoformat() for t in disp_burst_map[frame_number].sensing_datetimes[i:end]])
     else:
         print([t.isoformat() for t in disp_burst_map[frame_number].sensing_datetimes])
@@ -236,7 +236,7 @@ elif args.subparser_name == "frame":
     if args.k:
         k = int(args.k)
         for i in range(0, len_sensing_times, k):
-            end = i+k if i+k < len_sensing_times else len_sensing_times - 1
+            end = i+k if i+k < len_sensing_times else len_sensing_times
             print(f"K-cycle {math.ceil(i/k)}", disp_burst_map[frame_number].sensing_datetime_days_index[i:end])
     else:
         print(disp_burst_map[frame_number].sensing_datetime_days_index)


### PR DESCRIPTION
## Purpose
- Clear, easy-to-understand sentences outlining the purpose of the PR
## Proposed Changes
- Fixes for #1080
- Fixes for #1102
- Increased the machine sizes for CSLC query and download jobs because often the Sentinel1 process would take up an entire CPU core and not leave much for the actual functionality
- Tuned ASG for query and download jobs to make sure that query and download jobs aren't the bottleneck in processing when processing Priority 4 frames.

## Issues
- https://github.com/nasa/opera-sds-pcm/issues/1080
- https://github.com/nasa/opera-sds-pcm/issues/1102

## Testing
- Ran through the entire DISP-S1 Priority 1 Frames running query and download job and verified that all were successful.
- Ran the first set of processing for Priority 4 Frames which is the largest with ~800 frames. 
- Noticed that dev-sized GRQ ES couldn't keep up with the query load. Verified that production-sized GRQ is able to handle with 4x margin to spare.
- Wrote custom tool and performed validation for all Priority 1 Frames: https://github.com/nasa/opera-sds-pcm/blob/1106_disp_s1_hist_job_submission_validation/tools/testing/validate_cslc_downloads.py
