### PR TITLE
DIST-S1 CalVal PGE v6.0.0-rc.3.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.2.0"
+    "dist_s1"  = "6.0.0-rc.3.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -125,7 +125,7 @@ variable "pge_releases" {
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
     "tropo"    = "3.0.0-er.3.0-tropo"
-    "dist_s1"  = "6.0.0-rc.2.0"
+    "dist_s1"  = "6.0.0-rc.3.0"
     "disp_ni"  = "6.0.0-er.1.0"
   }
 }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.2.0"
+    "dist_s1"  = "6.0.0-rc.3.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -42,7 +42,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.3.0"
-    "dist_s1"  = "6.0.0-rc.2.0"
+    "dist_s1"  = "6.0.0-rc.3.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/modules/common/query_timers.tf
+++ b/cluster_provisioning/modules/common/query_timers.tf
@@ -453,6 +453,7 @@ resource "aws_lambda_function" "rtc_for_dist_query_timer" {
       "ENDPOINT" : "OPS",
       "DOWNLOAD_JOB_QUEUE" : var.queues.opera-job_worker-rtc_for_dist_data_download.name,
       "CHUNK_SIZE" : "1",
+      "K_OFFSETS_COUNTS" : "[(365, 4), (730, 3), (1095,3)]",
       "MAX_REVISION" : "1000",
       "SMOKE_RUN" : "false",
       "DRY_RUN" : "false",

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -825,7 +825,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.2.0"
+    "dist_s1"  = "6.0.0-rc.3.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/conf/AlgoParams.yaml.L3_DIST_S1.jinja2.tmpl
+++ b/conf/AlgoParams.yaml.L3_DIST_S1.jinja2.tmpl
@@ -2,7 +2,7 @@ algo_config:
     device: cpu
     memory_strategy: high
     tqdm_enabled: true
-    n_workers_for_norm_param_estimation: 8
+    n_workers_for_norm_param_estimation: 4
     batch_size_for_norm_param_estimation: 32
     stride_for_norm_param_estimation: 16
     apply_logit_to_inputs: true
@@ -18,15 +18,15 @@ algo_config:
     - 1095
     - 730
     - 365
-    low_confidence_alert_threshold: 3.5
-    high_confidence_alert_threshold: 5.5
+    low_confidence_alert_threshold: 2.5
+    high_confidence_alert_threshold: 4.5
     no_day_limit: 30
     exclude_consecutive_no_dist: 1
     percent_reset_thresh: 10
     no_count_reset_thresh: 7
     max_obs_num_year: 253
-    confidence_upper_lim: 32000
-    confirmation_confidence_threshold: 31.5
+    confirmation_confidence_upper_lim: 32000
+    confirmation_confidence_threshold: 22.5
     metric_value_upper_lim: 100.0
     model_source: transformer_optimized
     model_cfg_path:
@@ -36,3 +36,4 @@ algo_config:
     model_dtype: float32
     use_date_encoding: false
     n_anniversaries_for_mw: 3
+    model_context_length: 10

--- a/conf/RunConfig.yaml.L3_DIST_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DIST_S1.jinja2.tmpl
@@ -74,4 +74,4 @@ RunConfig:
         src_water_mask_path: {{ runconfig.src_water_mask_path }}
         apply_water_mask: {{ runconfig.apply_water_mask }}
         product_dst_dir: {{ runconfig.product_path_group.product_path }}
-        algo_config_path: {{ runconfig.product_path_group.input_path }}/AlgoParams.yaml
+        algo_config_path: {{ runconfig.static_ancillary_file_group.algorithm_parameters_file }}

--- a/conf/schema/AlgoParams_schema.L3_DIST_S1.yaml
+++ b/conf/schema/AlgoParams_schema.L3_DIST_S1.yaml
@@ -71,16 +71,18 @@ algo_config:
   max_obs_num_year: int(required=False)
 
   # Confidence upper limit for confirmation. Confidence is an accumulation of the metric over time.
-  confidence_upper_lim: int(required=False)
+  confirmation_confidence_upper_lim: int(required=False)
 
-  # This is the threshold for the confirmation process to determine if a disturbance is confirmed.
-  confirmation_confidence_threshold: num(required=False)
+  # This is the threshold for the confirmation process to determine if a disturbance is confirmed. If `None`, the value
+  # will be calculated based on the alert low confidence threshold (t_low) and the number of confirmation observations
+  # (n) default is 3 via (n ** 2) * t_low.
+  confirmation_confidence_threshold: any(num(), null(), required=False)
 
   # Metric upper limit set during confirmation
   metric_value_upper_lim: num(required=False)
 
   # Model source. If `external`, use externally supplied paths for weights and config. Otherwise, use
-  # distmetrics.model_load.ALLOWED_MODELS for other models.
+  # distmetrics.model_load.ALLOWED_MODELS for other models. If `None`, use default model source.
   model_source: any(enum('external', 'transformer_original', 'transformer_optimized', 'transformer_optimized_fine', 'transformer_anniversary_trained', 'transformer_anniversary_trained_optimized', 'transformer_anniversary_trained_optimized_fine'), null(), required=False)
 
   # Path to external model config file.
@@ -88,6 +90,9 @@ algo_config:
 
   # Path to external model weights file.
   model_wts_path: str(required=False)
+
+  # Maximum context length for the model. Auto-calculated from model_source if not provided.
+  model_context_length: any(int(), null(), required=False)
 
   # Whether to apply despeckling to the input data.
   apply_despeckling: bool(required=False)

--- a/conf/schema/RunConfig_schema.L3_DIST_S1.yaml
+++ b/conf/schema/RunConfig_schema.L3_DIST_S1.yaml
@@ -73,5 +73,8 @@ RunConfig:
         # Path to external algorithm config file. If None, SAS defaults are used.
         algo_config_path: str(required=False)
 
-        #
+        # Input data directory. If None, defaults to dst_dir.
         input_data_dir: str(required=False)
+
+        # Whether to check if the input paths exist. If True, the input paths are checked. Used during testing.
+        check_input_paths: bool(required=False)

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -234,6 +234,9 @@ DIST_S1:
   # Amount of margin in km to apply to staged ancillaries (Worldcover)
   ANCILLARY_MARGIN: 50
 
+  # S3 path to the algorithm parameters YAML file
+  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.7/algorithm_parameters_transformer_optimized.yaml"
+
 TROPO:
   # Number of workers to allocate to the "n_workers" field of the TROPO RunConfig
   NUM_WORKERS: 4

--- a/docker/hysds-io.json.rtc_for_dist_query
+++ b/docker/hysds-io.json.rtc_for_dist_query
@@ -53,6 +53,14 @@
       "optional": true
     },
     {
+      "name": "k-offsets-counts",
+      "from": "submitter",
+      "placeholder": "e.g. --k-offsets-counts=[(365, 4), (730, 3), (1095,3)]",
+      "type": "text",
+      "default": "--k-offsets-counts=[(365, 4), (730, 3), (1095,3)]",
+      "optional": true
+    },
+    {
       "name": "grace_mins",
       "from": "submitter",
       "placeholder": "e.g. --grace-mins=<grace_mins>",

--- a/docker/hysds-io.json.rtc_for_dist_query
+++ b/docker/hysds-io.json.rtc_for_dist_query
@@ -53,7 +53,7 @@
       "optional": true
     },
     {
-      "name": "k-offsets-counts",
+      "name": "k_offsets_counts",
       "from": "submitter",
       "placeholder": "e.g. --k-offsets-counts=[(365, 4), (730, 3), (1095,3)]",
       "type": "text",

--- a/docker/job-spec.json.SCIFLO_L3_DIST_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DIST_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dist_s1:6.0.0-rc.2.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.2.0.tar.gz",
+      "container_image_name": "opera_pge/dist_s1:6.0.0-rc.3.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.3.0.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -42,8 +42,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/dist_s1:6.0.0-rc.2.0",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.2.0.tar.gz",
+          "container_image_name": "opera_pge/dist_s1:6.0.0-rc.3.0",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.3.0.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.rtc_for_dist_query
+++ b/docker/job-spec.json.rtc_for_dist_query
@@ -44,7 +44,7 @@
       "destination": "positional"
     },
     {
-      "name": "k-offsets-counts",
+      "name": "k_offsets_counts",
       "destination": "positional"
     },
     {

--- a/docker/job-spec.json.rtc_for_dist_query
+++ b/docker/job-spec.json.rtc_for_dist_query
@@ -44,6 +44,10 @@
       "destination": "positional"
     },
     {
+      "name": "k-offsets-counts",
+      "destination": "positional"
+    },
+    {
       "name": "grace_mins",
       "destination": "positional"
     },

