### PR TITLE
DISP-S1 PGE v3.0.4 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -381,7 +381,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.3"
+    "disp_s1"  = "3.0.4"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -163,7 +163,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.3"
+    "disp_s1"  = "3.0.4"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -382,7 +382,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.3"
+    "disp_s1"  = "3.0.4"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -34,7 +34,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.3"
+    "disp_s1"  = "3.0.4"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -658,7 +658,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.3"
+    "disp_s1"  = "3.0.4"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -174,14 +174,14 @@ DISP_S1:
     FACTOR: 0.25
     CONSTANT: 1
   # S3 path to the frame-to-burst database JSON file to download for all DISP-S1 jobs
-  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.4/opera-s1-disp-0.9.0-frame-to-burst.json"
+  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.5/opera-s1-disp-0.9.0-frame-to-burst.json"
   # S3 path to the reference date database JSON file to download for all DISP-S1 jobs
   REFERENCE_DATE_DATABASE_JSON: "s3://opera-ancillaries/disp_frames/disp_s1_frame_reference_dates/opera-disp-s1-reference-dates-2025-02-13.json"
   # S3 path to the algorithm parameters YAML file to download for all DISP-S1 jobs
   # Note that the {processing_mode} placeholder is required, and will be automatically filled in with "forward" or "historical" based on the type of DISP-S1 job triggered
-  ALGORITHM_PARAMETERS_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.4/algorithm_parameters_{processing_mode}.yaml.tmpl"
+  ALGORITHM_PARAMETERS_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.5/algorithm_parameters_{processing_mode}.yaml.tmpl"
   # S3 path to the algorithm parameters override JSON file to download for all DISP-S1 jobs
-  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.4/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
+  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.5/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
 
 DSWX_NI:
   # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.3",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.3.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.4",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.4.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.3",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.3.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.4",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.4.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -26,8 +26,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/disp_s1:3.0.3",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.3.tar.gz",
+          "container_image_name": "opera_pge/disp_s1:3.0.4",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.4.tar.gz",
           "container_mappings": {
             "$HOME/.netrc": ["/root/.netrc"],
             "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
## Purpose
- This branch integrates the DISP-S1 PGE v3.0.4 with OPERA-PCM. This version incorporates the SAS "final" delivery v0.5.5.

## Issues
- Resolves #1110 

## Testing
- Unit tests have been added to test the ability to pull S3 paths from settings.yaml for certain precondition functions
- This branch has been deployed on a dev cluster and tested using the DISP-S1 PGE in both simulation and real mode.
- The PGE integration smoke test for DISP-S1 was also run

To trigger test DISP-S1 jobs, the sample historical commands from the [wiki](https://wiki.jpl.nasa.gov/display/operasds/DAAC+Data+Subscriber+Real+Usage+Examples) should be utilized.