### PR TITLE
Integrate latest releases of CSLC-S1 and RTC-S1 PGEs

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -368,8 +368,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.3"
-    "cslc_s1"  = "2.1.1"
-    "rtc_s1"   = "2.1.1"
+    "cslc_s1"  = "2.1.3"
+    "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -119,8 +119,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.3"
-    "cslc_s1"  = "2.1.1"
-    "rtc_s1"   = "2.1.1"
+    "cslc_s1"  = "2.1.3"
+    "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -368,8 +368,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.3"
-    "cslc_s1"  = "2.1.1"
-    "rtc_s1"   = "2.1.1"
+    "cslc_s1"  = "2.1.3"
+    "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -31,8 +31,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.3"
-    "cslc_s1"  = "2.1.1"
-    "rtc_s1"   = "2.1.1"
+    "cslc_s1"  = "2.1.3"
+    "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -697,8 +697,8 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.3"
-    "cslc_s1"  = "2.1.1"
-    "rtc_s1"   = "2.1.1"
+    "cslc_s1"  = "2.1.3"
+    "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
     "disp_s1"  = "3.0.6"
     "dswx_ni"  = "4.0.0-er.3.0"

--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -44,7 +44,7 @@ RunConfig:
         ErrorCodeBase: 200000
         SchemaPath: /home/compass_user/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
         IsoTemplatePath: /home/compass_user/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
-{#        IsoMeasuredParameterDescriptions: /home/compass_user/opera/pge/cslc_s1/templates/cslc_s1_measured_parameters.yaml#}
+        IsoMeasuredParameterDescriptions: /home/compass_user/opera/pge/cslc_s1/templates/cslc_s1_measured_parameters.yaml
       QAExecutable:
         Enabled: False
         ProgramPath:

--- a/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
@@ -44,7 +44,7 @@ RunConfig:
         ErrorCodeBase: 200000
         SchemaPath: /home/compass_user/opera/pge/cslc_s1/schema/cslc_s1_sas_schema.yaml
         IsoTemplatePath: /home/compass_user/opera/pge/cslc_s1/templates/OPERA_ISO_metadata_L2_CSLC_S1_template.xml.jinja2
-{#        IsoMeasuredParameterDescriptions: /home/compass_user/opera/pge/cslc_s1/templates/cslc_s1_static_measured_parameters.yaml#}
+        IsoMeasuredParameterDescriptions: /home/compass_user/opera/pge/cslc_s1/templates/cslc_s1_static_measured_parameters.yaml
         DataValidityStartDate: {{ runconfig.product_path_group.data_validity_start_date }}
       QAExecutable:
         Enabled: False

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -45,7 +45,7 @@ RunConfig:
         ErrorCodeBase: 300000
         SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
         IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
-{#        IsoMeasuredParameterDescriptions: /home/rtc_user/opera/pge/rtc_s1/templates/rtc_s1_measured_parameters.yaml#}
+        IsoMeasuredParameterDescriptions: /home/rtc_user/opera/pge/rtc_s1/templates/rtc_s1_measured_parameters.yaml
       QAExecutable:
         Enabled: False
         ProgramPath:

--- a/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
@@ -45,7 +45,7 @@ RunConfig:
         ErrorCodeBase: 300000
         SchemaPath: /home/rtc_user/opera/pge/rtc_s1/schema/rtc_s1_sas_schema.yaml
         IsoTemplatePath: /home/rtc_user/opera/pge/rtc_s1/templates/OPERA_ISO_metadata_L2_RTC_S1_template.xml.jinja2
-{#        IsoMeasuredParameterDescriptions: /home/rtc_user/opera/pge/rtc_s1/templates/rtc_s1_static_measured_parameters.yaml#}
+        IsoMeasuredParameterDescriptions: /home/rtc_user/opera/pge/rtc_s1/templates/rtc_s1_static_measured_parameters.yaml
         DataValidityStartDate: {{ runconfig.product_path_group.data_validity_start_date }}
       QAExecutable:
         Enabled: False

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -26,13 +26,13 @@ L2_CSLC_S1:
       # Pattern for parsing primary (per-burst) output filenames, such as:
       # OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20230807T212944Z_S1A_VV_v1.0.h5
       # OPERA_L2_CSLC-S1_T064-135518-IW2_20220501T015035Z_20230807T212944Z_S1A_VV_v1.0_BROWSE.png
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV))?_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV))?_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # OPERA_L2_CSLC-S1_20230807T234233Z_S1A_VV_v1.0.log
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>log|qa\.log|catalog\.json)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>log|qa\.log|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames
@@ -46,13 +46,13 @@ L2_CSLC_S1_STATIC:
       # Pattern for parsing primary (per-burst) output filenames, such as:
       # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_S1A_v1.0.h5
       # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_S1A_v1.0_BROWSE.h5
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<sensor>S1A|S1B)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<sensor>S1[A-C])_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # OPERA_L2_CSLC-S1_20230807T234233Z_S1A_VV_v1.0.log
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>log|qa\.log|catalog\.json)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>log|qa\.log|catalog\.json)$'
         verify: false
     Optional: []
       # Pattern for optional output product filenames