--- a/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
@@ -27,6 +27,8 @@ runconfig:
     input_path: /home/ops/input_dir
     product_path: /home/ops/output_dir
     scratch_path: /home/ops/scratch_dir
+  static_ancillary_file_group:
+    algorithm_parameters_file: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.
@@ -38,6 +40,7 @@ preconditions:
   - get_dist_s1_prev_product
   - get_dist_s1_mgrs_tile
   - get_dist_s1_mask_file
+  - get_static_ancillary_files
 
 # This lists all the postprocessor steps that this PGE will run after running the PGE.
 postprocess:
@@ -52,6 +55,11 @@ set_daac_product_type:
 get_dist_s1_mask_file:
   s3_bucket: "opera-umd-water-mask"
   s3_key: "v1/EPSG4326.vrt"
+
+get_static_ancillary_files:
+  # The s3 locations of each of the static ancillary file types used by DISP-S1
+  algorithm_parameters_file:
+    settings_key: "DIST_S1.ALGORITHM_PARAMETERS"
 
 # This function will add to the PGE output metadata when product to dataset conversion is performed
 set_extra_pge_output_metadata:
@@ -77,7 +85,7 @@ primary_output: "L3_DIST_S1"
 
 # Must be set to true to ensure algorithm parameter template is instantiated
 # for every DSWx-S1 job
