### PR TITLE
increase tropo time limit to 3600/3660

### DIFF
--- a/docker/job-spec.json.SCIFLO_L4_TROPO
+++ b/docker/job-spec.json.SCIFLO_L4_TROPO
@@ -1,8 +1,8 @@
 {
   "command": "/home/ops/verdi/ops/opera-pcm/opera_chimera/run_sciflo.sh",
   "disk_usage":"100GB",
-  "soft_time_limit": 2400,
-  "time_limit": 2460,
+  "soft_time_limit": 3600,
+  "time_limit": 3660,
   "imported_worker_files": {
     "$HOST_VERDI_HOME/.netrc": "/home/ops/.netrc",
     "$HOST_VERDI_HOME/.aws": "/home/ops/.aws",


### PR DESCRIPTION
## Purpose
TROPO jobs have been timing out in InT, this change increases the time limits.

## Proposed Changes
- [CHANGE] increase time_limit and soft_time_limit of tropo jobs from 2400 to 3600

## Testing
- one line change in job spec, not tested
