### PR TITLE
Restore missing AWS provider blocks

### DIFF
--- a/cluster_provisioning/dev-e2e/main.tf
+++ b/cluster_provisioning/dev-e2e/main.tf
@@ -1,3 +1,9 @@
+provider "aws" {
+  shared_credentials_files = [var.shared_credentials_file]
+  region                  = var.region
+  profile                 = var.profile
+}
+
 module "common" {
   source                                  = "../modules/common"
   hysds_release                           = var.hysds_release

--- a/cluster_provisioning/dev-int/main.tf
+++ b/cluster_provisioning/dev-int/main.tf
@@ -1,3 +1,9 @@
+provider "aws" {
+  shared_credentials_files = [var.shared_credentials_file]
+  region                  = var.region
+  profile                 = var.profile
+}
+
 module "common" {
   source                                  = "../modules/common"
   hysds_release                           = var.hysds_release

--- a/cluster_provisioning/dev-releaser/main.tf
+++ b/cluster_provisioning/dev-releaser/main.tf
@@ -1,3 +1,9 @@
+provider "aws" {
+  shared_credentials_files = [var.shared_credentials_file]
+  region                  = var.region
+  profile                 = var.profile
+}
+
 module "common" {
   source = "../modules/common"
 


### PR DESCRIPTION
## Purpose
- Restore missing AWS provider blocks
## Proposed Changes
- [ADD]
provider "aws" {
  shared_credentials_file = var.shared_credentials_file
  region                             = var.region
  profile                             = var.profile
}

Restores provider blocks that were removed in previous commits
- Add AWS provider configuration back to dev-e2e/main.tf
- Add AWS provider configuration back to dev-int/main.tf  
- Add AWS provider configuration back to dev-releaser/main.tf

## Issues
- Links to relevant issues
- Example: issue-XYZ
## Testing
- Provide some proof you've tested your changes 
- Example: test results available at ...
- Example: tested on operating system ...