--- a/conf/pge_outputs.yaml
+++ b/conf/pge_outputs.yaml
@@ -68,13 +68,13 @@ L2_RTC_S1:
       # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_VV.tif
       # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_mask.tif
       # OPERA_L2_RTC-S1_T069-147175-IW1_20180504T104522Z_20230804T203850Z_S1B_30_v1.0_BROWSE.png
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_BROWSE|_mask)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_BROWSE|_mask)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # OPERA_L2_RTC-S1_20230109T203121Z_S1B_30_v1.0.log
-      - regex: !!python/regexp '(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+)[.](?P<ext>log|qa\.log|catalog\.json)'
+      - regex: !!python/regexp '(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+)[.](?P<ext>log|qa\.log|catalog\.json)'
         verify: false
     Optional: []
       # Pattern for optional output product filenames
@@ -88,13 +88,13 @@ L2_RTC_S1_STATIC:
       # Pattern for parsing primary (per-burst) output filenames, such as:
       # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0.h5
       # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0_incidence_angle.tif
-      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      - regex: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_date>\d{8})_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         verify: true
         hash: md5
     Secondary:
       # Patterns for parsing aux filenames, such as:
       # OPERA_L2_RTC-S1_20230109T203121Z_S1B_30_v1.0.log
-      - regex: !!python/regexp '(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+)[.](?P<ext>log|qa\.log|catalog\.json)'
+      - regex: !!python/regexp '(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+)[.](?P<ext>log|qa\.log|catalog\.json)'
         verify: false
     Optional: []
       # Pattern for optional output product filenames

--- a/conf/schema/RunConfig_schema.L2_RTC_S1.yaml
+++ b/conf/schema/RunConfig_schema.L2_RTC_S1.yaml
@@ -261,9 +261,6 @@ geocoding_options:
   # Memory mode
   memory_mode: enum('auto', 'single_block', 'geogrid', 'geogrid_and_radargrid', required=False)
 
-  # Processing upsampling factor on top of the input geogrid
-  geogrid_upsampling: int(required=False)
-
   # Save the incidence angle
   save_incidence_angle: bool(required=False)
 

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -172,7 +172,7 @@
       "ipath": "hysds::data/L2_CSLC_S1",
       "level": "L2",
       "type": "L2_CSLC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B|S1C)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1[A-C])_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -196,7 +196,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_STATIC",
       "level": "L2",
       "type": "L2_CSLC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B|S1C)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1[A-C])_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json
+++ b/conf/sds/files/datasets.json
@@ -220,7 +220,7 @@
       "ipath": "hysds::data/L2_RTC_S1",
       "level": "L2",
       "type": "L2_RTC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B|S1C)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -244,7 +244,7 @@
       "ipath": "hysds::data/L2_RTC_S1_STATIC",
       "level": "L2",
       "type": "L2_RTC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B|S1C)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -172,7 +172,7 @@
       "ipath": "hysds::data/L2_CSLC_S1",
       "level": "L2",
       "type": "L2_CSLC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B|S1C)_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1[A-C])_(?P<pol>VV|VH|HH|HV|VV\\+VH|HH\\+HV)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -196,7 +196,7 @@
       "ipath": "hysds::data/L2_CSLC_S1_STATIC",
       "level": "L2",
       "type": "L2_CSLC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B|S1C)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1[A-C])_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/sds/files/datasets.json.tmpl.asg