-use_algorithm_parameters: true
+use_algorithm_parameters: false
 
 # List the groups that Chimera will need to localize
 # The entries MUST reference a property of `$.runconfig` of this YAML.

--- a/tests/unit/util/test_pge_util.py
+++ b/tests/unit/util/test_pge_util.py
@@ -536,8 +536,6 @@ def test_simulate_disp_s1_static_pge():
             Path(path).unlink(missing_ok=True)
 
 
-
-
 def test_simulate_dist_s1_pge():
     for path in glob.iglob('/tmp/OPERA_L3_DIST-S1*.*'):
         Path(path).unlink(missing_ok=True)
@@ -559,8 +557,8 @@ def test_simulate_dist_s1_pge():
     )
 
     creation_ts = pge_util.get_time_for_filename()
-    expected_output_basename = 'OPERA_L3_DIST-ALERT-S1_{tile_id}_{creation_ts}Z_{creation_ts}Z_S1_30_v0.1'
-    expected_ancillary_basename = 'OPERA_L3_DIST-S1_{creation_ts}Z_S1_30_v0.1'
+    expected_output_basename = 'OPERA_L3_DIST-ALERT-S1_{tile_id}_{creation_ts}Z_{creation_ts}Z_S1A_30_v0.1'
+    expected_ancillary_basename = 'OPERA_L3_DIST-S1_{creation_ts}Z_S1A_30_v0.1'
 
     try:
         for tile_id in pge_util.SIMULATED_MGRS_TILES:

--- a/util/pge_util.py
+++ b/util/pge_util.py
@@ -794,7 +794,7 @@ def get_dist_s1_simulated_output_filenames(dataset_match, pge_config, extension)
             tile_id=tile_id,
             acquisition_ts=acq_time,
             creation_ts=creation_time,
-            sensor='S1',
+            sensor='S1A',
             spacing='30',
             product_version='0.1',
         )
@@ -810,7 +810,7 @@ def get_dist_s1_simulated_output_filenames(dataset_match, pge_config, extension)
         else:
             base_name = ancillary_name_template.format(
                 creation_ts=creation_time,
-                sensor='S1',
+                sensor='S1A',
                 spacing='30',
                 product_version='0.1'
             )

--- a/wrapper/pge_functions.py
+++ b/wrapper/pge_functions.py
@@ -266,6 +266,10 @@ def dist_s1_lineage_metadata(context, work_dir):
     if 'src_water_mask_path' in run_config and run_config["src_water_mask_path"]:
         lineage_metadata.extend(glob.glob(os.path.join(work_dir, "*water_mask*.*")))
 
+    lineage_metadata.append(
+        os.path.join(work_dir, basename(run_config['static_ancillary_file_group']['algorithm_parameters_file']))
+    )
+
     return lineage_metadata
 
 
@@ -596,6 +600,10 @@ def update_dist_s1_runconfig(context, work_dir):
 
     if 'src_water_mask_path' in run_config and run_config["src_water_mask_path"]:
         run_config["src_water_mask_path"] = os.path.join(container_home_prefix, basename(run_config["src_water_mask_path"]))
+
+    run_config['static_ancillary_file_group']['algorithm_parameters_file'] = os.path.join(
+        container_home_prefix, basename(run_config['static_ancillary_file_group']['algorithm_parameters_file'])
+    )
 
     return run_config
 


### PR DESCRIPTION
## Purpose
This PR integrates the latest "CalVal" release of the DIST-S1 PGE.

## Testing
- [x] PGE sim unit tests
- [x] Cluster deploy
- [x] Sim mode job
- [x] Real mode jobs
  - [x] Initial product
  - [x] Chained products
  - [x] Other test cases (VV/VH, HH/HV, Forward mode, etc)

Real-mode test case output products have been archived to my LTS bucket at `pge_pcm_integration/dist_s1/6.0.0-rc.3.0_calval/real/`