### PR TITLE
Jinja2 Templates for Algorithm Parameters Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,7 @@ cython_debug/
 
 # AWS User-specific
 .idea/**/aws.xml
+.idea/**/terraform.xml
 
 # Generated files
 .idea/**/contentModel.xml

--- a/conf/AlgoParams.yaml.L3_DISP_S1.jinja2.tmpl
+++ b/conf/AlgoParams.yaml.L3_DISP_S1.jinja2.tmpl
@@ -1,0 +1,341 @@
+# JSON file containing frame-specific algorithm parameters to override the defaults passed
+#   in the `algorithm_parameters.yaml`.
+#   Type: string | null.
+algorithm_parameters_overrides_json: {{ runconfig.processing.algorithm_parameters_overrides_json }}
+ps_options:
+  # Amplitude dispersion threshold to consider a pixel a PS.
+  #   Type: number.
+  amp_dispersion_threshold: 0.2
+phase_linking:
+  # Size of the ministack for sequential estimator.
+  #   Type: integer.
+  ministack_size: 100
+  # Maximum number of compressed images to use in sequential estimator. If there are more
+  #   ministacks than this, the earliest CCSLCs will be left out of the later stacks. .
+  #   Type: integer.
+  max_num_compressed: 100
+  # Index of input SLC to use for making phase linked interferograms after EVD/EMI.
+  #   Type: integer.
+  output_reference_idx: 0
+  half_window:
+    # Half window size (in pixels) for x direction.
+    #   Type: integer.
+    x: 11
+    # Half window size (in pixels) for y direction.
+    #   Type: integer.
+    y: 5
+  # Use EVD on the coherence instead of using the EMI algorithm.
+  #   Type: boolean.
+  use_evd: false
+  # Beta regularization parameter for correlation matrix inversion. 0 is no regularization.
+  #   Type: number.
+  beta: 0.0
+  # Snap correlation values in the coherence matrix below this value to 0.
+  #   Type: number.
+  zero_correlation_threshold: 0.0
+  # Method for finding SHPs during phase linking.
+  #   Type: string.
+  #   Options: ['glrt', 'ks', 'rect', 'rect'].
+  shp_method: glrt
+  # Significance level (probability of false alarm) for SHP tests. Lower numbers include more
+  #   pixels within the multilook window during covariance estimation.
+  #   Type: number.
+  shp_alpha: 0.001
+  # If True, pixels labeled as PS will get set to NaN during phase linking to avoid summing
+  #   their phase. Default of False means that the SHP algorithm will decide if a pixel should
+  #   be included, regardless of its PS label.
+  #   Type: boolean.
+  mask_input_ps: false
+  # StBAS parameter to include only nearest-N interferograms forphase linking. A
+  #   `baseline_lag` of `n` will only include the closest`n` interferograms. `baseline_line`
+  #   must be positive.
+  #   Type: integer | null.
+  baseline_lag:
+  # Plan for creating Compressed SLCs during phase linking.
+  #   Type: string.
+  #   Options: ['always_first', 'first_per_ministack', 'last_per_ministack'].
+  compressed_slc_plan: last_per_ministack
+interferogram_network:
+  # For single-reference network: Index of the reference image in the network.
+  #   Type: integer | null.
+  reference_idx:
+  # Max `n` to form the nearest-`n` interferograms by index.
+  #   Type: integer | null.
+  max_bandwidth: 3
+  # Maximum temporal baseline of interferograms.
+  #   Type: integer | null.
+  max_temporal_baseline:
+  # For manual-index network: list of (ref_idx, sec_idx) defining the interferograms to form.
+  #   Type: array | null.
+  indexes:
+unwrap_options:
+  # Whether to run the unwrapping step after wrapped phase estimation.
+  #   Type: boolean.
+  run_unwrap: true
+  # Whether to run Goldstein filtering step on wrapped interferogram.
+  #   Type: boolean.
+  run_goldstein: false
+  # Whether to run interpolation step on wrapped interferogram.
+  #   Type: boolean.
+  run_interpolation: true
+  # Phase unwrapping method.
+  #   Type: string.
+  #   Options: ['snaphu', 'icu', 'phass', 'spurt', 'whirlwind'].
+  unwrap_method: snaphu
+  # Number of interferograms to unwrap in parallel.
+  #   Type: integer.
+  n_parallel_jobs: 4
+  # Set wrapped phase/correlation to 0 where mask is 0 before unwrapping. .
+  #   Type: boolean.
+  zero_where_masked: false
+  preprocess_options:
+    # Adaptive phase (Goldstein) filter exponent parameter.
+    #   Type: number.
+    alpha: 0.5
+    # (for interpolation) Maximum radius to find scatterers.
+    #   Type: integer.
+    max_radius: 71
+    # Threshold on the correlation raster to use for interpolation. Pixels with less than this
+    #   value are replaced by a weighted combination of neighboring pixels.
+    #   Type: number.
+    interpolation_cor_threshold: 0.3
+    # Threshold on the correlation raster to use for interpolation. Pixels with less than this
+    #   value are replaced by a weighted combination of neighboring pixels.
+    #   Type: number.
+    interpolation_similarity_threshold: 0.4
+  snaphu_options:
+    # Number of tiles to split the inputs into using SNAPHU's internal tiling.
+    #   Type: array.
+    ntiles:
+      - 5
+      - 5
+    # Amount of tile overlap (in pixels) along the (row, col) directions.
+    #   Type: array.
+    tile_overlap:
+      - 400
+      - 400
+    # Number of tiles to unwrap in parallel for each interferogram.
+    #   Type: integer.
+    n_parallel_tiles: 7
+    # Initialization method for SNAPHU.
+    #   Type: string.
+    #   Options: ['mcf', 'mst'].
+    init_method: mcf
+    # Statistical cost mode method for SNAPHU.
+    #   Type: string.
+    #   Options: ['defo', 'smooth'].
+    cost: smooth
+    # If True, after unwrapping with multiple tiles, an additional post-processing unwrapping
+    #   step is performed to re-optimize the unwrapped phase using a single tile.
+    #   Type: boolean.
+    single_tile_reoptimize: true
+  tophu_options:
+    # Number of tiles to split the inputs into.
+    #   Type: array.
+    ntiles:
+      - 1
+      - 1
+    # Extra multilook factor to use for the coarse unwrap.
+    #   Type: array.
+    downsample_factor:
+      - 1
+      - 1
+    # Initialization method for SNAPHU.
+    #   Type: string.
+    #   Options: ['mcf', 'mst'].
+    init_method: mcf
+    # Statistical cost mode method for SNAPHU.
+    #   Type: string.
+    #   Options: ['defo', 'smooth'].
+    cost: smooth
+  spurt_options:
+    # Temporal coherence to pick pixels used on an irregular grid.
+    #   Type: number.
+    temporal_coherence_threshold: 0.6
+    # Similarity to pick pixels used on an irregular grid. Any pixel with similarity above
+    #   `similarity_threshold` *or* above the temporal coherence threshold is chosen.
+    #   Type: number.
+    similarity_threshold: 0.5
+    # After running spurt, interpolate the values that were masked during unwrapping (which are
+    #   otherwise left as nan).
+    #   Type: boolean.
+    run_ambiguity_interpolation: true
+    general_settings:
+      # Tile up data spatially.
+      #   Type: boolean.
+      use_tiles: true
+    tiler_settings:
+      # Maximum number of tiles allowed.
+      #   Type: integer.
+      max_tiles: 64
+      # Number of points used for determining tiles based on density.
+      #   Type: integer.
+      target_points_for_generation: 120000
+      # Target points per tile when generating tiles.
+      #   Type: integer.
+      target_points_per_tile: 700000
+      # Dilation factor of non-overlapping tiles. 0.05 would lead to 5 percent dilation of the
+      #   tile.
+      #   Type: number.
+      dilation_factor: 0.04
+    solver_settings:
+      # Number of workers for temporal unwrapping in parallel. Set value to <=0 to let workflow
+      #   use default workers (ncpus - 1).
+      #   Type: integer.
+      t_worker_count: 16
+      # Number of workers for spatial unwrapping in parallel. Set value to <=0 to let workflow use
+      #   (ncpus - 1).
+      #   Type: integer.
+      s_worker_count: 5
+      # Temporal unwrapping operations over spatial links are performed in batches and each batch
+      #   is solved in parallel.
+      #   Type: integer.
+      links_per_batch: 150000
+      # Temporal unwrapping costs.
+      #   Type: string.
+      #   Options: ['constant', 'distance', 'centroid'].
+      t_cost_type: distance
+      # Scale factor used to compute edge costs for temporal unwrapping.
+      #   Type: number.
+      t_cost_scale: 100.0
+      # Spatial unwrapping costs.
+      #   Type: string.
+      #   Options: ['constant', 'distance', 'centroid'].
+      s_cost_type: constant
+      # Scale factor used to compute edge costs for spatial unwrapping.
+      #   Type: number.
+      s_cost_scale: 100.0
+      # Number of tiles to process in parallel. Set to 0 for all tiles.
+      #   Type: integer.
+      num_parallel_tiles: 1
+    merger_settings:
+      # Minimum number of overlap pixels to be considered valid.
+      #   Type: integer.
+      min_overlap_points: 25
+      # Currently, only 'dirichlet' is supported.
+      #   Type: dirichlet.
+      method: dirichlet
+      # Method used to estimate bulk offset between tiles.
+      #   Type: string.
+      #   Options: ['integer', 'L2'].
+      bulk_method: L2
+      # Number of interferograms to merge in one batch. Use zero to merge all interferograms in a
+      #   single batch.
+      #   Type: integer.
+      num_parallel_ifgs: 42
+timeseries_options:
+  # Whether to run the inversion step after unwrapping, if more than  a single-reference
+  #   network is used.
+  #   Type: boolean.
+  run_inversion: true
+  # Norm to use during timeseries inversion.
+  #   Type: string.
+  #   Options: ['L1', 'L2'].
+  method: L1
+  # Reference point (row, col) used if performing a time series inversion. If not provided, a
+  #   point will be selected from a consistent connected component with low amplitude
+  #   dispersion.
+  #   Type: array | null.
+  reference_point:
+  # Run the velocity estimation from the phase time series.
+  #   Type: boolean.
+  run_velocity: false
+  # Pixels with correlation below this value will be masked out.
+  #   Type: number.
+  correlation_threshold: 0.0
+  # Size (rows, columns) of blocks of data to load at a time. 3D dimsion is number of
+  #   interferograms (during inversion) and number of SLC dates (during velocity fitting).
+  #   Type: array.
+  block_shape:
+    - 256
+    - 256
+  # Number of parallel blocks to process at once.
+  #   Type: integer.
+  num_parallel_blocks: 4
+output_options:
+  # Output (x, y) resolution (in units of input data).
+  #   Type: object | null.
+  output_resolution:
+  # Alternative to specifying output resolution: Specify the (x, y) strides (decimation
+  #   factor) to perform while processing input. For example, strides of [4, 2] would turn an
+  #   input resolution of [5, 10] into an output resolution of [20, 20].
+  #   Type: object.
+  strides:
+    x: 6
+    y: 3
+  # Area of interest: [left, bottom, right, top] coordinates. e.g.
+  #   `bbox=[-150.2,65.0,-150.1,65.5]`.
+  #   Type: array | null.
+  bounds:
+  # Area of interest as a simple Polygon in well-known-text (WKT) format. Can pass a string,
+  #   or a `.wkt` filename containing the Polygon text.
+  #   Type: string | null.
+  bounds_wkt:
+  # EPSG code for the `bounds` or `bounds_wkt` coordinates, if specified.
+  #   Type: integer.
+  bounds_epsg: 4326
+  # Options for `create_dataset` with h5py.
+  #   Type: object.
+  hdf5_creation_options:
+    chunks:
+      - 128
+      - 128
+    compression: gzip
+    compression_opts: 4
+    shuffle: true
+  # GDAL creation options for GeoTIFF files.
+  #   Type: array.
+  gtiff_creation_options:
+    - COMPRESS=lzw
+    - ZLEVEL=4
+    - BIGTIFF=yes
+    - TILED=yes
+    - INTERLEAVE=band
+    - BLOCKXSIZE=128
+    - BLOCKYSIZE=128
+  # Whether to add overviews to the output GeoTIFF files. This will increase file size, but
+  #   can be useful for visualizing the data with web mapping tools. See
+  #   https://gdal.org/programs/gdaladdo.html for more.
+  #   Type: boolean.
+  add_overviews: true
+  # List of overview levels to create (if `add_overviews=True`).
+  #   Type: array.
+  overview_levels:
+    - 4
+    - 8
+    - 16
+    - 32
+    - 64
+  # Specify an extra reference datetime in UTC. Adding this lets you to create and unwrap two
+  #   single reference networks; the later resets at the given date (e.g. for a large
+  #   earthquake event). If passing strings, formats accepted are YYYY-MM-
+  #   DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM], or YYYY-MM-DD.
+  #   Type: string | null.
+  extra_reference_date:
+# Name of the subdataset to use in the input NetCDF files.
+#   Type: string.
+subdataset: /data/{{ runconfig.processing.polarization }}
+# When creating `recommended_mask`, pixels with temporal coherence below this threshold and
+#   with similarity below `recommended_similarity_threshold` are masked.
+#   Type: number.
+recommended_temporal_coherence_threshold: 0.6
+# When creating `recommended_mask`, pixels with similarity below this threshold and with
+#   temporal coherence below `recommended_temporal_coherence_threshold` are masked.
+#   Type: number.
+recommended_similarity_threshold: 0.30
+# When creating `recommended_mask`, use the `connected_component_label`
+#   layer to hide pixels whose label == 0.
+#   Type: boolean.
+recommended_use_conncomp: false
+# Spatial wavelength cutoff (in meters) for the spatial filter. Used to create the short
+#   wavelength displacement layer.
+#   Type: number.
+spatial_wavelength_cutoff: 30000.0
+# `vmin, vmax` matplotlib arguments (in meters) passed to browse image creator.
+#   Type: array.
+browse_image_vmin_vmax:
+  - -0.05
+  - 0.05
+# Number of output products to create in parallel.
+#   Type: integer.
+num_parallel_products: 3