+++ b/conf/sds/files/datasets.json.tmpl.asg
@@ -220,7 +220,7 @@
       "ipath": "hysds::data/L2_RTC_S1",
       "level": "L2",
       "type": "L2_RTC_S1",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1A|S1B|S1C)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<acquisition_ts>(?P<acq_year>\\d{4})(?P<acq_month>\\d{2})(?P<acq_day>\\d{2})T(?P<acq_hour>\\d{2})(?P<acq_minute>\\d{2})(?P<acq_second>\\d{2})Z)_(?P<creation_ts>(?P<cre_year>\\d{4})(?P<cre_month>\\d{2})(?P<cre_day>\\d{2})T(?P<cre_hour>\\d{2})(?P<cre_minute>\\d{2})(?P<cre_second>\\d{2})Z)_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {
@@ -244,7 +244,7 @@
       "ipath": "hysds::data/L2_RTC_S1_STATIC",
       "level": "L2",
       "type": "L2_RTC_S1_STATIC",
-      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1A|S1B|S1C)_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
+      "match_pattern": "(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\\w{4}-\\w{6}-\\w{3})_(?P<validity_ts>(?P<validity_year>\\d{4})(?P<validity_month>\\d{2})(?P<validity_day>\\d{2}))_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\\d+[.]\\d+))$",
       "alt_match_pattern": null,
       "extractor": null,
       "publish": {

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -369,7 +369,7 @@ PRODUCT_TYPES:
         # OPERA_L2_RTC-S1_T069-147174-IW3_20180504T104521Z_20230804T203850Z_S1B_30_v1.0_mask.tif
         # OPERA_L2_RTC-S1_T069-147175-IW1_20180504T104522Z_20230804T203850Z_S1B_30_v1.0_BROWSE.png
         # This pattern groups the metadata information in the filename using named groups.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B|S1C)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_BROWSE|_mask)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)|_BROWSE|_mask)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:
@@ -386,7 +386,7 @@ PRODUCT_TYPES:
       # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0_incidence_angle.tif
       # OPERA_L2_RTC-S1-STATIC_T069-147178-IW3_20140101_S1B_30_v1.0_number_of_looks.tif
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<sensor>S1A|S1B|S1C)_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>RTC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<sensor>S1[A-C])_(?P<spacing>30)_(?P<product_version>v\d+[.]\d+))(_BROWSE|_(?P<static_layer_name>incidence_angle|mask|local_incidence_angle|number_of_looks|rtc_anf_gamma0_to_beta0|rtc_anf_gamma0_to_sigma0))?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
       Configuration:

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -336,7 +336,7 @@ PRODUCT_TYPES:
         # Pattern for parsing output L2_CSLC-S1 product filenames, such as:
         # OPERA_L2_CSLC-S1_T064-135518-IW1_20220501T015035Z_20230807T212944Z_S1A_VV_v1.0.h5
         # This pattern groups the metadata information in the filename using named groups.
-        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1A|S1B|S1C)_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
+        Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<acquisition_ts>(?P<acq_year>\d{4})(?P<acq_month>\d{2})(?P<acq_day>\d{2})T(?P<acq_hour>\d{2})(?P<acq_minute>\d{2})(?P<acq_second>\d{2})Z)_(?P<creation_ts>(?P<cre_year>\d{4})(?P<cre_month>\d{2})(?P<cre_day>\d{2})T(?P<cre_hour>\d{2})(?P<cre_minute>\d{2})(?P<cre_second>\d{2})Z)_(?P<sensor>S1[A-C])_(?P<pol>VV|VH|HH|HV|VV\+VH|HH\+HV)_(?P<product_version>v\d+[.]\d+))(_BROWSE)?[.](?P<ext>tif|tiff|h5|png|iso\.xml)$'
         Strip_File_Extension: !!bool true
         Extractor: extractor.FilenameRegexMetExtractor
         Configuration:
@@ -351,7 +351,7 @@ PRODUCT_TYPES:
       # Pattern for parsing output L2_CSLC-S1 static layer product filenames, such as:
       # OPERA_L2_CSLC-S1-STATIC_T064-135524-IW2_20140101_S1A_v1.0.h5
       # This pattern groups the metadata information in the filename using named groups.
-      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<sensor>S1A|S1B|S1C)_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5|iso\.xml)$'
+      Pattern: !!python/regexp '(?P<id>(?P<project>OPERA)_(?P<level>L2)_(?P<product_type>CSLC)-(?P<source>S1)-STATIC_(?P<burst_id>\w{4}-\w{6}-\w{3})_(?P<validity_ts>(?P<validity_year>\d{4})(?P<validity_month>\d{2})(?P<validity_day>\d{2}))_(?P<sensor>S1[A-C])_(?P<product_version>v\d+[.]\d+))[.](?P<ext>h5|iso\.xml)$'
       Strip_File_Extension: !!bool true
       Extractor: extractor.FilenameRegexMetExtractor
       Configuration:

