### PR TITLE
Support for ESA/COD Provided IONEX Files

### DIFF
--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -56,6 +56,10 @@ DAAC_S3_CRED_URLS:
   RTC_DOWNLOAD: https://cumulus.asf.alaska.edu/s3credentials
   CSLC_DOWNLOAD: https://cumulus.asf.alaska.edu/s3credentials
 
+# Shortname for the provider type of IONEX file to download.
+# Valid choices are JPL, COD, or ESA (case-insensitive).
+IONEX_PROVIDER: "JPL"
+
 # The minimum coverage, defined as the percent of bursts in a bursts set, required to run DSWx_S1
 #  Must be an integer in the closed interval [0, 100] or null (~).
 #  Cannot be set together with DSWX_S1_MINIMUM_NUMBER_OF_BURSTS_REQUIRED.

--- a/data_subscriber/ionosphere_download.py
+++ b/data_subscriber/ionosphere_download.py
@@ -280,29 +280,35 @@ def get_arg_timerange(args):
 
 @backoff.on_exception(backoff.expo, exception=Exception, max_tries=3, jitter=None, giveup=lambda e: isinstance(e, IonosphereFileNotFoundException))
 def download_ionosphere_correction_file(dataset_dir, product_filepath):
-    logger.info("Downloading associated Ionosphere Correction file")
+    logger.info("Downloading associated Ionosphere Correction file (FIN type)")
+
+    provider = SettingsConf().cfg.get("IONEX_PROVIDER", "JPL")
+    logger.info("Using IONEX provider %s", provider)
+
     try:
         stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
             [
-                f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPLG}",
+                f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_FIN}",
+                f"--provider={provider}",
                 f"--output-directory={str(dataset_dir)}",
                 str(product_filepath)
             ]
         )
         output_ionosphere_file_path = stage_ionosphere_file.main(stage_ionosphere_file_args)
-        logger.info("Added JPLG Ionosphere correction file to dataset")
+        logger.info("Added FIN Ionosphere correction file to dataset")
     except IonosphereFileNotFoundException:
-        logger.warning("JPLG file type could not be found, querying for JPRG file type")
+        logger.warning("FIN file type could not be found, querying for RAP file type")
         try:
             stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
                 [
-                    f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPRG}",
+                    f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_RAP}",
+                    f"--provider={provider}",
                     f"--output-directory={str(dataset_dir)}",
                     str(product_filepath)
                 ]
             )
             output_ionosphere_file_path = stage_ionosphere_file.main(stage_ionosphere_file_args)
-            logger.info("Added JPRG Ionosphere correction file to dataset")
+            logger.info("Added RAP Ionosphere correction file to dataset")
         except IonosphereFileNotFoundException:
             logger.warning(f"Could not find any Ionosphere Correction file for product {product_filepath}")
             raise
@@ -312,31 +318,37 @@ def download_ionosphere_correction_file(dataset_dir, product_filepath):
 
 @backoff.on_exception(backoff.expo, exception=Exception, max_tries=3, jitter=None, giveup=lambda e: isinstance(e, IonosphereFileNotFoundException))
 def get_ionosphere_correction_file_url(dataset_dir, product_filepath):
-    logger.info("Downloading associated Ionosphere Correction file")
+    logger.info("Getting URL for associated Ionosphere Correction file")
+
+    provider = SettingsConf().cfg.get("IONEX_PROVIDER", "JPL")
+    logger.info("Using IONEX provider %s", provider)
+
     try:
         stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
             [
-                f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPLG}",
+                f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_FIN}",
+                f"--provider={provider}",
                 f"--output-directory={str(dataset_dir)}",
                 f"--url-only",
                 str(product_filepath)
             ]
         )
         ionosphere_url = stage_ionosphere_file.main(stage_ionosphere_file_args)