--- a/conf/AlgoParams.yaml.L3_DSWx_S1.jinja2.tmpl
+++ b/conf/AlgoParams.yaml.L3_DSWx_S1.jinja2.tmpl
@@ -1,0 +1,231 @@
+runconfig:
+    name: dswx_s1_workflow_algorithm
+
+    processing:
+        # dswx_workflow 'opera_dswx_s1', 'twele', 'opera_dswx_s1_inundated_vegetation'
+        dswx_workflow: 'opera_dswx_s1'
+        # Polarizations to be used for DSWx-SAR
+        # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
+        # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have.
+        # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data.
+        # ['auto'] will detect available polarizations from given RTC data
+        polarizations: ['auto']
+        # Additional for polarimetric computations to be performed in specific polarization modes (co/cross and co + cross)
+        # e.g. ['ratio', 'span']
+        polarimetric_option:
+
+        # Specifiy the max_value for permanent water and no_data_value for invalid pixels
+        reference_water:
+            max_value: 100
+            no_data_value: 255
+            # value assuming the permanent water [0-1]
+            permanent_water_value: 0.9
+            # number of pixel to apply erosion for drought case
+            drought_erosion_pixel: 10
+            # number of pixel to apply dilation for flood case
+            flood_dilation_pixel: 16
+
+        hand:
+            mask_value: 200
+
+        ocean_mask:
+            # Flag to apply ocean mask
+            mask_enabled: False
+            # Margin to apply ocean mask in km
+            mask_margin_km: 5
+            # Flag if the polygon is water
+            mask_polygon_water: True
+
+        mosaic:
+            mosaic_prefix: 'mosaic'
+            mosaic_cog_enable: True
+            # Burst Mosaic options
+            #   - average : overlapped areas are averaged.
+            #   - first : choose one burst without average.
+            mosaic_mode: 'first'
+
+        # Flag to turn on/off the filtering for RTC image.
+        # The enhanced Lee filter is available.
+        filter:
+            enabled: True
+            method: bregman
+            block_pad: 300
+            lee_filter:
+                window_size: 3
+            guided_filter:
+                radius: 1
+                eps: 3
+                ddepth: -1
+            bregman:
+                lambda_value: 20
+            anisotropic_diffusion:
+                weight: 1
+            # Window size for filtering.
+            line_per_block: 1000
+
+        initial_threshold:
+            # Maximum tile size for initial threshold.
+            maximum_tile_size:
+                x: 400
+                y: 400
+            # Minimum tile size for initial threshold.
+            minimum_tile_size:
+                x: 40
+                y: 40
+            # tile selecting strategy to identify the boundary between water and nonwater
+            # ['twele', 'chini', 'bimodality', 'combined']
+            # 'combined' option applies all selection strategy
+            selection_method: ['chini', 'bimodality']
+
+            # Thresholds to select tiles showing the boundary between water and nonwater
+            # using bimodality strategy.
+            # One values are required for twele method
+            tile_selection_twele: [0.09, 0.8, 0.97]
+            # Thresholds to select tiles showing the boundary between water and nonwater
+            # using bimodality strategy.
+            # One values are required for bimodality method
+            tile_selection_bimodality: 0.7
+            # Stratey to interpolate the tile-based thresholds.
+            # Currently, only 'smoothed' is available.
+            extending_method: 'gdal_grid'
+            # Thresholding algorithm for initial thresholds.
+            # Currently, 1) Otsu and 2) Kittler-Illingworth algorithms are available.
+            # ['otsu', 'ki']
+            threshold_method: 'ki'
+            # Thresholding boundary values in dB. The boundary values are computed internally
+            # using the statics of the rtc image. If the values are out of the given range,
+            # adopt these values instead of the computed values
+            threshold_bounds:
+                co_pol: [-28, -11]
+                cross_pol: [-28, -18]
+            # Flag to assume the trimodal distribution.
+            # If flag is false, the distribution is assumed to have bimodal distribution and
+            # estimate single threshold per tile. If True, the trimodal distribution is assumed,
+            # the lowest threshold is estimated.
+            multi_threshold: True
+            # Flag to adjust threshold where two gaussian distribution is not overlapped.
+            # If 'adjust_if_nonoverlap' is enabled,
+            # start to search the alternative threshold when two distributions are not
+            # overlapped. The 'low_dist_percentile' is the percentile of
+            # the low distribution and 'high_dist_percentile' is the percentile of
+            # the high distribution. Both values should be within range of 0 to 1.
+            adjust_if_nonoverlap: True
+            low_dist_percentile: 0.99
+            high_dist_percentile: 0.01
+            # Number of threads to run
+            # -1 represents the all available threads
+            number_cpu: {{ runconfig.processing.num_workers }}
+            tile_average: True
+            line_per_block: 300
+
+        fuzzy_value:
+            line_per_block: 200
+            hand:
+                # The units of the HAND is meters.
+                member_min: 0
+                member_max: 15
+            # membership bound for slope angle
+            slope:
+                # The units of the slope is degree.
+                member_min: 0.5
+                member_max: 15
+            # membership bound for reference water
+            reference_water:
+                # Minimum reference water value for membership
+                member_min: 0.8
+                # Maximum reference water value for membership
+                member_max: 0.95
+            # membership bound for area of initial water bodies
+            # area membership is only required for 'twele' workflow.
+            # area unit is pixel number.
+            area:
+                member_min: 0
+                member_max: 40
+            # Dark area is defined where cross-pol is lower than cross_land
+            # Water is defined where cross-pol is lower than cross_water
+            dark_area:
+                # Threshold [dB] for land in the dark area definition
+                cross_land: -18
+                # Threshold [dB] for water in the dark area definition
+                cross_water: -24
+            # High frequent water is defined based on two values
+            # water_min_value < high_frequent_water < water_max_value
+            high_frequent_water:
+                # Minimum value for high frequent water
+                water_min_value: 0.1
+                # Maximum value for high frequent water
+                water_max_value: 0.9
+
+        # Region growing options
+        region_growing:
+            # seed value for region growing start
+            initial_threshold: 0.81
+            # end value for region growing
+            relaxed_threshold: 0.51
+            line_per_block: 400
+
+        masking_ancillary:
+            # Land covers that behaves like dark lands in DSWx-SAR.
+            # The elements should be in given landcover file.
+            # The elements will be masked out during this step.
+            land_cover_darkland_list: ['Bare sparse vegetation', 'Urban', 'Moss and lichen']
+            # The elements is considered as the dark land candidates
+            # where these elemtns are spatially connected to the dark land.
+            land_cover_darkland_extension_list: ['Grassland', 'Shrubs']
+            land_cover_water_label: ['Permanent water bodies']
+            # VV and VH threshold values for dark land candidates
+            co_pol_threshold: -14.6
+            cross_pol_threshold: -22.8
+            # reference water threshold value for dark land candidates
+            water_threshold: 0.05
+            # Flag to enable the darkland extension.
+            extended_darkland: True
+            extended_darkland_minimum_pixel: 3
+            extended_darkland_water_buffer: 10
+            # Flag to enable the HAND filter.
+            hand_variation_mask: True
+            # pixels with HAND threshold is masked out.
+            hand_variation_threshold: 2.5
+            line_per_block: 400
+            number_cpu: {{ runconfig.processing.num_workers }}
+
+        refine_with_bimodality:
+            minimum_pixel: 40
+            lines_per_block: 500
+            number_cpu: {{ runconfig.processing.num_workers }}
+            thresholds:
+                ashman: 1.5
+                Bhattacharyya_coefficient: 0.97
+                bm_coefficient: 0.7
+                surface_ratio: 0.1
+
+        inundated_vegetation:
+            # 'auto' determine the inundated vegetation availability
+            # based on available cross-polarizations
+            enabled: auto
+            dual_pol_ratio_max: 12
+            dual_pol_ratio_min: 7
+            dual_pol_ratio_threshold: 8
+            cross_pol_min: -26
+            line_per_block: 300
+            target_area_file_type: 'auto'
+            target_worldcover_class: ['Herbaceous wetland']
+            target_glad_class: ['112-124', '200-207', '125-148']
+            filter:
+                enabled: True
+                method: lee
+                block_pad: 300
+                lee_filter:
+                    window_size: 3
+                guided_filter:
+                    radius: 1
+                    eps: 3
+                    ddepth: -1
+                bregman:
+                    lambda_value: 20
+                anisotropic_diffusion:
+                    weight: 1
+                # Window size for filtering.
+                line_per_block: 1000
+        # debug mode is true, intermediate product is generated.
+        debug_mode: False

--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -6,7 +6,7 @@ RunConfig:
         PGEName: CSLC_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.values() %}
+          {%- for input in runconfig.input_file_group.values() %}
           {%- if input is iterable and input is not string %}
           {%- for value in input %}
           - {{ value }}
