### PR TITLE
DISP-S1 PGE v3.0.6 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -365,9 +365,9 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.3"
     "cslc_s1"  = "2.1.1"
-    "rtc_s1"   = "2.1.1" 
+    "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.5"
+    "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
     "tropo"    = "3.0.0-er.1.0-tropo"
@@ -494,7 +494,7 @@ variable "amis" {
 }
 
 variable "cnm_r_sqs_arn" {
-} 
+}
 
 variable "asf_cnm_s_id_dev" {
 }
@@ -520,4 +520,4 @@ variable "clear_s3_aws_es" {
 variable "disp_s1_hist_status" {
   type    = bool
   default = false
-} 
+}

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -163,7 +163,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.5"
+    "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.1.0"
     "tropo"    = "3.0.0-er.1.0-tropo"

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -368,7 +368,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.5"
+    "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
     "tropo"    = "3.0.0-er.1.0-tropo"
@@ -469,15 +469,15 @@ variable "earthdata_pass" {
 variable "earthdata_uat_user" {
   default = ""
 }
-  
+
 variable "earthdata_uat_pass" {
   default = ""
 }
-  
+
 variable "disp_s1_hist_status" {
   type    = bool
   default = false
-}  
+}
 
 variable "amis" {
   type = map(string)

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -34,7 +34,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.5"
+    "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
     "tropo"    = "3.0.0-er.1.0-tropo"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -675,9 +675,9 @@ variable "use_daac_cnm_r" {
 }
 
 variable "cnm_r_sqs_arn" {
-  type = map(string)      
+  type = map(string)
   default = {
-  } 
+  }
 }
 
 variable "lambda_log_retention_in_days" {
@@ -692,7 +692,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.1"
     "rtc_s1"   = "2.1.1"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.5"
+    "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-er.2.0"
   }

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -159,8 +159,8 @@ L3_DISP_S1:
         verify: false
     Optional:
       # Pattern for parsing Compressed CSLC output filenames, such as:
-      # * "OPERA_L2_COMPRESSED-CSLC-S1_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
+      # * "OPERA_L2_COMPRESSED-CSLC-S1_F11114_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\d{5})_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
         verify: true
         hash: md5
 
