### PR TITLE
DISP-S1 PGE v3.0.7 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -371,7 +371,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.3"
     "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.6"
+    "disp_s1"  = "3.0.7"
     "dswx_ni"  = "4.0.0-er.4.0"
     "dist_s1"  = "6.0.0-rc.1.0"
     "tropo"    = "3.0.0-er.3.1-tropo"

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -122,7 +122,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.3"
     "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.6"
+    "disp_s1"  = "3.0.7"
     "dswx_ni"  = "4.0.0-er.4.0"
     "tropo"    = "3.0.0-er.3.0-tropo"
     "dist_s1"  = "6.0.0-rc.1.0"

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -371,7 +371,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.3"
     "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.6"
+    "disp_s1"  = "3.0.7"
     "dswx_ni"  = "4.0.0-er.4.0"
     "dist_s1"  = "6.0.0-rc.1.0"
     "tropo"    = "3.0.0-er.3.1-tropo"

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -18,7 +18,7 @@ variable "profile" {
 }
 
 variable "verdi_release" {
-  type    = string 
+  type    = string
 }
 
 variable "registry_release" {
@@ -40,7 +40,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.3"
     "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.6"
+    "disp_s1"  = "3.0.7"
     "dswx_ni"  = "4.0.0-er.3.0"
     "dist_s1"  = "6.0.0-rc.1.0"
     "tropo"    = "3.0.0-er.3.1-tropo"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -700,7 +700,7 @@ variable "pge_releases" {
     "cslc_s1"  = "2.1.3"
     "rtc_s1"   = "2.1.3"
     "dswx_s1"  = "3.0.2"
-    "disp_s1"  = "3.0.6"
+    "disp_s1"  = "3.0.7"
     "dswx_ni"  = "4.0.0-er.4.0"
     "dist_s1"  = "6.0.0-rc.1.0"
     "tropo"    = "3.0.0-er.3.1-tropo"

--- a/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
@@ -51,6 +51,8 @@ RunConfig:
           - {{ input }}
           {%- endfor %}
         frame_id: {{ runconfig.processing.frame_id }}
+        # TODO: uncomment once we want to support forward "catch-up" processing mode
+        #last_processed: {{ runconfig.input_file_group.last_processed }}
       dynamic_ancillary_file_group:
         algorithm_parameters_file: {{ runconfig.product_path_group.input_path }}/AlgoParams.yaml
         {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}

--- a/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DISP_S1.jinja2.tmpl
@@ -54,7 +54,6 @@ RunConfig:
         # TODO: uncomment once we want to support forward "catch-up" processing mode
         #last_processed: {{ runconfig.input_file_group.last_processed }}
       dynamic_ancillary_file_group:
-        algorithm_parameters_file: {{ runconfig.product_path_group.input_path }}/AlgoParams.yaml
         {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
         {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}
         {%- if runconfig.dynamic_ancillary_file_group[ type ] is iterable and runconfig.dynamic_ancillary_file_group[ type ] is not string %}

--- a/conf/schema/AlgoParams_schema.L3_DISP_S1.yaml
+++ b/conf/schema/AlgoParams_schema.L3_DISP_S1.yaml
@@ -166,8 +166,6 @@ timeseries_options:
     # Number of parallel blocks to process at once.
     num_parallel_blocks: int()
 output_options:
-    # Output (x, y) resolution (in units of input data).
-    output_resolution: any(include('x_y_object'), null())
     # Alternative to specifying output resolution: Specify the (x, y) strides (decimation
     # factor) to perform while processing input. For example, strides of [4, 2] would turn an
     # input resolution of [5, 10] into an output resolution of [20, 20].
@@ -193,7 +191,7 @@ output_options:
     # with web mapping tools. See https://gdal.org/programs/gdaladdo.html for more.
     add_overviews: bool()
     # List of overview levels to create (if add_overviews=True).
-    overview_levels: list(int())
+    overview_levels: list(int(), required=False)
     # Specify an extra reference datetime in UTC. Adding this lets you
     # to create and unwrap two single reference networks; the later resets at
     # the given date (e.g. for a large earthquake event). If passing strings,
@@ -201,11 +199,6 @@ output_options:
     # or YYYY-MM-DD
     extra_reference_date: any(str(), null())
 
-# JSON file containing frame-specific algorithm parameters to override the
-# defaults passed in the `algorithm_parameters.yaml`.
-algorithm_parameters_overrides_json: any(str(), null())
-# Name of the subdataset to use in the input NetCDF files.
-subdataset: str()
 # Spatial wavelength cutoff (in meters) for the spatial filter. Used to
 # create the short wavelength displacement layer
 spatial_wavelength_cutoff: num()

--- a/conf/schema/RunConfig_schema.L3_DISP_S1.yaml
+++ b/conf/schema/RunConfig_schema.L3_DISP_S1.yaml
@@ -46,6 +46,10 @@ RunConfig:
         # Frame ID of the bursts contained in `cslc_file_list`.
         frame_id: int(required=True)
 
+        # (For FORWARD/'Catch up' HISTORICAL processing mode) last processed date for the frame. If
+        #  provided, the SAS will only output products whose secondary datetime is *after*
+        #  `last_processed`. Otherwise, the SAS will output all products.
+        last_processed: any(str(), null(), required=False)
       dynamic_ancillary_file_group:
         # Path to file containing SAS algorithm parameters.
         algorithm_parameters_file: str(required=False)
@@ -79,6 +83,10 @@ RunConfig:
 
         # JSON file containing list of reference date changes for each frame
         reference_date_database_json: str(required=False)
+
+        # JSON file containing frame-specific algorithm parameters to override the
+        # defaults passed in the `algorithm_parameters.yaml`.
+        algorithm_parameters_overrides_json: any(str(), null(), required=False)
 
       primary_executable:
         # Product type of the PGE.

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -190,11 +190,13 @@ DISP_S1:
     FACTOR: 0.25
     CONSTANT: 1
   # S3 path to the frame-to-burst database JSON file to download for all DISP-S1 jobs
-  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.7/opera-s1-disp-0.9.0-frame-to-burst.json"
+  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.9/opera-s1-disp-0.9.0-frame-to-burst.json"
   # S3 path to the reference date database JSON file to download for all DISP-S1 jobs
   REFERENCE_DATE_DATABASE_JSON: "s3://opera-ancillaries/disp_frames/disp_s1_frame_reference_dates/opera-disp-s1-reference-dates-2025-02-13.json"
+  # S3 path to the algorithm parameters YAML file to download for historical DISP-S1 jobs
+  ALGORITHM_PARAMETERS_HISTORICAL_YAML: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.9/algorithm_parameters_historical_20250701.yaml"
   # S3 path to the algorithm parameters override JSON file to download for all DISP-S1 jobs
-  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.7/opera-disp-s1-algorithm-parameters-overrides-2025-02-21.json"
+  ALGORITHM_PARAMETERS_OVERRIDES_JSON: "s3://opera-ancillaries/algorithm_parameters/disp_s1/0.5.9/opera-disp-s1-algorithm-parameters-overrides-2025-06-17.json"
 
 DISP_S1_STATIC:
   # Amount of margin in km to apply to staged ancillaries (DEM)
@@ -207,7 +209,7 @@ DISP_S1_STATIC:
     FACTOR: 0.25
     CONSTANT: 1
   # S3 path to the frame-to-burst database JSON file to download for all DISP-S1 jobs
-  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.7/opera-s1-disp-0.9.0-frame-to-burst.json"
+  FRAME_TO_BURST_JSON: "s3://opera-ancillaries/disp_frames/disp-s1/0.5.9/opera-s1-disp-0.9.0-frame-to-burst.json"
 
 DSWX_NI:
   # Amount of margin in km to apply to staged ancillaries (DEM/Worldcover)

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.6",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.7",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.7.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L3_DISP_S1_hist
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/disp_s1:3.0.6",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
+      "container_image_name": "opera_pge/disp_s1:3.0.7",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.7.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -26,8 +26,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/disp_s1:3.0.6",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.6.tar.gz",
+          "container_image_name": "opera_pge/disp_s1:3.0.7",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-disp_s1-3.0.7.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -16,7 +16,9 @@ runconfig:
   input_file_group:
     input_file_paths: __CHIMERA_VAL__
     compressed_cslc_paths: __CHIMERA_VAL__
+    last_processed: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
+    algorithm_parameters_file: __CHIMERA_VAL__
     static_layers_files: __CHIMERA_VAL__
     mask_file: __CHIMERA_VAL__
     dem_file: __CHIMERA_VAL__
@@ -24,6 +26,7 @@ runconfig:
   static_ancillary_file_group:
     frame_to_burst_json: __CHIMERA_VAL__
     reference_date_database_json: __CHIMERA_VAL__
+    algorithm_parameters_overrides_json: __CHIMERA_VAL__
   product_path_group:
     product_version: __CHIMERA_VAL__
     input_path: /home/mamba/input_dir
@@ -33,7 +36,6 @@ runconfig:
   processing:
     polarization: __CHIMERA_VAL__
     frame_id: __CHIMERA_VAL__
-    algorithm_parameters_overrides_json: __CHIMERA_VAL__
     product_type: __CHIMERA_VAL__
     threads_per_worker: __CHIMERA_VAL__
     n_parallel_bursts: __CHIMERA_VAL__
@@ -71,6 +73,9 @@ set_daac_product_type:
 
 get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DISP-S1
+  algorithm_parameters_file:
+    # TODO: we'll need to support supplying a forward config as well at some point
+    settings_key: "DISP_S1.ALGORITHM_PARAMETERS_HISTORICAL_YAML"
   frame_to_burst_json:
     settings_key: "DISP_S1.FRAME_TO_BURST_JSON"
   reference_date_database_json:
@@ -106,9 +111,9 @@ pge_name: "L3_DISP_S1"
 primary_input: "L2_CSLC_S1"
 primary_output: "L3_DISP_S1"
 
-# Must be set to true to ensure algorithm parameter template is instantiated
-# for every DISP-S1 job
-use_algorithm_parameters: true
+# We currently pull algorithm parameters from S3, so we do not need to enable
+# generation from the template.
+use_algorithm_parameters: false
 
 # List the groups that Chimera will need to localize
 # The entries MUST reference a property of `$.runconfig` of this YAML.

--- a/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DISP_S1.yaml
@@ -49,6 +49,7 @@ preconditions:
   - get_disp_s1_frame_id
   - get_disp_s1_product_type
   - get_disp_s1_num_workers
+  - get_disp_s1_last_processed
   - get_s3_input_filepaths
   - get_static_ancillary_files
   - get_disp_s1_compressed_cslc_files

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -429,6 +429,24 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_disp_s1_last_processed(self):
+        """
+        Determines the last processed date for a DISP-S1 for use with
+        "catch-up" forward processing.
+
+        TODO: currently a stub until we need to support this feature
+        """
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        rc_params = {
+            "last_processed": ""
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
+
     def get_disp_s1_polarization(self):
         """
         Determines the polarization value of the CSLC-S1 products used with a


### PR DESCRIPTION
## Purpose
- This branch integrates the DISP-S1 PGE v3.0.7 with OPERA PCM. This version incorporates the SAS v0.5.9, which includes updates for both the baseline DISP-S1 processing, as well as the Static Layer workflow.
- Another notable change with this integration: the algorithm parameters config is now pulled from S3 without modification. Previously, it had been instantiated from a template, but with recent changes to the config schemas this is no longer necessary. It is now possible to use settings.yaml to define both the algorithm parameters as well as the override file.

## Issues
- Resolves #1203 

## Testing
- Branch has been tested on a dev cluster with the following:
  - PGE simulation mode
  - Real processing mode using frame 10859 example commands from data subscriber examples wiki page
  - Smoke test, which includes both baseline and static layer workflows. Use PGE branch `release/3.0.7` when executing the test.