@@ -14,27 +14,27 @@ RunConfig:
           {%- else %}
           - {{ input }}
           {%- endif %}{# if input is iterable and input is not string #}
-          {%- endfor %}{# for input in data.input_file_group.values() #}
+          {%- endfor %}{# for input in runconfig.input_file_group.values() #}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
-          {%- for type in data.static_ancillary_file_group.keys() %}
-          {%- if data.static_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.static_ancillary_file_group.keys() %}
+          {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
           {%- else %}
           {{ type }}:
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: CSLC_S1
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: conda
         ProgramOptions:
           - run
@@ -58,23 +58,23 @@ RunConfig:
           pge_name_group:
             pge_name: CSLC_S1_PGE
           input_file_group:
-            {%- for type in data.input_file_group.keys() %}
-            {%- if data.input_file_group[ type ] is not none %}
+            {%- for type in runconfig.input_file_group.keys() %}
+            {%- if runconfig.input_file_group[ type ] is not none %}
             {{ type }}:
-            {%- if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string %}
-            {%- for value in data.input_file_group[ type ] %}
+            {%- if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string %}
+            {%- for value in runconfig.input_file_group[ type ] %}
               - {{ value }}
-            {%- endfor %}{# for value in data.input_file_group[ type ] #}
+            {%- endfor %}{# for value in runconfig.input_file_group[ type ] #}
             {%- else %}
-              - {{ data.input_file_group[ type ] }}
-            {%- endif %}{# if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string #}
-            {%- endif %}{# if data.input_file_group[ type ] is not none #}
-            {%- endfor %}{# for type in data.input_file_group.keys() #}
+              - {{ runconfig.input_file_group[ type ] }}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
+            {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
             burst_id:
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -83,23 +83,23 @@ RunConfig:
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_description: "Digital Elevation Model (DEM) for the NASA OPERA project version 1.1 (v1.1) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid"
           static_ancillary_file_group:
-            {%- for type in data.static_ancillary_file_group.keys() %}
-            {%- if data.static_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.static_ancillary_file_group.keys() %}
+            {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
             {%- endfor %}
           product_path_group:
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            sas_output_file: {{ data.product_path_group.product_path }}
-            product_version: "{{ data.product_path_group.product_version }}"
-            product_specification_version: "{{ data.product_path_group.product_specification_version }}"
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            sas_output_file: {{ runconfig.product_path_group.product_path }}
+            product_version: "{{ runconfig.product_path_group.product_version }}"
+            product_specification_version: "{{ runconfig.product_path_group.product_specification_version }}"
           primary_executable:
             product_type: CSLC_S1
           processing:
-            polarization: {{ data.processing.polarization }}
+            polarization: {{ runconfig.processing.polarization }}
             geocoding:
               flatten: True
               x_posting: 5

--- a/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
@@ -6,7 +6,7 @@ RunConfig:
         PGEName: CSLC_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.values() %}
+          {%- for input in runconfig.input_file_group.values() %}
           {%- if input is iterable and input is not string %}
           {%- for value in input %}
           - {{ value }}
@@ -14,27 +14,27 @@ RunConfig:
           {%- else %}
           - {{ input }}
           {%- endif %}{# if input is iterable and input is not string #}
-          {%- endfor %}{# for input in data.input_file_group.values() #}
+          {%- endfor %}{# for input in runconfig.input_file_group.values() #}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
-          {%- for type in data.static_ancillary_file_group.keys() %}
-          {%- if data.static_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.static_ancillary_file_group.keys() %}
+          {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
           {%- else %}
           {{ type }}:
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: CSLC_S1
-        ProductVersion: "{{ data.product_path_group.static_product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.static_product_version }}"
         ProgramPath: conda
         ProgramOptions:
           - run
@@ -44,7 +44,7 @@ RunConfig:
         ErrorCodeBase: 200000
         SchemaPath: /home/compass_user/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
         IsoTemplatePath: /home/compass_user/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
-        DataValidityStartDate: {{ data.product_path_group.data_validity_start_date }}
+        DataValidityStartDate: {{ runconfig.product_path_group.data_validity_start_date }}
       QAExecutable:
         Enabled: False
         ProgramPath:
@@ -59,23 +59,23 @@ RunConfig:
           pge_name_group:
             pge_name: CSLC_S1_PGE
           input_file_group:
-            {%- for type in data.input_file_group.keys() %}
-            {%- if data.input_file_group[ type ] is not none %}
+            {%- for type in runconfig.input_file_group.keys() %}
+            {%- if runconfig.input_file_group[ type ] is not none %}
             {{ type }}:
-            {%- if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string %}
-            {%- for value in data.input_file_group[ type ] %}
+            {%- if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string %}
+            {%- for value in runconfig.input_file_group[ type ] %}
               - {{ value }}
-            {%- endfor %}{# for value in data.input_file_group[ type ] #}
+            {%- endfor %}{# for value in runconfig.input_file_group[ type ] #}
             {%- else %}
-              - {{ data.input_file_group[ type ] }}
-            {%- endif %}{# if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string #}
-            {%- endif %}{# if data.input_file_group[ type ] is not none #}
-            {%- endfor %}{# for type in data.input_file_group.keys() #}
+              - {{ runconfig.input_file_group[ type ] }}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
+            {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
             burst_id:
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -84,23 +84,23 @@ RunConfig:
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_description: "Digital Elevation Model (DEM) for the NASA OPERA project version 1.1 (v1.1) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid"
           static_ancillary_file_group:
-            {%- for type in data.static_ancillary_file_group.keys() %}
-            {%- if data.static_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.static_ancillary_file_group.keys() %}
+            {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
             {%- endfor %}
           product_path_group:
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            sas_output_file: {{ data.product_path_group.product_path }}
-            product_version: "{{ data.product_path_group.static_product_version }}"
-            product_specification_version: "{{ data.product_path_group.product_specification_version }}"
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            sas_output_file: {{ runconfig.product_path_group.product_path }}
+            product_version: "{{ runconfig.product_path_group.static_product_version }}"
+            product_specification_version: "{{ runconfig.product_path_group.product_specification_version }}"
           primary_executable:
             product_type: CSLC_S1_STATIC
           processing:
-            polarization: {{ data.processing.polarization }}
+            polarization: {{ runconfig.processing.polarization }}
             geocoding:
               flatten: True
               x_posting: 5

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -6,7 +6,7 @@ RunConfig:
         PGEName: RTC_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.values() %}
+          {%- for input in runconfig.input_file_group.values() %}
           {%- if input is iterable and input is not string %}
           {%- for value in input %}
           - {{ value }}
@@ -14,27 +14,27 @@ RunConfig:
           {%- else %}
           - {{ input }}
           {%- endif %}{# if input is iterable and input is not string #}
-          {%- endfor %}{# for input in data.input_file_group.values() #}
+          {%- endfor %}{# for input in runconfig.input_file_group.values() #}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
-          {%- for type in data.static_ancillary_file_group.keys() %}
-          {%- if data.static_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.static_ancillary_file_group.keys() %}
+          {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
           {%- else %}
           {{ type }}:
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: RTC_S1
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: conda
         ProgramOptions:
           - run
@@ -59,24 +59,24 @@ RunConfig:
           pge_name_group:
             pge_name: RTC_S1_PGE
           input_file_group:
-            {%- for type in data.input_file_group.keys() %}
-            {%- if data.input_file_group[ type ] is not none %}
+            {%- for type in runconfig.input_file_group.keys() %}
+            {%- if runconfig.input_file_group[ type ] is not none %}
             {{ type }}:
-            {%- if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string %}
-            {%- for value in data.input_file_group[ type ] %}
+            {%- if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string %}
+            {%- for value in runconfig.input_file_group[ type ] %}
               - {{ value }}
-            {%- endfor %}{# for value in data.input_file_group[ type ] #}
+            {%- endfor %}{# for value in runconfig.input_file_group[ type ] #}
             {%- else %}
-              - {{ data.input_file_group[ type ] }}
-            {%- endif %}{# if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string #}
-            {%- endif %}{# if data.input_file_group[ type ] is not none #}
-            {%- endfor %}{# for type in data.input_file_group.keys() #}
+              - {{ runconfig.input_file_group[ type ] }}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
+            {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
             burst_id:
             source_data_access: "https://search.asf.alaska.edu/#/?dataset=SENTINEL-1&productTypes=SLC"
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -85,20 +85,20 @@ RunConfig:
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_file_description: "Digital Elevation Model (DEM) for the NASA OPERA project version 1.1 (v1.1) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid"
           static_ancillary_file_group:
-            {%- for type in data.static_ancillary_file_group.keys() %}
-            {%- if data.static_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.static_ancillary_file_group.keys() %}
+            {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
             {%- endfor %}
           product_group:
-            product_version: "{{ data.product_path_group.product_version }}"
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            output_dir: {{ data.product_path_group.product_path }}
+            product_version: "{{ runconfig.product_path_group.product_version }}"
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            output_dir: {{ runconfig.product_path_group.product_path }}
             product_id:
-            rtc_s1_static_validity_start_date: {{ data.product_path_group.data_validity_start_date }}
+            rtc_s1_static_validity_start_date: {{ runconfig.product_path_group.data_validity_start_date }}
             product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC"
             static_layers_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC-STATIC&operaBurstID={burst_id}&end={end_date}"
             save_bursts: True
@@ -110,19 +110,19 @@ RunConfig:
             product_type: RTC_S1
           processing:
             check_ancillary_inputs_coverage: True
-            polarization: {{ data.processing.polarization }}
+            polarization: {{ runconfig.processing.polarization }}
             rtc:
               output_type: gamma0
 
-            num_workers: {{ data.processing.num_workers }}
+            num_workers: {{ runconfig.processing.num_workers }}
 
             geocoding:
               memory_mode: auto
 
-              estimated_geometric_accuracy_bias_x: {{ data.processing.estimated_geometric_accuracy_bias_x }}
-              estimated_geometric_accuracy_bias_y: {{ data.processing.estimated_geometric_accuracy_bias_y }}
-              estimated_geometric_accuracy_stddev_x: {{ data.processing.estimated_geometric_accuracy_stddev_x }}
-              estimated_geometric_accuracy_stddev_y: {{ data.processing.estimated_geometric_accuracy_stddev_y }}
+              estimated_geometric_accuracy_bias_x: {{ runconfig.processing.estimated_geometric_accuracy_bias_x }}
+              estimated_geometric_accuracy_bias_y: {{ runconfig.processing.estimated_geometric_accuracy_bias_y }}
+              estimated_geometric_accuracy_stddev_x: {{ runconfig.processing.estimated_geometric_accuracy_stddev_x }}
+              estimated_geometric_accuracy_stddev_y: {{ runconfig.processing.estimated_geometric_accuracy_stddev_y }}
             mosaicking:
               mosaic_mode: first
             browse_image_group:

--- a/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
@@ -6,7 +6,7 @@ RunConfig:
         PGEName: RTC_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.values() %}
+          {%- for input in runconfig.input_file_group.values() %}
           {%- if input is iterable and input is not string %}
           {%- for value in input %}
           - {{ value }}
@@ -14,27 +14,27 @@ RunConfig:
           {%- else %}
           - {{ input }}
           {%- endif %}{# if input is iterable and input is not string #}
-          {%- endfor %}{# for input in data.input_file_group.values() #}
+          {%- endfor %}{# for input in runconfig.input_file_group.values() #}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
-          {%- for type in data.static_ancillary_file_group.keys() %}
-          {%- if data.static_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.static_ancillary_file_group.keys() %}
+          {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
           {%- else %}
           {{ type }}:
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: RTC_S1
-        ProductVersion: "{{ data.product_path_group.static_product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.static_product_version }}"
         ProgramPath: conda
         ProgramOptions:
           - run
@@ -45,7 +45,7 @@ RunConfig:
         ErrorCodeBase: 300000
         SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
         IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
-        DataValidityStartDate: {{ data.product_path_group.data_validity_start_date }}
+        DataValidityStartDate: {{ runconfig.product_path_group.data_validity_start_date }}
       QAExecutable:
         Enabled: False
         ProgramPath:
@@ -60,24 +60,24 @@ RunConfig:
           pge_name_group:
             pge_name: RTC_S1_PGE
           input_file_group:
-            {%- for type in data.input_file_group.keys() %}
-            {%- if data.input_file_group[ type ] is not none %}
+            {%- for type in runconfig.input_file_group.keys() %}
+            {%- if runconfig.input_file_group[ type ] is not none %}
             {{ type }}:
-            {%- if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string %}
-            {%- for value in data.input_file_group[ type ] %}
+            {%- if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string %}
+            {%- for value in runconfig.input_file_group[ type ] %}
               - {{ value }}
-            {%- endfor %}{# for value in data.input_file_group[ type ] #}
+            {%- endfor %}{# for value in runconfig.input_file_group[ type ] #}
             {%- else %}
-              - {{ data.input_file_group[ type ] }}
-            {%- endif %}{# if data.input_file_group[ type ] is iterable and data.input_file_group[ type ] is not string #}
-            {%- endif %}{# if data.input_file_group[ type ] is not none #}
-            {%- endfor %}{# for type in data.input_file_group.keys() #}
+              - {{ runconfig.input_file_group[ type ] }}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
+            {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
+            {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
             burst_id:
             source_data_access: "https://search.asf.alaska.edu/#/?dataset=SENTINEL-1&productTypes=SLC"
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -86,20 +86,20 @@ RunConfig:
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_file_description: "Digital Elevation Model (DEM) for the NASA OPERA project version 1.1 (v1.1) based on the Copernicus DEM 30-m and Copernicus 90-m referenced to the WGS84 ellipsoid"
           static_ancillary_file_group:
-            {%- for type in data.static_ancillary_file_group.keys() %}
-            {%- if data.static_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.static_ancillary_file_group.keys() %}
+            {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
             {%- endfor %}
           product_group:
-            product_version: "{{ data.product_path_group.static_product_version }}"
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            output_dir: {{ data.product_path_group.product_path }}
+            product_version: "{{ runconfig.product_path_group.static_product_version }}"
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            output_dir: {{ runconfig.product_path_group.product_path }}
             product_id:
-            rtc_s1_static_validity_start_date: {{ data.product_path_group.data_validity_start_date }}
+            rtc_s1_static_validity_start_date: {{ runconfig.product_path_group.data_validity_start_date }}
             product_data_access: "https://search.asf.alaska.edu/#/?dataset=OPERA-S1&productTypes=RTC-STATIC&operaBurstID={burst_id}&end={end_date}"
             save_bursts: True
             save_mosaics: False
@@ -110,19 +110,19 @@ RunConfig:
             product_type: RTC_S1_STATIC
           processing:
             check_ancillary_inputs_coverage: True
-            polarization: {{ data.processing.polarization }}
+            polarization: {{ runconfig.processing.polarization }}
             rtc:
               output_type: gamma0
 
-            num_workers: {{ data.processing.num_workers }}
+            num_workers: {{ runconfig.processing.num_workers }}
 
             geocoding:
               memory_mode: auto
 
-              estimated_geometric_accuracy_bias_x: {{ data.processing.estimated_geometric_accuracy_bias_x }}
-              estimated_geometric_accuracy_bias_y: {{ data.processing.estimated_geometric_accuracy_bias_y }}
-              estimated_geometric_accuracy_stddev_x: {{ data.processing.estimated_geometric_accuracy_stddev_x }}
-              estimated_geometric_accuracy_stddev_y: {{ data.processing.estimated_geometric_accuracy_stddev_y }}
+              estimated_geometric_accuracy_bias_x: {{ runconfig.processing.estimated_geometric_accuracy_bias_x }}
+              estimated_geometric_accuracy_bias_y: {{ runconfig.processing.estimated_geometric_accuracy_bias_y }}
+              estimated_geometric_accuracy_stddev_x: {{ runconfig.processing.estimated_geometric_accuracy_stddev_x }}
+              estimated_geometric_accuracy_stddev_y: {{ runconfig.processing.estimated_geometric_accuracy_stddev_y }}
             mosaicking:
               mosaic_mode: first
             browse_image_group:

--- a/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
@@ -6,29 +6,29 @@ RunConfig:
         PGEName: DISP_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.input_file_paths %}
+          {%- for input in runconfig.input_file_group.input_file_paths %}
           - {{ input }}
           {%- endfor %}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string %}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string %}
           {{ type }}:
-          {%- for value in data.dynamic_ancillary_file_group[ type ] %}
+          {%- for value in runconfig.dynamic_ancillary_file_group[ type ] %}
             - {{ value }}
-          {%- endfor %}{# for value in data.dynamic_ancillary_file_group[ type ] #}
+          {%- endfor %}{# for value in runconfig.dynamic_ancillary_file_group[ type ] #}
           {%- else %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
-          {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string #}
-          {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is not none #}
-          {%- endfor %}{# for type in data.dynamic_ancillary_file_group.keys() #}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
+          {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string #}
+          {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is not none #}
+          {%- endfor %}{# for type in runconfig.dynamic_ancillary_file_group.keys() #}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DISP_S1
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: disp-s1
         ProgramOptions:
           - run
@@ -42,50 +42,50 @@ RunConfig:
         ProgramPath:
         ProgramOptions: []
       DebugLevelGroup:
-        DebugSwitch: {{ data.processing.debug_switch }}
+        DebugSwitch: {{ runconfig.processing.debug_switch }}
         ExecuteViaShell: False
     SAS:
       input_file_group:
         cslc_file_list:
-          {%- for input in data.input_file_group.input_file_paths %}
+          {%- for input in runconfig.input_file_group.input_file_paths %}
           - {{ input }}
           {%- endfor %}
-        frame_id: {{ data.processing.frame_id }}
+        frame_id: {{ runconfig.processing.frame_id }}
       dynamic_ancillary_file_group:
-        algorithm_parameters_file: {{ data.processing.algorithm_parameters }}
-        {%- for type in data.dynamic_ancillary_file_group.keys() %}
-        {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-        {%- if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string %}
+        algorithm_parameters_file: {{ runconfig.processing.algorithm_parameters }}
+        {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+        {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+        {%- if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string %}
         {{ type }}:
-        {%- for value in data.dynamic_ancillary_file_group[ type ] %}
+        {%- for value in runconfig.dynamic_ancillary_file_group[ type ] %}
           - {{ value }}
-        {%- endfor %}{# for value in data.dynamic_ancillary_file_group[ type ] #}
+        {%- endfor %}{# for value in runconfig.dynamic_ancillary_file_group[ type ] #}
         {%- else %}
-        {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
-        {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string #}
-        {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is not none #}
-        {%- endfor %}{# for type in data.dynamic_ancillary_file_group.keys() #}
+        {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
+        {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string #}
+        {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is not none #}
+        {%- endfor %}{# for type in runconfig.dynamic_ancillary_file_group.keys() #}
       static_ancillary_file_group:
-        {%- for type in data.static_ancillary_file_group.keys() %}
-        {%- if data.static_ancillary_file_group[ type ] is not none %}
-        {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+        {%- for type in runconfig.static_ancillary_file_group.keys() %}
+        {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+        {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
         {%- else %}
         {{ type }}:
         {%- endif %}
         {%- endfor %}
       primary_executable:
-        product_type: {{ data.processing.product_type }}
+        product_type: {{ runconfig.processing.product_type }}
       product_path_group:
-        product_path: {{ data.product_path_group.product_path }}
-        scratch_path: {{ data.product_path_group.scratch_path }}
-        sas_output_path: {{ data.product_path_group.product_path }}
-        product_version: "{{ data.product_path_group.product_version }}"
-        save_compressed_slc: {{ data.product_path_group.save_compressed_slc }}
+        product_path: {{ runconfig.product_path_group.product_path }}
+        scratch_path: {{ runconfig.product_path_group.scratch_path }}
+        sas_output_path: {{ runconfig.product_path_group.product_path }}
+        product_version: "{{ runconfig.product_path_group.product_version }}"
+        save_compressed_slc: {{ runconfig.product_path_group.save_compressed_slc }}
       worker_settings:
         gpu_enabled: false
-        threads_per_worker: {{ data.processing.threads_per_worker }}
-        n_parallel_bursts: {{ data.processing.n_parallel_bursts }}
+        threads_per_worker: {{ runconfig.processing.threads_per_worker }}
+        n_parallel_bursts: {{ runconfig.processing.n_parallel_bursts }}
         block_shape:
           - 512
           - 512
-      log_file: {{ data.product_path_group.scratch_path }}/disp-s1-sas.log
+      log_file: {{ runconfig.product_path_group.scratch_path }}/disp-s1-sas.log

--- a/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
@@ -52,7 +52,7 @@ RunConfig:
           {%- endfor %}
         frame_id: {{ runconfig.processing.frame_id }}
       dynamic_ancillary_file_group:
-        algorithm_parameters_file: {{ runconfig.processing.algorithm_parameters }}
+        algorithm_parameters_file: {{ runconfig.product_path_group.input_path }}/AlgoParams.yaml
         {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
         {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
         {%- if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string %}

--- a/conf/RunConfig.yaml.L3_DISP_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DISP_S1_STATIC.jinja2.tmpl
@@ -6,29 +6,29 @@ RunConfig:
         PGEName: DISP_S1_STATIC_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.input_file_paths %}{# This should map to CSLC-STATIC files, even though the SAS considers them dynamic ancillaries at the moment #}
+          {%- for input in runconfig.input_file_group.input_file_paths %}{# This should map to CSLC-STATIC files, even though the SAS considers them dynamic ancillaries at the moment #}
           - {{ input }}
           {%- endfor %}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string %}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string %}
           {{ type }}:
-          {%- for value in data.dynamic_ancillary_file_group[ type ] %}
+          {%- for value in runconfig.dynamic_ancillary_file_group[ type ] %}
             - {{ value }}
-          {%- endfor %}{# for value in data.dynamic_ancillary_file_group[ type ] #}
+          {%- endfor %}{# for value in runconfig.dynamic_ancillary_file_group[ type ] #}
           {%- else %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
-          {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string #}
-          {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is not none #}
-          {%- endfor %}{# for type in data.dynamic_ancillary_file_group.keys() #}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
+          {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string #}
+          {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is not none #}
+          {%- endfor %}{# for type in runconfig.dynamic_ancillary_file_group.keys() #}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DISP_S1_STATIC
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: disp-s1
         ProgramOptions:
           - run
@@ -41,32 +41,32 @@ RunConfig:
         ProgramPath:
         ProgramOptions: []
       DebugLevelGroup:
-        DebugSwitch: {{ data.processing.debug_switch }}
+        DebugSwitch: {{ runconfig.processing.debug_switch }}
         ExecuteViaShell: False
     SAS:
       input_file_group:
-        frame_id: {{ data.processing.frame_id }}
+        frame_id: {{ runconfig.processing.frame_id }}
       dynamic_ancillary_file_group:
         static_layers_files:
-          {%- for input in data.input_file_group.input_file_paths %}
+          {%- for input in runconfig.input_file_group.input_file_paths %}
           - {{ input }}
           {%- endfor %}
-        {%- for type in data.dynamic_ancillary_file_group.keys() %}
-        {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-        {%- if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string %}
+        {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+        {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+        {%- if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string %}
         {{ type }}:
-        {%- for value in data.dynamic_ancillary_file_group[ type ] %}
+        {%- for value in runconfig.dynamic_ancillary_file_group[ type ] %}
           - {{ value }}
-        {%- endfor %}{# for value in data.dynamic_ancillary_file_group[ type ] #}
+        {%- endfor %}{# for value in runconfig.dynamic_ancillary_file_group[ type ] #}
         {%- else %}
-        {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
-        {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is iterable and data.dynamic_ancillary_file_group[ type ] is not string #}
-        {%- endif %}{# if data.dynamic_ancillary_file_group[ type ] is not none #}
-        {%- endfor %}{# for type in data.dynamic_ancillary_file_group.keys() #}
+        {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
+        {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string #}
+        {%- endif %}{# if runconfig.dynamic_ancillary_file_group[ type ] is not none #}
+        {%- endfor %}{# for type in runconfig.dynamic_ancillary_file_group.keys() #}
       static_ancillary_file_group:
-        {%- for type in data.static_ancillary_file_group.keys() %}
-        {%- if data.static_ancillary_file_group[ type ] is not none %}
-        {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+        {%- for type in runconfig.static_ancillary_file_group.keys() %}
+        {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+        {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
         {%- else %}
         {{ type }}:
         {%- endif %}
@@ -74,14 +74,14 @@ RunConfig:
       primary_executable:
         product_type: DISP_S1_STATIC
       product_path_group:
-        product_path: {{ data.product_path_group.product_path }}
-        scratch_path: {{ data.product_path_group.scratch_path }}
-        sas_output_path: {{ data.product_path_group.product_path }}
-        product_version: "{{ data.product_path_group.product_version }}"
+        product_path: {{ runconfig.product_path_group.product_path }}
+        scratch_path: {{ runconfig.product_path_group.scratch_path }}
+        sas_output_path: {{ runconfig.product_path_group.product_path }}
+        product_version: "{{ runconfig.product_path_group.product_version }}"
       worker_settings:
-        threads_per_worker: {{ data.processing.threads_per_worker }}
-        n_parallel_bursts: {{ data.processing.n_parallel_bursts }}
+        threads_per_worker: {{ runconfig.processing.threads_per_worker }}
+        n_parallel_bursts: {{ runconfig.processing.n_parallel_bursts }}
         block_shape:
           - 512
           - 512
-      log_file: {{ data.product_path_group.scratch_path }}/disp-s1-sas.log
+      log_file: {{ runconfig.product_path_group.scratch_path }}/disp-s1-sas.log

--- a/conf/RunConfig.yaml.L3_DIST_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DIST_S1.jinja2.tmpl
@@ -6,26 +6,26 @@ RunConfig:
         PGEName: DIST_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.pre_rtc_copol %}
+          {%- for input in runconfig.input_file_group.pre_rtc_copol %}
           - {{ input }}
           {%- endfor %}
-          {%- for input in data.input_file_group.pre_rtc_crosspol %}
+          {%- for input in runconfig.input_file_group.pre_rtc_crosspol %}
           - {{ input }}
           {%- endfor %}
-          {%- for input in data.input_file_group.post_rtc_copol %}
+          {%- for input in runconfig.input_file_group.post_rtc_copol %}
           - {{ input }}
           {%- endfor %}
-          {%- for input in data.input_file_group.post_rtc_crosspol %}
+          {%- for input in runconfig.input_file_group.post_rtc_crosspol %}
           - {{ input }}
           {%- endfor %}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap: {}  # TODO: Don't know how I should fill this part out based on the SAS RC
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DIST_S1
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: /opt/miniforge/envs/dist-s1-env/bin/dist-s1
         ProgramOptions:
         - run_sas
@@ -45,29 +45,29 @@ RunConfig:
     SAS:
       run_config:
         pre_rtc_copol:
-          {%- for input in data.input_file_group.pre_rtc_copol %}
+          {%- for input in runconfig.input_file_group.pre_rtc_copol %}
           - {{ input }}
           {%- endfor %}
         pre_rtc_crosspol:
-          {%- for input in data.input_file_group.pre_rtc_crosspol %}
+          {%- for input in runconfig.input_file_group.pre_rtc_crosspol %}
           - {{ input }}
           {%- endfor %}
         post_rtc_copol:
-          {%- for input in data.input_file_group.post_rtc_copol %}
+          {%- for input in runconfig.input_file_group.post_rtc_copol %}
           - {{ input }}
           {%- endfor %}
         post_rtc_crosspol:
-          {%- for input in data.input_file_group.post_rtc_crosspol %}
+          {%- for input in runconfig.input_file_group.post_rtc_crosspol %}
           - {{ input }}
           {%- endfor %}
-        mgrs_tile_id: {{ data.mgrs_tile_id }}
-        dst_dir: {{ data.product_path_group.scratch_path }}
-        water_mask_path: {{ data.water_mask_path }}
-        apply_water_mask: {{ data.apply_water_mask }}
+        mgrs_tile_id: {{ runconfig.mgrs_tile_id }}
+        dst_dir: {{ runconfig.product_path_group.scratch_path }}
+        water_mask_path: {{ runconfig.water_mask_path }}
+        apply_water_mask: {{ runconfig.apply_water_mask }}
         memory_strategy: high
         tqdm_enabled: false
-        n_lookbacks: {{ data.n_lookbacks }}
+        n_lookbacks: {{ runconfig.n_lookbacks }}
         moderate_confidence_threshold: 3.5
         high_confidence_threshold: 5.5
-        product_dst_dir: {{ data.product_path_group.product_path }}
+        product_dst_dir: {{ runconfig.product_path_group.product_path }}
         bucket: ~

--- a/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_HLS.jinja2.tmpl
@@ -6,22 +6,22 @@ RunConfig:
         PGEName: DSWX_HLS_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.input_file_path %}
+          {%- for input in runconfig.input_file_group.input_file_path %}
           - {{ input }}
           {%- endfor %}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DSWX_HLS
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: python3
         ProgramOptions:
           - /home/conda/proteus-1.0.1/bin/dswx_hls.py
@@ -45,13 +45,13 @@ RunConfig:
             pge_name: DSWX_HLS_PGE
           input_file_group:
             input_file_path:
-              {%- for input in data.input_file_group.input_file_path %}
+              {%- for input in runconfig.input_file_group.input_file_path %}
               - {{ input }}
               {%- endfor %}
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[type] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[type] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[type] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[type] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -64,14 +64,14 @@ RunConfig:
           primary_executable:
             product_type: DSWX_HLS
           product_path_group:
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            output_dir: {{ data.product_path_group.product_path }}
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            output_dir: {{ runconfig.product_path_group.product_path }}
             product_id: dswx_hls
-            product_version: {{ data.product_path_group.product_version }}
+            product_version: {{ runconfig.product_path_group.product_version }}
           processing:
-            check_ancillary_inputs_coverage: {{ data.processing.check_ancillary_inputs_coverage }}
-            apply_ocean_masking: {{ data.processing.apply_ocean_masking }}
+            check_ancillary_inputs_coverage: {{ runconfig.processing.check_ancillary_inputs_coverage }}
+            apply_ocean_masking: {{ runconfig.processing.apply_ocean_masking }}
             save_wtr: True    # Layer 1 - WTR
             save_bwtr: True   # Layer 2 - BWTR
             save_conf: True   # Layer 3 - CONF

--- a/conf/RunConfig.yaml.L3_DSWx_NI.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_NI.jinja2.tmpl
@@ -6,22 +6,22 @@ RunConfig:
         PGEName: DSWX_NI_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.input_file_paths %}
+          {%- for input in runconfig.input_file_group.input_file_paths %}
           - {{ input }}
           {%- endfor %}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DSWX_NI
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: python3
         ProgramOptions:
           - /home/dswx_user/OPERA/DSWX-SAR/src/dswx_sar/dswx_ni.py
@@ -44,22 +44,22 @@ RunConfig:
             pge_name: DSWX_NI_PGE
           input_file_group:
             input_file_path:
-              {%- for input in data.input_file_group.input_file_paths %}
+              {%- for input in runconfig.input_file_group.input_file_paths %}
               - {{ input }}
               {%- endfor %}
             input_file_historical_path:
-            input_mgrs_collection_id: {{ data.input_file_group.input_mgrs_collection_id }}
+            input_mgrs_collection_id: {{ runconfig.input_file_group.input_mgrs_collection_id }}
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
             {%- endfor %}
             mean_backscattering:
             standard_deviation_backscattering:
-            algorithm_parameters: {{ data.processing.algorithm_parameters }}
+            algorithm_parameters: {{ runconfig.processing.algorithm_parameters }}
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_file_description: 'Copernicus DEM GLO-30 2021 WGS84'
             worldcover_file_description: 'ESA WorldCover 10m 2020 v1.0'
@@ -68,9 +68,9 @@ RunConfig:
             glad_classification_file_description: 'GLAD Global Land Cover 2020'
           static_ancillary_file_group:
             static_ancillary_inputs_flag: True
-            {%- for type in data.static_ancillary_file_group.keys() %}
-            {%- if data.static_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.static_ancillary_file_group.keys() %}
+            {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -78,11 +78,11 @@ RunConfig:
           primary_executable:
             product_type: dswx_ni
           product_path_group:
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            sas_output_path: {{ data.product_path_group.product_path }}
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            sas_output_path: {{ runconfig.product_path_group.product_path }}
             # TODO: this should become a string once SAS schema is fixed
-            product_version: {{ data.product_path_group.product_version }}
+            product_version: {{ runconfig.product_path_group.product_version }}
             output_imagery_format: 'COG'
           browse_image_group:
             save_browse: True
@@ -95,4 +95,4 @@ RunConfig:
             set_layover_shadow_to_nodata: True
             set_ocean_masked_to_nodata: False
             save_tif_to_output: True
-          log_file: {{ data.product_path_group.scratch_path }}/dswx-ni.log
+          log_file: {{ runconfig.product_path_group.scratch_path }}/dswx-ni.log

--- a/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
@@ -6,22 +6,22 @@ RunConfig:
         PGEName: DSWX_S1_PGE
       InputFilesGroup:
         InputFilePaths:
-          {%- for input in data.input_file_group.input_file_paths %}
+          {%- for input in runconfig.input_file_group.input_file_paths %}
           - {{ input }}
           {%- endfor %}
       DynamicAncillaryFilesGroup:
         AncillaryFileMap:
-          {%- for type in data.dynamic_ancillary_file_group.keys() %}
-          {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-          {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+          {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+          {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+          {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
           {%- endif %}
           {%- endfor %}
       ProductPathGroup:
-        OutputProductPath: {{ data.product_path_group.product_path }}
-        ScratchPath: {{ data.product_path_group.scratch_path }}
+        OutputProductPath: {{ runconfig.product_path_group.product_path }}
+        ScratchPath: {{ runconfig.product_path_group.scratch_path }}
       PrimaryExecutable:
         ProductIdentifier: DSWX_S1
-        ProductVersion: "{{ data.product_path_group.product_version }}"
+        ProductVersion: "{{ runconfig.product_path_group.product_version }}"
         ProgramPath: python3
         ProgramOptions:
           - /home/dswx_user/OPERA/DSWX-SAR/src/dswx_sar/dswx_s1.py
@@ -44,19 +44,19 @@ RunConfig:
             pge_name: DSWX_S1_PGE
           input_file_group:
             input_file_path:
-              {%- for input in data.input_file_group.input_file_paths %}
+              {%- for input in runconfig.input_file_group.input_file_paths %}
               - {{ input }}
               {%- endfor %}
-            input_mgrs_collection_id: {{ data.input_file_group.input_mgrs_collection_id }}
+            input_mgrs_collection_id: {{ runconfig.input_file_group.input_mgrs_collection_id }}
           dynamic_ancillary_file_group:
-            {%- for type in data.dynamic_ancillary_file_group.keys() %}
-            {%- if data.dynamic_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.dynamic_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
+            {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.dynamic_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
             {%- endfor %}
-            algorithm_parameters: {{ data.processing.algorithm_parameters }}
+            algorithm_parameters: {{ runconfig.processing.algorithm_parameters }}
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_file_description: 'Copernicus DEM GLO-30 2021 WGS84'
             worldcover_file_description: 'ESA WorldCover 10m 2020 v1.0'
@@ -65,9 +65,9 @@ RunConfig:
             glad_classification_file_description: 'GLAD Global Land Cover 2020'
           static_ancillary_file_group:
             static_ancillary_inputs_flag: True
-            {%- for type in data.static_ancillary_file_group.keys() %}
-            {%- if data.static_ancillary_file_group[ type ] is not none %}
-            {{ type }}: {{ data.static_ancillary_file_group[ type ] }}
+            {%- for type in runconfig.static_ancillary_file_group.keys() %}
+            {%- if runconfig.static_ancillary_file_group[ type ] is not none %}
+            {{ type }}: {{ runconfig.static_ancillary_file_group[ type ] }}
             {%- else %}
             {{ type }}:
             {%- endif %}
@@ -75,10 +75,10 @@ RunConfig:
           primary_executable:
             product_type: dswx_s1
           product_path_group:
-            product_path: {{ data.product_path_group.product_path }}
-            scratch_path: {{ data.product_path_group.scratch_path }}
-            sas_output_path: {{ data.product_path_group.product_path }}
-            product_version: "{{ data.product_path_group.product_version }}"
+            product_path: {{ runconfig.product_path_group.product_path }}
+            scratch_path: {{ runconfig.product_path_group.scratch_path }}
+            sas_output_path: {{ runconfig.product_path_group.product_path }}
+            product_version: "{{ runconfig.product_path_group.product_version }}"
             output_imagery_format: 'COG'
           browse_image_group:
             save_browse: True
@@ -91,4 +91,4 @@ RunConfig:
             set_layover_shadow_to_nodata: True
             set_ocean_masked_to_nodata: False
             save_tif_to_output: True
-          log_file: {{ data.product_path_group.scratch_path }}/dswx-s1.log
+          log_file: {{ runconfig.product_path_group.scratch_path }}/dswx-s1.log

--- a/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DSWx_S1.jinja2.tmpl
@@ -56,7 +56,7 @@ RunConfig:
             {{ type }}:
             {%- endif %}
             {%- endfor %}
-            algorithm_parameters: {{ runconfig.processing.algorithm_parameters }}
+            algorithm_parameters: {{ runconfig.product_path_group.input_path }}/AlgoParams.yaml
             # TODO: update descriptions as necessary when new ancillary releases are available
             dem_file_description: 'Copernicus DEM GLO-30 2021 WGS84'
             worldcover_file_description: 'ESA WorldCover 10m 2020 v1.0'

--- a/conf/schema/AlgoParams_schema.L3_DISP_S1.yaml
+++ b/conf/schema/AlgoParams_schema.L3_DISP_S1.yaml
@@ -1,0 +1,227 @@
+ps_options:
+    # Amplitude dispersion threshold to consider a pixel a PS.
+    amp_dispersion_threshold: num()
+phase_linking:
+    # Size of the ministack for sequential estimator.
+    ministack_size: int(min=2)
+    # Maximum number of compressed images to use in sequential estimator.
+    # If there are more ministacks than this, the earliest CCSLCs will be left
+    # out of the later stacks.
+    max_num_compressed: int(min=1)
+    # Index of input SLC to use for making phase linked interferograms after EVD/EMI.
+    output_reference_idx: int(required=False)
+    half_window:
+        # Half window size (in pixels) for x direction.
+        x: int()
+        # Half window size (in pixels) for y direction.
+        y: int()
+    # Use EVD on the coherence instead of using the EMI algorithm.
+    use_evd: bool()
+    # Beta regularization parameter for correlation matrix inversion. 0 is no regularization.
+    beta: num(min=0.0, max=1.0)
+    # Snap correlation values in the coherence matrix below this value to 0.
+    zero_correlation_threshold: num(min=0.0, max=1.0)
+    # Method for finding SHPs during phase linking.
+    shp_method: enum('glrt', 'ks', 'rect')
+    # Significance level (probability of false alarm) for SHP tests. Lower numbers include more
+    # pixels within the multilook window during covariance estimation.
+    shp_alpha: num(min=0.0, max=1.0)
+    # If True, pixels labeled as PS will get set to NaN during phase linking to
+    # avoid summing their phase. Default of False means that the SHP algorithm
+    # will decide if a pixel should be included, regardless of its PS label.
+    mask_input_ps: bool(required=False)
+    # StBAS parameter to include only nearest-N interferograms forphase linking. A
+    #   `baseline_lag` of `n` will only include the closest`n` interferograms. `baseline_line`
+    #   must be positive.
+    baseline_lag: any(int(min=0), null())
+    # Plan for creating Compressed SLCs during phase linking.
+    compressed_slc_plan: enum('always_first', 'first_per_ministack', 'last_per_ministack')
+interferogram_network:
+    # For single-reference network: Index of the reference image in the network.
+    reference_idx: any(int(), null())
+    # Max n to form the nearest-n interferograms by index.
+    max_bandwidth: any(int(), null())
+    # Maximum temporal baseline of interferograms.
+    max_temporal_baseline: any(int(), null())
+    # For manual-index network: List of (ref_idx, sec_idx) defining the interferograms to form.
+    indexes: any(list(list()), null())
+unwrap_options:
+    # Whether to run the unwrapping step after wrapped phase estimation.
+    run_unwrap: bool()
+    # Whether to run Goldstein filtering step on wrapped interferogram.
+    run_goldstein: bool()
+    # Whether to run interpolation step on wrapped interferogram.
+    run_interpolation: bool()
+    # Phase unwrapping method.
+    unwrap_method: enum('snaphu', 'icu', 'phass', 'spurt', 'whirlwind')
+    # Number of interferograms to unwrap in parallel.
+    n_parallel_jobs: int()
+    # Set wrapped phase/correlation to 0 where mask is 0 before unwrapping. .
+    zero_where_masked: bool()
+    preprocess_options:
+        # Adaptive phase (Goldstein) filter exponent parameter.
+        alpha: num(min=0.0, max=1.0)
+        # (for interpolation) Maximum radius to find scatterers.
+        max_radius: int(min=0)
+        # Threshold on the correlation raster to use for interpolation. Pixels with less than this
+        #   value are replaced by a weighted combination of neighboring pixels.
+        interpolation_cor_threshold: num(min=0.0, max=1.0)
+        # Threshold on the correlation raster to use for interpolation. Pixels with less than this
+        #   value are replaced by a weighted combination of neighboring pixels.
+        interpolation_similarity_threshold: num(min=0.0, max=1.0)
+    snaphu_options:
+        # Number of tiles to split the inputs into using SNAPHU's internal tiling.
+        ntiles: list(int())
+        # Amount of tile overlap (in pixels) along the (row, col) directions.
+        tile_overlap: list(int(), min=2, max=2)
+        # Number of tiles to unwrap in parallel for each interferogram.
+        n_parallel_tiles: int()
+        # Initialization method for SNAPHU.
+        init_method: enum('mcf', 'mst')
+        # Statistical cost mode method for SNAPHU.
+        cost: enum('defo', 'smooth')
+        # If True, after unwrapping with multiple tiles, an additional post-processing unwrapping
+        #   step is performed to re-optimize the unwrapped phase using a single tile.
+        single_tile_reoptimize: bool()
+    tophu_options:
+        # Number of tiles to split the inputs into.
+        ntiles: list(int())
+        # Extra multilook factor to use for the coarse unwrap.
+        downsample_factor: list(int())
+        # Initialization method for SNAPHU.
+        init_method: enum('mcf', 'mst')
+        # Statistical cost mode method for SNAPHU.
+        cost: enum('defo', 'smooth')
+    spurt_options:
+        # Temporal coherence to pick pixels used on an irregular grid.
+        temporal_coherence_threshold: num(min=0.0, max=1.0)
+        # Similarity to pick pixels used on an irregular grid. Any pixel with similarity above
+        #   `similarity_threshold` *or* above the temporal coherence threshold is chosen.
+        similarity_threshold: num(min=0.0, max=1.0)
+        run_ambiguity_interpolation: bool()
+        general_settings:
+            # Tile up data spatially.
+            use_tiles: bool()
+        tiler_settings:
+            # Maximum number of tiles allowed.
+            max_tiles: int(min=1)
+            # Number of points used for determining tiles based on density.
+            #   Type: integer.
+            target_points_for_generation: int(min=1)
+            # Target points per tile when generating tiles.
+            target_points_per_tile: int(min=1)
+            # Dilation factor of non-overlapping tiles. 0.05 would lead to 5 percent dilation of the
+            #   tile.
+            dilation_factor: num(min=0.0)
+        solver_settings:
+            # Number of workers for temporal unwrapping in parallel. Set value to <=0 to let workflow
+            #   use default workers (ncpus - 1).
+            t_worker_count: int()
+            # Number of workers for spatial unwrapping in parallel. Set value to <=0 to let workflow use
+            #   (ncpus - 1).
+            s_worker_count: int()
+            # Temporal unwrapping operations over spatial links are performed in batches and each batch
+            #   is solved in parallel.
+            links_per_batch: int(min=1)
+            # Temporal unwrapping costs.
+            #   Options: ['constant', 'distance', 'centroid'].
+            t_cost_type: enum('constant', 'distance', 'centroid')
+            # Scale factor used to compute edge costs for temporal unwrapping.
+            t_cost_scale: num(min=0.0)
+            # Spatial unwrapping costs.
+            #   Options: ['constant', 'distance', 'centroid'].
+            s_cost_type: enum('constant', 'distance', 'centroid')
+            # Scale factor used to compute edge costs for spatial unwrapping.
+            s_cost_scale: num(min=0.0)
+            # Number of tiles to process in parallel. Set to 0 for all tiles.
+            num_parallel_tiles: int(min=0)
+        merger_settings:
+            # Minimum number of overlap pixels to be considered valid.
+            min_overlap_points: int()
+            # Currently, only 'dirichlet' is supported.
+            method: enum('dirichlet')
+            # Method used to estimate bulk offset between tiles.
+            #   Options: ['integer', 'L2'].
+            bulk_method: enum('integer', 'L2')
+            # Number of interferograms to merge in one batch. Use zero to merge all
+            # interferograms in a single batch.
+            num_parallel_ifgs: int(min=0)
+timeseries_options:
+    # Whether to run the inversion step after unwrapping, if more than a single-reference
+    # network is used.
+    run_inversion: bool()
+    # Norm to use during timeseries inversion.
+    method: enum('L1', 'L2')
+    # Reference point (row, col) used if performing a time series inversion. If not provided, a
+    # point will be selected from a consistent connected component with low amplitude
+    # dispersion.
+    reference_point: any(list(int(), min=2, max=2), null())
+    # Run the velocity estimation from the phase time series.
+    run_velocity: bool()
+    # Pixels with correlation below this value will be masked out.
+    correlation_threshold: num(min=0.0, max=1.0)
+    # Size (rows, columns) of blocks of data to load at a time. 3D dimsion is number of
+    # interferograms (during inversion) and number of SLC dates (during velocity fitting).
+    block_shape: list(int(), min=2, max=2)
+    # Number of parallel blocks to process at once.
+    num_parallel_blocks: int()
+output_options:
+    # Output (x, y) resolution (in units of input data).
+    output_resolution: any(include('x_y_object'), null())
+    # Alternative to specifying output resolution: Specify the (x, y) strides (decimation
+    # factor) to perform while processing input. For example, strides of [4, 2] would turn an
+    # input resolution of [5, 10] into an output resolution of [20, 20].
+    strides: include('x_y_object')
+    # Area of interest: (left, bottom, right, top) longitude/latitude e.g.
+    # `bbox=(-150.2,65.0,-150.1,65.5)`.
+    bounds: any(list(num(), min=4, max=4), null())
+    # Area of interest as a simple Polygon in well-known-text (WKT) format.
+    #  Can pass a string, or a `.wkt` filename containing the Polygon text.
+    bounds_wkt: any(str(), null())
+    # EPSG code for the `bounds`, if specified.
+    bounds_epsg: int()
+    # Options for `create_dataset` with h5py.
+    hdf5_creation_options:
+        chunks: list(int())
+        compression: str()
+        compression_opts: int()
+        shuffle: bool()
+    # GDAL creation options for GeoTIFF files.
+    gtiff_creation_options: list(str())
+    # Whether to add overviews to the output GeoTIFF files.
+    # This will increase file size, but can be useful for visualizing the data
+    # with web mapping tools. See https://gdal.org/programs/gdaladdo.html for more.
+    add_overviews: bool()
+    # List of overview levels to create (if add_overviews=True).
+    overview_levels: list(int())
+    # Specify an extra reference datetime in UTC. Adding this lets you
+    # to create and unwrap two single reference networks; the later resets at
+    # the given date (e.g. for a large earthquake event). If passing strings,
+    # formats accepted are YYYY-MM-DD[T]HH:MM[:SS[.ffffff]][Z or [±]HH[:]MM],
+    # or YYYY-MM-DD
+    extra_reference_date: any(str(), null())
+
+# JSON file containing frame-specific algorithm parameters to override the
+# defaults passed in the `algorithm_parameters.yaml`.
+algorithm_parameters_overrides_json: any(str(), null())
+# Name of the subdataset to use in the input NetCDF files.
+subdataset: str()
+# Spatial wavelength cutoff (in meters) for the spatial filter. Used to
+# create the short wavelength displacement layer
+spatial_wavelength_cutoff: num()
+# `vmin, vmax` matplotlib arguments (in meters) passed to browse image creator.
+browse_image_vmin_vmax: list(num(), min=2, max=2)
+# When creating `recommended_mask`, pixels with temporal coherence below this threshold and with similarity below
+# `recommended_similarity_threshold` are masked.
+recommended_temporal_coherence_threshold: num()
+# When creating `recommended_mask`, pixels with similarity below this threshold and with temporal coherence below
+# `recommended_temporal_coherence_threshold` are masked.
+recommended_similarity_threshold: num()
+# Number of output products to create in parallel.
+num_parallel_products: int()
+# When creating `recommended_mask`, use the `connected_component_label` layer to hide pixels whose label == 0.
+recommended_use_conncomp: bool()
+---
+x_y_object:
+    x: int()
+    y: int()

--- a/conf/schema/AlgoParams_schema.L3_DSWx_S1.yaml
+++ b/conf/schema/AlgoParams_schema.L3_DSWx_S1.yaml
@@ -1,0 +1,241 @@
+runconfig:
+    name: str()
+
+    processing:
+        # Algorithms for surface water extents
+        # ['opera_dswx_s1', 'twele', 'opera_dswx_s1_inundated_vegetation']
+        dswx_workflow: str(required=False)
+
+        # Polarizations to be used for DSWx-SAR
+        # [polarizations] for list of specific frequency(s) e.g. [VV, VH] or [VV]
+        # 'dual-pol', 'co-pol', 'cross-pol' will search the polarizations Input GeoTiff files have.
+        # For example, 'co-pol' uses ['HH'], ['VV'], or ['HH', 'VV'] by looking at the input data.
+        polarizations: any(list(str(min=2, max=10), min=1, max=4), str(min=4, max=4), null(), required=False)
+        # Additional for polarimetric computations to be performed in specific polarization modes (co/cross and co + cross)
+        polarimetric_option: any(list(enum('ratio', 'span'), min=1, max=2), enum('ratio', 'span'), null(), required=False)
+
+        # Specify the max_value for permanent water and no_data_value for invalid pixels
+        reference_water:
+            max_value: num(required=False)
+            no_data_value: num(required=False)
+            permanent_water_value: num(required=False)
+            drought_erosion_pixel: int(required=False)
+            flood_dilation_pixel: int(required=False)
+
+        hand:
+            mask_value: num(required=False)
+
+        ocean_mask:
+            # Flag to apply ocean mask
+            mask_enabled: bool(required=False)
+            # Margin to apply ocean mask in km
+            mask_margin_km: int(required=False)
+            # Flag if the polygon is water
+            mask_polygon_water: bool(required=False)
+
+        mosaic:
+            mosaic_prefix: str(required=False)
+            mosaic_cog_enable: bool(required=False)
+            mosaic_mode: str(required=False)
+        # Flag to turn on/off the filtering for RTC image.
+        # The enhanced Lee filter is available.
+        filter:
+            enabled: bool(required=False)
+            method: str(required=False)
+            line_per_block: num(min=1, required=False)
+            block_pad: num(min=1, required=False)
+            lee_filter:
+                window_size: num(min=1, required=False)
+            guided_filter:
+                # Radius of the kernel used in the Guided Filter.
+                radius: num(min=1, required=False)
+                # Regularization parameter in Guided Filter to smooth within
+                # a radius. Default is 3.
+                eps: num(required=False)
+                # The depth of the output image.
+                ddepth: num(required=False)
+            bregman:
+                # The regularization parameter for TV Bregman denoising.
+                # It controls the amount of smoothing. Higher values
+                # produce more smoothed results.
+                lambda_value: num(required=False)
+            anisotropic_diffusion:
+                # Denoising weight. The greater the weight, the more
+                # denoising (at the expense of fidelity to image).
+                weight: num(required=False)
+
+        initial_threshold:
+            # Maximum tile size for initial threshold.
+            maximum_tile_size:
+                x: num(required=False)
+                y: num(required=False)
+            # Minimum tile size for initial threshold.
+            minimum_tile_size:
+                x: num(required=False)
+                y: num(required=False)
+            # Tile selecting strategy to identify the boundary between water and nonwater
+            # ['twele', 'chini', 'bimodality', 'combined']
+            # 'combined' option applies all selection strategy
+            selection_method: list(enum('twele', 'chini', 'bimodality', 'combined'), min=1, max=3, required=False)
+            # Thresholds to select tiles showing the boundary between water and nonwater
+            # three values are required for twele method
+            # 1) std / mean of tiles
+            # 2) min value and 3) max value of mean of subtiles / mean of tiles
+            tile_selection_twele: list(required=False)
+            # Thresholds to select tiles showing the boundary between water and nonwater
+            # using bimodality strategy.
+            # One values are required for bimodality method
+            tile_selection_bimodality: num(required=False)
+            # Strategy to interpolate the tile-based thresholds.
+            # Currently, only 'smoothed' is available.
+            extending_method: str(required=False)
+            # Thresholding algorithm for initial thresholds.
+            # Currently, 1) Otsu and 2) Kittler-Illingworth algorithms are available.
+            # ['otsu', 'ki']
+            threshold_method: str(required=False)
+            # Thresholding boundary values in dB. The boundary values are computed internally
+            # using the statics of the rtc image. If the values are out of the given range,
+            # adopt these values instead of the computed values
+            threshold_bounds:
+                co_pol: list(required=False)
+                cross_pol: list(required=False)
+            # Flag to assume the trimodal distribution.
+            # If flag is false, the distribution is assumed to have bimodal distribution and
+            # estimate single threshold per tile. If True, the trimodal distribution is assumed,
+            # the lowest threshold is estimated.
+            multi_threshold: bool(required=False)
+            # Flag to adjust threshold where two gaussian distribution is not overlapped.
+            # If 'adjust_if_nonoverlap' is enabled,
+            # start to search the alternative threshold when two distributions are not
+            # overlapped. The 'low_dist_percentile' is the percentile of
+            # the low distribution and 'high_dist_percentile' is the percentile of
+            # the high distribution. Both values should be within range of 0 to 1.
+            adjust_if_nonoverlap: bool(required=False)
+            low_dist_percentile: num(required=False, min=0, max=1)
+            high_dist_percentile: num(required=False, min=0, max=1)
+            # Flag to average the thresholds within the tile.
+            # The output thresholds are assigned to each tile.
+            tile_average: bool(required=False)
+            # Number of threads to run
+            # -1 represents the all available threads
+            number_cpu: num(required=False)
+            line_per_block: num(min=1, required=False)
+
+        fuzzy_value:
+            line_per_block: num(min=1, required=False)
+            hand:
+                # Min and max values for hand are automatically calculated
+                # from input HAND, but they are not given,
+                # below values are used.
+                member_min: num(required=False)
+                member_max: num(required=False)
+            # Membership bound for slope angle
+            slope:
+                member_min: num(required=False)
+                member_max: num(required=False)
+            # Membership bound for reference water
+            reference_water:
+                # Minimum reference water value for membership
+                member_min: num(required=False)
+                # Maximum reference water value for membership
+                member_max: num(required=False)
+            # Membership bound for area of initial water bodies.
+            # Area membership is only required for 'twele' workflow.
+            area:
+                member_min: num(required=False)
+                member_max: num(required=False)
+            # Dark area is defined where cross-pol is lower than cross_land
+            # Water is defined where cross-pol is lower than cross_water
+            dark_area:
+                # Threshold [dB] for land in the dark area definition
+                cross_land: num(required=False)
+                # Threshold [dB] for water in the dark area definition
+                cross_water: num(required=False)
+            # High frequent water is defined based on two values
+            # water_min_value < high_frequent_water < water_max_value
+            high_frequent_water:
+                # Minimum value for high frequent water
+                water_min_value: num(required=False)
+                # Maximum value for high frequent water
+                water_max_value: num(required=False)
+
+        region_growing:
+            # Seed value for region growing start
+            initial_threshold: num(min=0, max=1, required=False)
+            # Value where region growing is stopped
+            relaxed_threshold: num(min=0, max=1, required=False)
+            line_per_block: num(min=1, required=False)
+
+        masking_ancillary:
+            # Land covers that behaves like dark lands in DSWx-SAR.
+            # The elements should be in given landcover file.
+            # The elements will be masked out during this step.
+            land_cover_darkland_list: list(required=False)
+            # The elements is considered as the dark land candidates
+            # where these elements are spatially connected to the dark land.
+            land_cover_darkland_extension_list: list(required=False)
+            land_cover_water_label: list(required=False)
+            # VV and VH threshold values for dark land candidates
+            co_pol_threshold: num(min=-30, max=10, required=False)
+            cross_pol_threshold: num(min=-30, max=10, required=False)
+            # Reference water threshold value for dark land candidates
+            water_threshold: num(min=0, max=100, required=False)
+            minimum_pixel: num(min=0, required=False)
+            # Flag to enable the darkland extension.
+            extended_darkland: bool(required=False)
+            extended_darkland_minimum_pixel: int(required=False)
+            extended_darkland_water_buffer: int(required=False, min=0)
+            # Assuming the height of the water/land boundaries has low
+            # variation, the standard deviation is estimated along the boundaries
+            # and removed if the std is high.
+            hand_variation_mask: bool(required=False)
+            # pixels with HAND threshold is masked out.
+            hand_variation_threshold: num(min=0, max=100, required=False)
+            line_per_block: num(min=1, required=False)
+            number_cpu: num(required=False)
+
+        refine_with_bimodality:
+            number_cpu: num(required=False)
+            lines_per_block: num(min=1, required=False)
+            minimum_pixel: num(min=0, required=False)
+            thresholds:
+                ashman: num(min=0, required=False)
+                Bhattacharyya_coefficient: num(min=0, required=False)
+                bm_coefficient: num(min=0, required=False)
+                surface_ratio: num(min=0, required=False)
+
+        inundated_vegetation:
+            # 'auto' determine the inundated vegetation availability
+            # based on available cross-polarizations
+            enabled: enum(True, False, 'auto')
+            dual_pol_ratio_max: num(min=0, max=30, required=False)
+            dual_pol_ratio_min: num(min=0, max=30, required=False)
+            dual_pol_ratio_threshold: num(min=0, max=30, required=False)
+            cross_pol_min: num(min=-30, max=10, required=False)
+            line_per_block: num(min=1, required=False)
+            # If 'auto' is selected and GLAD is available, GLAD will be
+            # used for inundated vegetation. In the 'auto' option,
+            # GLAD is not provided, then WorldCover will be used to extract
+            # the target areas.
+            target_area_file_type: enum('WorldCover', 'GLAD', 'auto')
+            # Land covers where the inundated vegetation is detected.
+            target_worldcover_class: list(required=False)
+            target_glad_class: list(required=False)
+            filter:
+                enabled: bool(required=False)
+                method: str(required=False)
+                line_per_block: num(min=1, required=False)
+                block_pad: num(min=1, required=False)
+                lee_filter:
+                    window_size: num(min=1, required=False)
+                guided_filter:
+                    radius: num(min=1, required=False)
+                    eps: num(required=False)
+                    ddepth: num(required=False)
+                bregman:
+                    lambda_value: num(required=False)
+                anisotropic_diffusion:
+                    weight: num(required=False)
+
+        # If debug mode is true, intermediate product is generated.
+        debug_mode: bool(required=False)

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -181,9 +181,6 @@ DISP_S1:
   FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.7/opera-s1-disp-0.9.0-frame-to-burst.json"
   # S3 path to the reference date database JSON file to download for all DISP-S1 jobs
   REFERENCE_DATE_DATABASE_JSON: "s3://opera-ancillaries/disp_frames/disp_s1_frame_reference_dates/opera-disp-s1-reference-dates-2025-02-13.json"
-  # S3 path to the algorithm parameters YAML file to download for all DISP-S1 jobs
-  # Note that the {processing_mode} placeholder is required, and will be automatically filled in with "forward" or "historical" based on the type of DISP-S1 job triggered
-  ALGORITHM_PARAMETERS_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.7/algorithm_parameters_{processing_mode}.yaml.tmpl"
   # S3 path to the algorithm parameters override JSON file to download for all DISP-S1 jobs
   ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.7/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
 

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -26,12 +26,13 @@ runconfig:
     reference_date_database_json: __CHIMERA_VAL__
   product_path_group:
     product_version: __CHIMERA_VAL__
+    input_path: /home/mamba/input_dir
     product_path: /home/mamba/output_dir
     scratch_path: /home/mamba/scratch_dir
     save_compressed_slc: __CHIMERA_VAL__
   processing:
+    polarization: __CHIMERA_VAL__
     frame_id: __CHIMERA_VAL__
-    algorithm_parameters: __CHIMERA_VAL__
     algorithm_parameters_overrides_json: __CHIMERA_VAL__
     product_type: __CHIMERA_VAL__
     threads_per_worker: __CHIMERA_VAL__
@@ -56,8 +57,6 @@ preconditions:
   - get_disp_s1_mask_file
   - get_disp_s1_dem
   - get_disp_s1_save_compressed_slc
-  - get_disp_s1_algorithm_parameters
-  - instantiate_algorithm_parameters_template
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
@@ -83,15 +82,6 @@ get_disp_s1_mask_file:
   s3_bucket: "opera-water-mask"
   s3_key: "v0.3/EPSG4326.vrt"
 
-get_disp_s1_algorithm_parameters:
-  # This S3 path only defines a location pattern of an algorithm parameters template file,
-  # the processing mode (forward vs. historical) will be filled in by the function itself
-  settings_key: "DISP_S1.ALGORITHM_PARAMETERS_YAML"
-
-instantiate_algorithm_parameters_template:
-  template_mapping:
-    polarization: __POLARIZATION__
-
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:
    daac_product_type: daac_product_type
@@ -114,6 +104,10 @@ pge_name: "L3_DISP_S1"
 # Set the primary input/output types here
 primary_input: "L2_CSLC_S1"
 primary_output: "L3_DISP_S1"
+
+# Must be set to true to ensure algorithm parameter template is instantiated
+# for every DISP-S1 job
+use_algorithm_parameters: true
 
 # List the groups that Chimera will need to localize
 # The entries MUST reference a property of `$.runconfig` of this YAML.

--- a/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DSWx_S1.yaml
@@ -27,10 +27,11 @@ runconfig:
     mgrs_collection_database_file: __CHIMERA_VAL__
   product_path_group:
     product_version: __CHIMERA_VAL__
+    input_path: /home/dswx_user/input_dir
     product_path: /home/dswx_user/output_dir
     scratch_path: /home/dswx_user/scratch_dir
   processing:
-    algorithm_parameters: __CHIMERA_VAL__
+    num_workers: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
@@ -44,8 +45,6 @@ preconditions:
   - get_dswx_s1_dynamic_ancillary_maps
   - get_dswx_s1_dem
   - get_dswx_s1_num_workers
-  - get_dswx_s1_algorithm_parameters
-  - instantiate_algorithm_parameters_template
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
@@ -93,14 +92,6 @@ get_dswx_s1_dem:
   s3_bucket: "opera-dem"
   s3_key: "v1.1"
 
-get_dswx_s1_algorithm_parameters:
-  s3_bucket: "opera-ancillaries"
-  s3_key: "algorithm_parameters/dswx_s1/dswx_s1_algorithm_parameters_final_1.0.0.yaml.tmpl"
-
-instantiate_algorithm_parameters_template:
-  template_mapping:
-    num_workers: __NUMBER_CPU__
-
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:
    daac_product_type: daac_product_type
@@ -122,6 +113,10 @@ pge_name: "L3_DSWx_S1"
 # Set the primary input/output types here
 primary_input: "L2_RTC_S1"
 primary_output: "L3_DSWx_S1"
+
+# Must be set to true to ensure algorithm parameter template is instantiated
+# for every DSWx-S1 job
+use_algorithm_parameters: true
 
 # List the groups that Chimera will need to localize
 # The entries MUST reference a property of `$.runconfig` of this YAML.

--- a/util/conf_util.py
+++ b/util/conf_util.py
@@ -108,18 +108,20 @@ class RunConfig(object):
         tmpl_file_dir = norm_path(os.path.join(os.path.dirname(__file__), "..", "conf"))
         file_loader = FileSystemLoader(tmpl_file_dir)
         env = Environment(loader=file_loader)
+
         template = env.get_template(
             "RunConfig.yaml.{}.jinja2.tmpl".format(template_type)
         )
+
         self._template_type = template_type
-        self._rendered_rc = template.render(data=rc_data)
+        self._rendered_rc = template.render(runconfig=rc_data)
 
     def validate(self, rc_file, template_type):
-
         try:
             schema_file = os.path.join(os.path.dirname(__file__), "..", "conf", "schema",
                                        "RunConfig_schema.{}.yaml".format(template_type))
             schema = yamale.make_schema(schema_file)
+
             # Create a Data object
             data = yamale.make_data(rc_file)
             yamale.validate(schema, data)

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -102,11 +102,6 @@ def dswx_s1_lineage_metadata(context, work_dir):
     local_db_filepaths = glob.glob(os.path.join(work_dir, "*.sqlite*"))
     lineage_metadata.extend(local_db_filepaths)
 
-    local_algorithm_parameters_filepath = os.path.join(
-        work_dir, basename(run_config["processing"]["algorithm_parameters"])
-    )
-    lineage_metadata.append(local_algorithm_parameters_filepath)
-
     return lineage_metadata
 
 
@@ -166,11 +161,6 @@ def disp_s1_lineage_metadata(context, work_dir):
 
     local_mask_filepaths = glob.glob(os.path.join(work_dir, "*mask*.*"))
     lineage_metadata.extend(local_mask_filepaths)
-
-    local_algorithm_parameters_filepath = os.path.join(
-        work_dir, basename(run_config["processing"]["algorithm_parameters"])
-    )
-    lineage_metadata.append(local_algorithm_parameters_filepath)
 
     # Algorithm parameters overrides has already been downloaded to local disk
     local_algorithm_parameters_overrides_filepath = run_config["processing"]["algorithm_parameters_overrides_json"]
@@ -363,9 +353,6 @@ def update_dswx_s1_runconfig(context, work_dir):
     }
     run_config["static_ancillary_file_group"] = updated_static_ancillary_file_paths
 
-    algorithm_parameters_filename = basename(run_config["processing"]["algorithm_parameters"])
-    run_config["processing"]["algorithm_parameters"] = f'{container_home_prefix}/{algorithm_parameters_filename}'
-
     return run_config
 
 
@@ -452,8 +439,8 @@ def update_disp_s1_runconfig(context, work_dir):
                          os.path.basename(run_config["dynamic_ancillary_file_group"]["mask_file"]))
         )
 
-    run_config["processing"]["algorithm_parameters"] = (
-        os.path.join(container_home_prefix, os.path.basename(run_config["processing"]["algorithm_parameters"]))
+    run_config["processing"]["algorithm_parameters_overrides_json"] = (
+        os.path.join(container_home_prefix, os.path.basename(run_config["processing"]["algorithm_parameters_overrides_json"]))
     )
 
     return run_config


### PR DESCRIPTION
## Purpose
- To address an issue with how an Algorithm Parameters config can sometimes reference another static ancillary input (such as a parameters override config), this branch reworks how Algorithm Parameters are instantiated from template to bring them in line with how the baseline RunConfig is generated. Currently, this only affects the DSWx-S1 and DISP-S1 PGE workflows.
- Rather than download a simple find/replace template for algo params from S3, there are now Jinja2 templates for them within the `conf` directory, as well as the corresponding Yamale schemas to verify contents of an instantiated template within PCM.
- The algo param templates are instantiated using the values derived from `opera_chimera` precondition functions in the same way as the baseline RunConfig
- The path to the instantiated algo parameters file is now fixed within the corresponding RunConfig template
- To enable instantiation of the algo parameters config, the `use_algorithm_parameters` option must be set to `True` in the corresponding chimera PGE config.
- Jinja2 template instantiation now uses `runconfig` as the top-level name of the dictionary containing the values to instantiate with. Previously this was `data`, which made the mapping from placeholders to values confusing in the actual templates.

## Issues
- Fixes #1125

## Testing
- Branch has been tested on a dev cluster by submitting DISP-S1 and DSWx-S1 jobs in both real and simulation mode to ensure the Algorithm Parameters are instantiated as expected.
- Modifying the Algorithm Parameters Override file referenced in settings.yaml has also been tested to ensure the correct path is reflected in the instantiated Algorithm Parameters.