--- a/docker/hysds-io.json.pge_smoke_test
+++ b/docker/hysds-io.json.pge_smoke_test
@@ -7,7 +7,7 @@
             "name": "pge_name",
             "from": "submitter",
             "type": "enum",
-            "enumerables": ["dswx_hls", "dswx_s1", "disp_s1", "dswx_ni", "dist_s1"],
+            "enumerables": ["dswx_hls", "dswx_s1", "disp_s1", "dswx_ni", "dist_s1", "cslc_s1", "rtc_s1"],
             "optional": false
         },
         {

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.1.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.1.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.1.1",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.1.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -48,7 +48,23 @@
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]
           }
-    }
+        },
+        {
+          "container_image_name": "opera_pge/cslc_s1:2.1.3",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
+          "container_mappings": {
+            "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
+            "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]
+          }
+        },
+        {
+          "container_image_name": "opera_pge/rtc_s1:2.1.3",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.3.tar.gz",
+          "container_mappings": {
+            "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
+            "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]
+          }
+        }
     ],
     "recommended-queues": [ "opera-job_worker-pge_smoke_test_amd", "opera-job_worker-pge_smoke_test_intel" ],
     "post": [ "hysds.triage.triage" ],

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -100,6 +100,6 @@ localize_groups:
 # * See SIMULATE_OUTPUTS usage in opera_pge_wrapper.py and chimera.precondition_evaluator.py
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
-    - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
+    - '(?P<mission_id>S1[A-C])_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
 output_base_name: OPERA_L2_CSLC-S1_{burst_id}_{acquisition_ts}Z_{creation_ts}Z_{sensor}_{pol}_{product_version}
 ancillary_base_name: OPERA_L2_CSLC-S1_{creation_ts}Z_{sensor}_{pol}_{product_version}

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
@@ -101,6 +101,6 @@ localize_groups:
 # * See SIMULATE_OUTPUTS usage in opera_pge_wrapper.py and chimera.precondition_evaluator.py
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
-    - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
+    - '(?P<mission_id>S1[A-C])_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
 output_base_name: OPERA_L2_CSLC-S1-STATIC_{burst_id}_{validity_ts}_{sensor}_{product_version}
 ancillary_base_name: OPERA_L2_CSLC-S1_{creation_ts}Z_{sensor}_{pol}_{product_version}

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
@@ -105,6 +105,6 @@ localize_groups:
 # * See SIMULATE_OUTPUTS usage in opera_pge_wrapper.py and chimera.precondition_evaluator.py
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
-    - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
+    - '(?P<mission_id>S1[A-C])_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
 output_base_name: OPERA_L2_RTC-S1_{burst_id}_{acquisition_ts}Z_{creation_ts}Z_{sensor}_30_{product_version}
 ancillary_base_name: OPERA_L2_RTC-S1_{creation_ts}Z_{sensor}_30_{product_version}

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
@@ -107,6 +107,6 @@ localize_groups:
 # * See SIMULATE_OUTPUTS usage in opera_pge_wrapper.py and chimera.precondition_evaluator.py
 #######################################################################
 input_file_base_name_regexes: # regexes taken from settings.yaml
-    - '(?P<mission_id>S1A|S1B)_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
+    - '(?P<mission_id>S1[A-C])_(?P<beam_mode>IW)_(?P<product_type>SLC)(?P<resolution>_)_(?P<level>1)(?P<class>S)(?P<pol>SH|SV|DH|DV)_(?P<start_ts>(?P<start_year>\d{4})(?P<start_month>\d{2})(?P<start_day>\d{2})T(?P<start_hour>\d{2})(?P<start_minute>\d{2})(?P<start_second>\d{2}))_(?P<stop_ts>(?P<stop_year>\d{4})(?P<stop_month>\d{2})(?P<stop_day>\d{2})T(?P<stop_hour>\d{2})(?P<stop_minute>\d{2})(?P<stop_second>\d{2}))_(?P<orbit_num>\d{6})_(?P<data_take_id>[0-9A-F]{6})_(?P<product_id>[0-9A-F]{4})[-]r(?P<revision_id>\d+)$'
 output_base_name: OPERA_L2_RTC-S1-STATIC_{burst_id}_{validity_ts}_{sensor}_30_{product_version}
 ancillary_base_name: OPERA_L2_RTC-S1_{creation_ts}Z_{sensor}_30_{product_version}

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1606,7 +1606,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         slc_filename = metadata['FileName']
 