-        logger.info("Added JPLG Ionosphere correction file to dataset")
+        logger.info("FIN Ionosphere correction file URL: %s", ionosphere_url)
     except IonosphereFileNotFoundException:
         logger.warning("JPLG file type could not be found, querying for JPRG file type")
         try:
             stage_ionosphere_file_args = stage_ionosphere_file.get_parser().parse_args(
                 [
-                    f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_JPRG}",
+                    f"--type={stage_ionosphere_file.IONOSPHERE_TYPE_RAP}",
+                    f"--provider={provider}",
                     f"--output-directory={str(dataset_dir)}",
                     f"--url-only",
                     str(product_filepath)
                 ]
             )
             ionosphere_url = stage_ionosphere_file.main(stage_ionosphere_file_args)
-            logger.info("Added JPRG Ionosphere correction file to dataset")
+            logger.info("RAP Ionosphere correction file URL: %s", ionosphere_url)
         except IonosphereFileNotFoundException:
             logger.warning(f"Could not find any Ionosphere Correction file for product {product_filepath}")
             raise

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -27,7 +27,7 @@ from opera_chimera.constants.opera_chimera_const import (
 )
 from tools.stage_ancillary_map import main as stage_ancillary_map
 from tools.stage_dem import main as stage_dem
-from tools.stage_ionosphere_file import VALID_IONOSPHERE_TYPES
+from tools.stage_ionosphere_file import LEGACY_IONOSPHERE_TYPES, VALID_IONOSPHERE_TYPES
 from tools.stage_worldcover import main as stage_worldcover
 from util import datasets_json_util
 from util.common_util import get_working_dir
@@ -1965,7 +1965,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         # Find the available Ionosphere files staged by the download job
         ionosphere_file_objects = []
-        for ionosphere_file_type in VALID_IONOSPHERE_TYPES + ['RAP', 'FIN']:
+        for ionosphere_file_type in VALID_IONOSPHERE_TYPES + LEGACY_IONOSPHERE_TYPES:
             ionosphere_file_objects.extend(
                 list(filter(lambda s3_object: ionosphere_file_type in s3_object.key, s3_objects))
             )

--- a/tests/unit/tools/test_stage_ionosphere_file.py
+++ b/tests/unit/tools/test_stage_ionosphere_file.py
@@ -84,9 +84,10 @@ class TestStageIonosphereFile(unittest.TestCase):
         test_date = "20250804"
         year, julian_day = tools.stage_ionosphere_file.start_date_to_julian_day(test_date)
         ionosphere_type = IONOSPHERE_TYPE_FIN
+        provider = PROVIDER_JPL
 
         legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
-            ionosphere_type, julian_day, year
+            ionosphere_type, provider, julian_day, year
         )
 
         self.assertEqual(legacy_archive_name, "jplg2160.25i.Z")
@@ -94,10 +95,44 @@ class TestStageIonosphereFile(unittest.TestCase):
         ionosphere_type = IONOSPHERE_TYPE_RAP
 
         legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
-            ionosphere_type, julian_day, year
+            ionosphere_type, provider, julian_day, year
         )
 
         self.assertEqual(legacy_archive_name, "jprg2160.25i.Z")
+
+        ionosphere_type = IONOSPHERE_TYPE_FIN
+        provider = PROVIDER_ESA
+
+        legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(legacy_archive_name, "esag2160.25i.Z")
+
+        ionosphere_type = IONOSPHERE_TYPE_RAP
+
+        legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(legacy_archive_name, "esrg2160.25i.Z")
+
+        ionosphere_type = IONOSPHERE_TYPE_FIN
+        provider = PROVIDER_COD
+
+        legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(legacy_archive_name, "codg2160.25i.Z")
+
+        ionosphere_type = IONOSPHERE_TYPE_RAP
+
+        legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(legacy_archive_name, "corg2160.25i.Z")
 
     def test_get_new_archive_name(self):
         """Tests for the get_new_archive_name() function"""

