### PR TITLE
1215 forward query populate cmr rtc cache

### DIFF
--- a/data_subscriber/dist_s1_utils.py
+++ b/data_subscriber/dist_s1_utils.py
@@ -320,9 +320,6 @@ def previous_product_download_batch_id_from_rtc(dist_products, bursts_to_product
     # TODO: As the first pass we're going to inefficient brute force search. But it may actually being practical ...
     # because we'll do like 100 dict look ups at most and so that's less than 10 milliseconds. We should still optimize this.
 
-    for g in granule_ids:
-        print(f"RTC granule: {g}") #TODO: remove this later
-
     granules_dict, rtc_granules = granule_list_to_trigger_data_structure(granule_ids, bursts_to_products)
     min_acquisition_cycle = min(g["acquisition_cycle"] for g in rtc_granules)
     download_batch_id_dict = {}

--- a/data_subscriber/rtc_for_dist/dist_dependency.py
+++ b/data_subscriber/rtc_for_dist/dist_dependency.py
@@ -12,7 +12,7 @@ from opera_commons.es_connection import get_grq_es, get_mozart_es
 # batch_id looks like this: 32UPD_4_302; download_batch_id looks like this: p32UPD_4_a302
 
 GRQ_ES_DIST_S1_INDEX = "grq_v0.1_l3_dist_s1*"
-CMR_RTC_CACHE_INDEX = "cmr_rtc_cache*"
+CMR_RTC_CACHE_INDEX = "cmr_rtc_cache" #TODO: We should use wildcard later after we add year and month to the index name
 
 def file_paths_from_prev_product(previous_tile_product):
     """

--- a/data_subscriber/rtc_for_dist/dist_dependency.py
+++ b/data_subscriber/rtc_for_dist/dist_dependency.py
@@ -63,7 +63,8 @@ class DistDependency:
             self.logger.debug(f"Previous tile product found: {file_paths=}")
             return False, file_paths, None # Previous tile product exists so run with it.
         
-        # No previous product was found and cannot determine what the previous product should be. Run without previous tile product.
+        self.logger.info(f"No previous tile product was found and cannot determine what the previous product should be. \
+Run without previous tile product.")
         if prev_product_download_batch_id is None:
             return False, None, None
         
@@ -72,7 +73,7 @@ class DistDependency:
             self.logger.info(f"Previous tile job found in state {prev_tile_job['_source']['status']}")
             return True, None, prev_tile_job["_source"]["job_id"] # Wait for the job to complete.
 
-        # No previous tile product and cannot find the previous tile job.  Run without previous tile product.
+        self.logger.info(f"No previous tile product and cannot find the previous tile job.  Run without previous tile product.")
         return False, None, None
 
     def get_previous_tile_product(self, download_batch_id):


### PR DESCRIPTION
## Purpose
- DIST-S1 forward processing query, when using revision time, will update the `cmr_rtc_cache` every run.
## Proposed Changes
- `rtc_for_dist_query.py` forward processing updates the `cmr_rtc_cache` by looking at the revision date difference between the current time and the latest date in the cache.

## Issues
- #1215 
## Testing
- Tested with a few different dates ranges in the cache and revision time
- Verified that the cache is not updated if query is run in temporal time
- Verified that the updated cache is used in the subsequent queries in determining previous tile product
