### PR TITLE
DISP-S1 v3.0.5 Integraion

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -381,7 +381,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.4"
+    "disp_s1"  = "3.0.5"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -163,7 +163,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.4"
+    "disp_s1"  = "3.0.5"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -382,7 +382,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.4"
+    "disp_s1"  = "3.0.5"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -34,7 +34,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.4"
+    "disp_s1"  = "3.0.5"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -658,7 +658,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.4"
+    "disp_s1"  = "3.0.5"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
   }

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -174,14 +174,14 @@ DISP_S1:
     FACTOR: 0.25
     CONSTANT: 1
   # S3 path to the frame-to-burst database JSON file to download for all DISP-S1 jobs
-  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.5/opera-s1-disp-0.9.0-frame-to-burst.json"
+  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.7/opera-s1-disp-0.9.0-frame-to-burst.json"
   # S3 path to the reference date database JSON file to download for all DISP-S1 jobs
   REFERENCE_DATE_DATABASE_JSON: "s3://opera-ancillaries/disp_frames/disp_s1_frame_reference_dates/opera-disp-s1-reference-dates-2025-02-13.json"
   # S3 path to the algorithm parameters YAML file to download for all DISP-S1 jobs
   # Note that the {processing_mode} placeholder is required, and will be automatically filled in with "forward" or "historical" based on the type of DISP-S1 job triggered
-  ALGORITHM_PARAMETERS_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.5/algorithm_parameters_{processing_mode}.yaml.tmpl"
+  ALGORITHM_PARAMETERS_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.7/algorithm_parameters_{processing_mode}.yaml.tmpl"
   # S3 path to the algorithm parameters override JSON file to download for all DISP-S1 jobs
-  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.5/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
+  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.7/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
 
 DSWX_NI:
   # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ COPY . /home/ops/verdi/ops/opera-pcm
 RUN set -ex \
  && source /home/ops/.bash_profile \
  # TODO: remove pin of conda and gdal once updated gdal (3.7.*) has been pushed to the main channel
- && sudo /opt/conda/bin/conda install -y -c conda-forge conda==22.11.1 gdal==3.6.2 cffi poppler==22.12.0 \
+ && sudo /opt/conda/bin/conda install -y -c conda-forge conda gdal==3.6.4 cffi poppler eccodes==2.31.0 \
  && ln -sf /opt/eccodes/bin/grib_to_netcdf /home/ops/verdi/bin/ \
  # TODO: remove the following kludge once this issue has been resolved:
  # https://stackoverflow.com/questions/71904252/gdalinfo-error-while-loading-shared-libraries-libtiledb-so-2-2-cannot-open-sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,11 @@ USER ops
 COPY . /home/ops/verdi/ops/opera-pcm
 RUN set -ex \
  && source /home/ops/.bash_profile \
- # TODO: remove pin of conda and gdal once updated gdal (3.7.*) has been pushed to the main channel
- && sudo /opt/conda/bin/conda install -y -c conda-forge conda gdal==3.6.4 cffi poppler eccodes==2.31.0 \
+ && sudo /opt/conda/bin/conda install -y -c conda-forge conda==22.11.1 gdal==3.6.2 cffi poppler==22.12.0 \
+ # install eccodes from RPM for ECMWF merger
+ && curl -o /tmp/eccodes-2.28.1-1.x86_64.rpm https://artifactory.jpl.nasa.gov:443/artifactory/general-develop/gov/nasa/jpl/nisar/sds/pcm/eccodes/eccodes-2.28.1-1.x86_64.rpm \
+ && sudo dnf install -y /tmp/eccodes-2.28.1-1.x86_64.rpm \
+ && rm -rf /tmp/eccodes-2.28.1-1.x86_64.rpm \
  && ln -sf /opt/eccodes/bin/grib_to_netcdf /home/ops/verdi/bin/ \
  # TODO: remove the following kludge once this issue has been resolved:
  # https://stackoverflow.com/questions/71904252/gdalinfo-error-while-loading-shared-libraries-libtiledb-so-2-2-cannot-open-sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ COPY . /home/ops/verdi/ops/opera-pcm
 RUN set -ex \
  && source /home/ops/.bash_profile \
  # TODO: remove pin of conda and gdal once updated gdal (3.7.*) has been pushed to the main channel
- && sudo /opt/conda/bin/conda install -y -c conda-forge conda gdal==3.6.4 cffi poppler eccodes==2.31.0 \
+ && sudo /opt/conda/bin/conda install -y -c conda-forge conda==22.11.1 gdal==3.6.2 cffi poppler==22.12.0 \
  && ln -sf /opt/eccodes/bin/grib_to_netcdf /home/ops/verdi/bin/ \
  # TODO: remove the following kludge once this issue has been resolved:
  # https://stackoverflow.com/questions/71904252/gdalinfo-error-while-loading-shared-libraries-libtiledb-so-2-2-cannot-open-sh

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.4",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.4.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.5",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.4",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.4.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.5",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -26,8 +26,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/disp_s1:3.0.4",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.4.tar.gz",
+          "container_image_name": "opera_pge/disp_s1:3.0.5",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
           "container_mappings": {
             "$HOME/.netrc": ["/root/.netrc"],
             "$HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
## Purpose
- This PR integrates the DISP-S1 PGE v3.0.5 release with the v0.5.7 version of the DISP-S1 SAS

## Issues
- Closes #1122 

## Testing
- Deployed test cluster
  - Ran smoke test
  - Ran PGE in simulation mode
  - Ran PGE in real mode with 2 consecutive CSLC queries (an earlier attempt did fail due to user error)