@@ -243,7 +243,7 @@ L4_TROPO:
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
-      # OPERA_L4_TROPO_20250411T173117.log 
+      # OPERA_L4_TROPO_20250411T173117.log
       - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L4)_(?P<product_type>TROPO)_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})))?[.](?P<ext>log|catalog\.json|qa\.log)$'
         verify: false
     Optional: []

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -160,7 +160,7 @@ L3_DISP_S1:
     Optional:
       # Pattern for parsing Compressed CSLC output filenames, such as:
       # * "OPERA_L2_COMPRESSED-CSLC-S1_F11114_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\d{5})_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<disp_frame_id>F\d{5})_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
         verify: true
         hash: md5
 

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -364,7 +364,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_COMPRESSED",
       "level": "L2",
       "type": "L2_CSLC_S1_COMPRESSED",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\\d{5})_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -364,7 +364,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_COMPRESSED",
       "level": "L2",
       "type": "L2_CSLC_S1_COMPRESSED",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\\d{5})_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<disp_frame_id>F\\d{5})_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -364,7 +364,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_COMPRESSED",
       "level": "L2",
       "type": "L2_CSLC_S1_COMPRESSED",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\\d{5})_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -364,7 +364,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_COMPRESSED",
       "level": "L2",
       "type": "L2_CSLC_S1_COMPRESSED",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\\d{5})_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<disp_frame_id>F\\d{5})_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<ref_date_time>\\d{8})T000000Z_(?P<first_date_time>\\d{8})T000000Z_(?P<last_date_time>\\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -482,9 +482,9 @@ PRODUCT_TYPES:
 
     L2_CSLC_S1_COMPRESSED:
       # Pattern for parsing filenames such as:
-      # * "OPERA_L2_COMPRESSED-CSLC-S1_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
+      # * "OPERA_L2_COMPRESSED-CSLC-S1_F11114_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\d{5})_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
       Configuration:

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -484,7 +484,7 @@ PRODUCT_TYPES:
       # Pattern for parsing filenames such as:
       # * "OPERA_L2_COMPRESSED-CSLC-S1_F11114_T078-165495-IW3_20190906T000000Z_20190906T000000Z_20191108T000000Z_20230101T100506Z_VV_v1.0.h5"
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<frame_id>F\d{5})_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>COMPRESSED-CSLC)-(?P<source>S1)_(?P<disp_frame_id>F\d{5})_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<ref_date_time>\d{8})T000000Z_(?P<first_date_time>\d{8})T000000Z_(?P<last_date_time>\d{8})T000000Z_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
       Configuration:

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.5",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.6",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.5",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.6",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.5",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.6",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
       "container_mappings": {
         "$HOME/.netrc": ["/root/.netrc"],
         "$HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -26,8 +26,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/disp_s1:3.0.5",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.5.tar.gz",
+          "container_image_name": "opera_pge/disp_s1:3.0.6",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
           "container_mappings": {
             "$HOME/.netrc": ["/root/.netrc"],
             "$HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -130,4 +130,4 @@ input_file_base_name_regexes:
 sample_input_dataset_id: "OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20160822T000000Z_S1A_VV_v0.1"
 output_base_name: OPERA_L3_DISP-S1_IW_{frame_id}_{pol}_{ref_datetime}Z_{sec_datetime}Z_{product_version}_{creation_ts}Z
 ancillary_base_name: OPERA_L3_DISP-S1_IW_{frame_id}_{product_version}_{creation_ts}Z
-compressed_cslc_name: OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_{ref_date}T000000Z_{first_date}T000000Z_{last_date}T000000Z_{creation_ts}Z_{pol}_{product_version}
+compressed_cslc_name: OPERA_L2_COMPRESSED-CSLC-S1_{frame_id}_{burst_id}_{ref_date}T000000Z_{first_date}T000000Z_{last_date}T000000Z_{creation_ts}Z_{pol}_{product_version}

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -130,4 +130,4 @@ input_file_base_name_regexes:
 sample_input_dataset_id: "OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20160822T000000Z_S1A_VV_v0.1"
 output_base_name: OPERA_L3_DISP-S1_IW_{frame_id}_{pol}_{ref_datetime}Z_{sec_datetime}Z_{product_version}_{creation_ts}Z
 ancillary_base_name: OPERA_L3_DISP-S1_IW_{frame_id}_{product_version}_{creation_ts}Z
-compressed_cslc_name: OPERA_L2_COMPRESSED-CSLC-S1_{frame_id}_{burst_id}_{ref_date}T000000Z_{first_date}T000000Z_{last_date}T000000Z_{creation_ts}Z_{pol}_{product_version}
+compressed_cslc_name: OPERA_L2_COMPRESSED-CSLC-S1_{disp_frame_id}_{burst_id}_{ref_date}T000000Z_{first_date}T000000Z_{last_date}T000000Z_{creation_ts}Z_{pol}_{product_version}

--- a/tests/unit/util/test_pge_util.py
+++ b/tests/unit/util/test_pge_util.py
@@ -432,7 +432,7 @@ def test_simulate_disp_s1_pge():
     creation_ts = pge_util.get_time_for_filename()
     expected_output_basename = 'OPERA_L3_DISP-S1_IW_F10859_VV_20160705T000000Z_20160822T000000Z_v0.1_{creation_ts}Z'
     expected_ancillary_basename = 'OPERA_L3_DISP-S1_IW_F10859_v0.1_{creation_ts}Z'
-    expected_compressed_cslc_basename = 'OPERA_L2_COMPRESSED-CSLC-S1_{burst_id}_20160705T000000Z_20160822T000000Z_20160915T000000Z_{creation_ts}Z_VV_v0.1'
+    expected_compressed_cslc_basename = 'OPERA_L2_COMPRESSED-CSLC-S1_F10859_{burst_id}_20160705T000000Z_20160822T000000Z_20160915T000000Z_{creation_ts}Z_VV_v0.1'
 
     try:
         assert Path(f'/tmp/{expected_output_basename.format(creation_ts=creation_ts)}.nc').exists()

--- a/tools/stage_ionosphere_file.py
+++ b/tools/stage_ionosphere_file.py
@@ -168,7 +168,7 @@ def parse_start_date_from_cslc(input_cslc_file):
     # Parse the CSLC file name with the following regex, derived from the
     # official naming conventions
     cslc_regex_pattern = (
-        r"OPERA_L2_(COMPRESSED-)?CSLC-S1_(?P<burst_id>\w{4}-\w{6}-\w{3})_"
+        r"OPERA_L2_(COMPRESSED-)?CSLC-S1_(?P<frame_id>F\d{5}_)?(?P<burst_id>\w{4}-\w{6}-\w{3})_"
         r"(?P<acquisition_ts>\d{8}T\d{6})Z_.*"
     )
     cslc_regex = re.compile(cslc_regex_pattern)

--- a/tools/stage_ionosphere_file.py
+++ b/tools/stage_ionosphere_file.py
@@ -168,7 +168,7 @@ def parse_start_date_from_cslc(input_cslc_file):
     # Parse the CSLC file name with the following regex, derived from the
     # official naming conventions
     cslc_regex_pattern = (
-        r"OPERA_L2_(COMPRESSED-)?CSLC-S1_(?P<frame_id>F\d{5}_)?(?P<burst_id>\w{4}-\w{6}-\w{3})_"
+        r"OPERA_L2_(COMPRESSED-)?CSLC-S1_(?P<disp_frame_id>F\d{5}_)?(?P<burst_id>\w{4}-\w{6}-\w{3})_"
         r"(?P<acquisition_ts>\d{8}T\d{6})Z_.*"
     )
     cslc_regex = re.compile(cslc_regex_pattern)

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -655,7 +655,7 @@ def get_disp_s1_simulated_output_filenames(dataset_match, pge_config, extension)
     elif extension.endswith('h5'):
         for burst_id in CCSLC_BURST_IDS:
             base_name = compressed_cslc_template.format(
-                frame_id="F10859",
+                disp_frame_id="F10859",
                 burst_id=burst_id,
                 ref_date="20160705",
                 first_date="20160822",

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -655,6 +655,7 @@ def get_disp_s1_simulated_output_filenames(dataset_match, pge_config, extension)
     elif extension.endswith('h5'):
         for burst_id in CCSLC_BURST_IDS:
             base_name = compressed_cslc_template.format(
+                frame_id="F10859",
                 burst_id=burst_id,
                 ref_date="20160705",
                 first_date="20160822",
@@ -798,7 +799,7 @@ def get_tropo_simulated_output_filenames(dataset_match, pge_config, extension):
         output_filenames.append(f'{base_name}.qa.log')
     elif extension.endswith('catalog.json'):
         output_filenames.append(f'{base_name}.catalog.json')
-    
+
     return output_filenames
 
 def simulate_output(pge_name: str, pge_config: dict, dataset_match: re.Match, output_dir: str, extensions: str):


### PR DESCRIPTION
## Purpose
- This branch integrates the DISP-S1 PGE v3.0.6 with OPERA PCM. This version continues to wrap the previous SAS delivery, but incorporates the DISP frame number into the output Compressed-CSLC file names to avoid potential collisions when adjacent frames share an input CSLC burst.

## Issues
- Resolves #1156 

## Testing
- Branch has been tested on a dev cluster by running the following:
  - DISP-S1 PGE workflow using simulation mode
  - DISP-S1 PGE workflow using real mode
  - DISP-S1 PGE smoke test
- Changes to the CCSLC output file name has been visually inspected in S3 and within the ES index for CCSLC products:

In S3
<img width="1777" alt="Screenshot 2025-05-13 at 12 27 12 PM" src="https://github.com/user-attachments/assets/71f5eeb4-bac7-4374-a2b6-0f9476bdefcd" />


In ES
<img width="1369" alt="Screenshot 2025-05-13 at 12 35 29 PM" src="https://github.com/user-attachments/assets/6972c1b0-9adc-4eb1-b12a-3de5556ff4d2" />