--- a/tests/unit/tools/test_stage_ionosphere_file.py
+++ b/tests/unit/tools/test_stage_ionosphere_file.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+
+import tempfile
+import unittest
+
+
+import tools.stage_ionosphere_file
+from tools.stage_ionosphere_file import (IONOSPHERE_TYPE_RAP,
+                                         IONOSPHERE_TYPE_FIN,
+                                         PROVIDER_JPL,
+                                         PROVIDER_ESA,
+                                         PROVIDER_COD,
+                                         IonosphereFileNotFoundException)
+
+
+class TestStageIonosphereFile(unittest.TestCase):
+    """Unit tests for the stage_ionosphere_file.py script"""
+
+    def setUp(self) -> None:
+        # Create a temporary working directory
+        self.working_dir = tempfile.TemporaryDirectory(suffix="_temp", prefix="test_stage_ionosphere_file_")
+
+    def tearDown(self) -> None:
+        self.working_dir.cleanup()
+
+    def test_parse_start_date_from_safe(self):
+        """Tests for the parse_start_date_from_safe() function"""
+        # Typical case: name of a valid input SLC file
+        test_safe_file_name = "S1B_IW_SLC__1SDV_20180504T104507_20180504T104535_010770_013AEE_919F.zip"
+
+        safe_start_date = tools.stage_ionosphere_file.parse_start_date_from_safe(test_safe_file_name)
+
+        self.assertEqual(safe_start_date, "20180504")
+
+        # Error case: invalid SAFE file name
+        test_safe_file_name = "invalid_safe_file_name.zip"
+
+        with self.assertRaises(RuntimeError):
+            tools.stage_ionosphere_file.parse_start_date_from_safe(test_safe_file_name)
+
+    def test_parse_start_date_from_cslc(self):
+        """Tests for the parse_start_date_from_cslc() function"""
+        # Typical case: name of a valid input CSLC file
+        test_cslc_file_name = "OPERA_L2_CSLC-S1_T042-088937-IW1_20250804T000000Z_20250804T000000Z_S1A_VV_v1.0.h5"
+
+        cslc_start_date = tools.stage_ionosphere_file.parse_start_date_from_cslc(test_cslc_file_name)
+
+        self.assertEqual(cslc_start_date, "20250804")
+
+        # Error case: invalid CSLC file name
+        test_cslc_file_name = "invalid_cslc_file_name.cslc"
+
+        with self.assertRaises(RuntimeError):
+            tools.stage_ionosphere_file.parse_start_date_from_cslc(test_cslc_file_name)
+
+    def test_parse_start_date_from_archive(self):
+        """Tests for the parse_start_date_from_archive() function"""
+        # Typical case: name of a valid input archive file
+        for test_archive_file_name in ("S1A_IW_SLC__1SDV_20220501T015035_20220501T015102_043011_0522A4_42CC.zip",
+                                       "OPERA_L2_CSLC-S1_T093-197858-IW3_20220501T013640Z_20220501T073552Z_S1A_VV_v1.0.h5"):
+            archive_start_date = tools.stage_ionosphere_file.parse_start_date_from_archive(test_archive_file_name)
+
+            self.assertEqual(archive_start_date, "20220501")
+
+        # Error case: invalid archive file name
+        test_archive_file_name = "invalid_archive_file_name.zip"
+
+        with self.assertRaises(RuntimeError):
+            tools.stage_ionosphere_file.parse_start_date_from_archive(test_archive_file_name)
+
+    def test_start_date_to_julian_day(self):
+        """Tests for the start_date_to_julian_day() function"""
+        test_date = "20250804"
+        year, julian_day = tools.stage_ionosphere_file.start_date_to_julian_day(test_date)
+
+        self.assertIsInstance(year, str)
+        self.assertIsInstance(julian_day, str)
+
+        self.assertEqual(year, "2025")
+        self.assertEqual(julian_day, "216")
+
+    def test_get_legacy_archive_name(self):
+        """Tests for the get_legacy_archive_name() function"""
+        test_date = "20250804"
+        year, julian_day = tools.stage_ionosphere_file.start_date_to_julian_day(test_date)
+        ionosphere_type = IONOSPHERE_TYPE_FIN
+
+        legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
+            ionosphere_type, julian_day, year
+        )
+
+        self.assertEqual(legacy_archive_name, "jplg2160.25i.Z")
+
+        ionosphere_type = IONOSPHERE_TYPE_RAP
+
+        legacy_archive_name = tools.stage_ionosphere_file.get_legacy_archive_name(
+            ionosphere_type, julian_day, year
+        )
+
+        self.assertEqual(legacy_archive_name, "jprg2160.25i.Z")
+
+    def test_get_new_archive_name(self):
+        """Tests for the get_new_archive_name() function"""
+        test_date = "20250804"
+        year, julian_day = tools.stage_ionosphere_file.start_date_to_julian_day(test_date)
+        ionosphere_type = IONOSPHERE_TYPE_FIN
+        provider = PROVIDER_JPL
+
+        new_archive_name = tools.stage_ionosphere_file.get_new_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(new_archive_name, "JPL0OPSFIN_20252160000_01D_02H_GIM.INX.gz")
+
+        ionosphere_type = IONOSPHERE_TYPE_RAP
+
+        new_archive_name = tools.stage_ionosphere_file.get_new_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(new_archive_name, "JPL0OPSRAP_20252160000_01D_02H_GIM.INX.gz")
+
+        ionosphere_type = IONOSPHERE_TYPE_FIN
+        provider = PROVIDER_ESA
+
+        new_archive_name = tools.stage_ionosphere_file.get_new_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(new_archive_name, "ESA0OPSFIN_20252160000_01D_02H_GIM.INX.gz")
+
+        ionosphere_type = IONOSPHERE_TYPE_RAP
+
+        new_archive_name = tools.stage_ionosphere_file.get_new_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(new_archive_name, "ESA0OPSRAP_20252160000_01D_01H_GIM.INX.gz")
+
+        ionosphere_type = IONOSPHERE_TYPE_FIN
+        provider = PROVIDER_COD
+
+        new_archive_name = tools.stage_ionosphere_file.get_new_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(new_archive_name, "COD0OPSFIN_20252160000_01D_01H_GIM.INX.gz")
+
+        ionosphere_type = IONOSPHERE_TYPE_RAP
+
+        new_archive_name = tools.stage_ionosphere_file.get_new_archive_name(
+            ionosphere_type, provider, julian_day, year
+        )
+
+        self.assertEqual(new_archive_name, "COD0OPSRAP_20252160000_01D_01H_GIM.INX.gz")