-        slc_regex = "(S1A|S1B)_IW_SLC__1S(?P<pol>SH|SV|DH|DV).*"
+        slc_regex = "(S1[A-C])_IW_SLC__1S(?P<pol>SH|SV|DH|DV).*"
 
         result = re.search(slc_regex, slc_filename)
 

--- a/pge_smoke_test/run_pge_smoke_test.sh
+++ b/pge_smoke_test/run_pge_smoke_test.sh
@@ -16,7 +16,7 @@ PGE_NAME=$1
 S3_BUCKET=$2
 PGE_REPO_BRANCH=$3
 PGE_REPO_URL="https://github.com/nasa/opera-sds-pge.git"
-PGE_HOME=/home/ops/verdi/ops/opera-sds-pge
+PGE_HOME=$WORKING_DIR/opera-sds-pge
 
 echo "##########################################" 2>&1
 echo -n "Starting PGE integration smoke test for ${PGE_NAME}: " 2>&1

--- a/pge_smoke_test/run_pge_smoke_test.sh
+++ b/pge_smoke_test/run_pge_smoke_test.sh
@@ -23,7 +23,22 @@ echo -n "Starting PGE integration smoke test for ${PGE_NAME}: " 2>&1
 date 2>&1
 
 echo "Working dir is ${WORKING_DIR}" 2>&1
+
+echo "Debug info:"
 echo "User is $(id -u):$(id -g)"
+echo "Home dir: ${HOME}"
+
+echo "/home"
+ls -la /home
+
+echo "/home/ops"
+ls -la /home/ops
+
+echo "/home/ops/verdi/"
+ls -la /home/ops/verdi/
+
+echo "/home/ops/verdi/ops"
+ls -la /home/ops/verdi/ops
 
 VERSION_TAG=$(docker images | grep opera_pge/${PGE_NAME} -m 1 | xargs sh -c 'echo $1') 2>&1
 STATUS=$?

--- a/pge_smoke_test/run_pge_smoke_test.sh
+++ b/pge_smoke_test/run_pge_smoke_test.sh
@@ -23,6 +23,7 @@ echo -n "Starting PGE integration smoke test for ${PGE_NAME}: " 2>&1
 date 2>&1
 
 echo "Working dir is ${WORKING_DIR}" 2>&1
+echo "User is $(id -u):$(id -g)"
 
 VERSION_TAG=$(docker images | grep opera_pge/${PGE_NAME} -m 1 | xargs sh -c 'echo $1') 2>&1
 STATUS=$?

--- a/pge_smoke_test/run_pge_smoke_test.sh
+++ b/pge_smoke_test/run_pge_smoke_test.sh
@@ -22,23 +22,8 @@ echo "##########################################" 2>&1
 echo -n "Starting PGE integration smoke test for ${PGE_NAME}: " 2>&1
 date 2>&1
 
-echo "Working dir is ${WORKING_DIR}" 2>&1
-
-echo "Debug info:"
 echo "User is $(id -u):$(id -g)"
-echo "Home dir: ${HOME}"
-
-echo "/home"
-ls -la /home
-
-echo "/home/ops"
-ls -la /home/ops
-
-echo "/home/ops/verdi/"
-ls -la /home/ops/verdi/
-
-echo "/home/ops/verdi/ops"
-ls -la /home/ops/verdi/ops
+echo "Working dir is ${WORKING_DIR}" 2>&1
 
 VERSION_TAG=$(docker images | grep opera_pge/${PGE_NAME} -m 1 | xargs sh -c 'echo $1') 2>&1
 STATUS=$?

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "smart_open",
-        "pandas",
+        "pandas<2.3.0",
         "h5py"
     ],
     extras_require={


### PR DESCRIPTION
## Purpose
- This PR integrates the 2.1.3 releases of the CSLC-S1 and RTC-S1 PGEs, adding support for S1C input data
- Fixes for PGE on-demand smoke test job for HySDS v5.4.1

## Issues
- Closes #1174 
- Closes #1180

## Testing
- Deployed test cluster
  - CSLC:
    - [x] Smoke tests pass
    - [x] Tested with S1A data in sim mode
    - [x] Tested with S1C data in sim mode
    - [x] Tested with S1A data in real mode
    - [ ] Tested with S1C data in real mode
  - RTC:
    - [ ] Smoke tests pass
    - [x] Tested with S1A data in sim mode
    - [x] Tested with S1C data in sim mode
    - [x] Tested with S1A data in real mode
    - [ ] Tested with S1C data in real mode