--- a/tools/stage_ionosphere_file.py
+++ b/tools/stage_ionosphere_file.py
@@ -27,10 +27,16 @@ from util.edl_util import DEFAULT_EDL_ENDPOINT, SessionWithHeaderRedirection
 DEFAULT_DOWNLOAD_ENDPOINT = "https://cddis.nasa.gov/archive/gnss/products/ionex"
 """Default URL endpoint for Ionosphere download requests"""
 
-IONOSPHERE_TYPE_JPLG = "jplg"
-IONOSPHERE_TYPE_JPRG = "jprg"
-VALID_IONOSPHERE_TYPES = [IONOSPHERE_TYPE_JPLG, IONOSPHERE_TYPE_JPRG]
+IONOSPHERE_TYPE_RAP = "RAP"
+IONOSPHERE_TYPE_FIN = "FIN"
+VALID_IONOSPHERE_TYPES = [IONOSPHERE_TYPE_RAP, IONOSPHERE_TYPE_FIN]
 """The valid Ionosphere file types that this script can download"""
+
+PROVIDER_JPL = "JPL"
+PROVIDER_ESA = "ESA"
+PROVIDER_COD = "COD"
+VALID_PROVIDER_TYPES = [PROVIDER_JPL, PROVIDER_ESA, PROVIDER_COD]
+"""The valid Ionosphere file providers types this script supports"""
 
 class IonosphereFileNotFoundException(Exception):
     """Exception to identify no result found (404) for a requested Ionosphere archive"""
@@ -60,10 +66,14 @@ def get_parser():
                         help="Specify the EarthData Login password to use with "
                              "the download request. If a password is not provided, "
                              "it is obtained from the local .netrc file.")
-    parser.add_argument("-t", "--type", type=str.lower, choices=VALID_IONOSPHERE_TYPES,
-                        default=IONOSPHERE_TYPE_JPLG,
+    parser.add_argument("-t", "--type", type=str.upper, choices=VALID_IONOSPHERE_TYPES,
+                        default=IONOSPHERE_TYPE_RAP,
                         help=f"Specify the type of Ionosphere file to download. "
                              f"Must be one of {VALID_IONOSPHERE_TYPES}")
+    parser.add_argument("--provider", type=str.upper, choices=VALID_PROVIDER_TYPES,
+                        default=PROVIDER_JPL,
+                        help=f"Specify the provider of the Ionosphere file to download. "
+                             f"Must be one of {VALID_PROVIDER_TYPES}.")
     parser.add_argument("--url-only", action="store_true",
                         help="Only output the URL from where the resulting Ionosphere "
                              "file may be downloaded from.")
@@ -225,15 +235,15 @@ def parse_start_date_from_archive(input_archive_file):
 
     return start_date
 
-def safe_start_date_to_julian_day(safe_start_date):
+def start_date_to_julian_day(start_date):
     """
-    Converts a start date parsed from an SLC file name to the corresponding
+    Converts a start date parsed from a file name to the corresponding
     year and day of year (aka Julian day).
 
     Parameters
     ----------
-    safe_start_date : str
-        Start date parsed from an SLC filename in YYYYMMDD format.
+    start_date : str
+        Start date parsed from a filename in YYYYMMDD format.
 
     Returns
     -------
@@ -244,7 +254,7 @@ def safe_start_date_to_julian_day(safe_start_date):
 
     """
     date_format = "%Y%m%d"
-    dt = datetime.datetime.strptime(safe_start_date, date_format)
+    dt = datetime.datetime.strptime(start_date, date_format)
     time_tuple = dt.timetuple()
     year = time_tuple.tm_year
     doy = time_tuple.tm_yday
@@ -257,16 +267,26 @@ def safe_start_date_to_julian_day(safe_start_date):
     return str(year), str(doy)
 
 def get_legacy_archive_name(ionosphere_file_type, doy, year):
-    """Returns the ionosphere archive name using the legacy naming conventions"""
-    archive_name = f"{ionosphere_file_type}{doy}0.{year[2:]}i.Z"
+    """Returns the Ionosphere archive name using the legacy JPL naming conventions"""
+    legacy_ionosphere_type = "jprg" if ionosphere_file_type == IONOSPHERE_TYPE_RAP else "jplg"
+
+    archive_name = f"{legacy_ionosphere_type}{doy}0.{year[2:]}i.Z"
 
     return archive_name
 
-def get_new_archive_name(ionosphere_file_type, doy, year):
-    """Returns the ionosphere archive name using the new naming conventions"""
-    product_type = "RAP" if ionosphere_file_type == IONOSPHERE_TYPE_JPRG else "FIN"
+def get_new_archive_name(ionosphere_file_type, provider, doy, year):
+    """Returns the Ionosphere archive name using the new naming conventions"""
+    # JPL provided files always use a 2-hour interval
+    if provider == PROVIDER_JPL:
+        hour_interval = "02"
+    # For ESA provided files we prefer a 1-hour interval for type RAP, for type FIN only 2-hour is available
+    elif provider == PROVIDER_ESA:
+        hour_interval = "01" if ionosphere_file_type == IONOSPHERE_TYPE_RAP else "02"
+    # COD provided files use a 1-hour interval for both types
+    else:
+        hour_interval = "01"
 
-    archive_name = f"JPL0OPS{product_type}_{year}{doy}0000_01D_02H_GIM.INX.gz"
+    archive_name = f"{provider}0OPS{ionosphere_file_type}_{year}{doy}0000_01D_{hour_interval}H_GIM.INX.gz"
 
     return archive_name
 
@@ -391,22 +411,27 @@ def main(args):
 
     logger.info(f"Determining Ionosphere file for input file {args.input_filename}")
 
-    # Parse the relevant info from the input SAFE filename
+    # Parse the relevant info from the input SAFE/CSLC filename
     start_date = parse_start_date_from_archive(args.input_filename)
 
     logger.info(f"Parsed start date {start_date} from filename")
 
     # Convert start date to Year and Day of Year (Julian date)
-    year, doy = safe_start_date_to_julian_day(start_date)
+    year, doy = start_date_to_julian_day(start_date)
 
-    # Formulate the archive name and URL location based on the file type and
-    # the Julian date of the SLC archive. There are two file-naming conventions
-    # we need to account for.
+    # Formulate the archive name and URL location based on the file type, provider
+    # and the Julian date of the SLC archive.
     legacy_archive_name = get_legacy_archive_name(args.type, doy, year)
-    new_archive_name = get_new_archive_name(args.type, doy, year)
+    new_archive_name = get_new_archive_name(args.type, args.provider, doy, year)
 
-    # Check for the first available of the two naming conventions
-    for archive_name in (legacy_archive_name, new_archive_name):
+    # For JPL provided files there are two file-naming conventions we need to account for.
+    if args.provider == PROVIDER_JPL:
+        names_to_check = (legacy_archive_name, new_archive_name)
+    else:
+        names_to_check = new_archive_name,
+
+    # Check for the first available of the available naming conventions
+    for archive_name in names_to_check:
         request_url = join(args.download_endpoint, year, doy, archive_name)
 
         session = SessionWithHeaderRedirection(args.username, args.password)
@@ -422,8 +447,8 @@ def main(args):
     else:
         raise IonosphereFileNotFoundException(
             f'Could not find an Ionosphere file under '
-            f'{join(args.download_endpoint, year, doy)} matching either '
-            f'{legacy_archive_name} or {new_archive_name}'
+            f'{join(args.download_endpoint, year, doy)} matching {names_to_check} '
+            f'for provider {args.provider} and type {args.type}'
         )
 
     # If user request the URL only, print it to standard out and the log

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -32,7 +32,7 @@ def slc_s1_lineage_metadata(context, work_dir):
     lineage_metadata.extend(local_dem_filepaths)
 
     # Legacy Ionosphere files
-    local_tec_filepaths = glob.glob(os.path.join(work_dir, "jp*.*i"))
+    local_tec_filepaths = glob.glob(os.path.join(work_dir, "*0.*i"))
     lineage_metadata.extend(local_tec_filepaths)
 
     # New Ionosphere files

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -36,7 +36,7 @@ def slc_s1_lineage_metadata(context, work_dir):
     lineage_metadata.extend(local_tec_filepaths)
 
     # New Ionosphere files
-    local_tec_filepaths = glob.glob(os.path.join(work_dir, "JPL*.INX"))
+    local_tec_filepaths = glob.glob(os.path.join(work_dir, "*.INX"))
     lineage_metadata.extend(local_tec_filepaths)
 
     local_burstdb_filepaths = glob.glob(os.path.join(work_dir, "*.sqlite*"))


### PR DESCRIPTION
## Purpose
- This branch updates the `stage_ionosphere_file.py` script to accept a new `--provider` argument, which can be used to select the provider of an Ionosphere file within the CDDIS archive. Current choices for provider include JPL (the previous default), ESA and COD.
- This branch also exposes a `IONEX_PROVIDER` option within `settings.yaml`, which can be used to change the IONEX provider without requiring cluster redeployment. This setting will affect Ionosphere file staging for the CSLC-S1 and DISP-S1 workflows.

## Issues
- Resolves #1236 

## Testing
A new unit test suite has been added for `stage_ionosphere_file.py`
This branch has been deployed to a dev cluster, and use of the `IONEX_PROVIDER` field in settings.yaml has been tested with all available values (JPL/ESA/COD) by submitting CSLC-S1 jobs.