### PR TITLE
Update Tropo accountability script for extended date range support

### DIFF
--- a/tools/ops/cmr_audit/cmr_audit_tropo.py
+++ b/tools/ops/cmr_audit/cmr_audit_tropo.py
@@ -78,11 +78,27 @@ def export_missing_dates_to_csv(counts, filename='tropo_missing_dates.csv'):
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Query CMR for granule counts in a date range"
+        description="Query CMR for OPERA Tropo granule counts and generate accountability reports",
+        epilog="""
+Examples:
+  # Use default date range (2016-01-01 to today - 2 days):
+  python cmr_audit_tropo.py --start 2016-01-01
+
+  # Query specific date range:
+  python cmr_audit_tropo.py --start 2016-01-01 --end 2016-06-30
+
+  # Query with custom provider and product:
+  python cmr_audit_tropo.py --start 2016-01-01 --provider ASF --short_name OPERA_L4_TROPO-ZENITH_V1
+
+This script generates two CSV files:
+  - tropo_granule_counts.csv: Count of granules for each date
+  - tropo_missing_dates.csv: Dates with fewer than 4 granules
+        """,
+        formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
-        '--start', type=str, default="2016-07-01",
-        help="Start date in YYYY-MM-DD format (default: 2016-07-01)"
+        '--start', type=str, default="2016-01-01",
+        help="Start date in YYYY-MM-DD format (default: 2016-01-01)"
     )
     parser.add_argument(
         '--end', type=str,


### PR DESCRIPTION
## Summary
This PR addresses issue #1307 by updating the Tropo accountability script to support earlier date ranges and improving its documentation.

## Changes
- Updated default start date from `2016-07-01` to `2016-01-01` to support recently completed early runs (2016-01-01 through 2016-06-30)
- Enhanced help documentation with detailed usage examples showing how to:
  - Use the default date range
  - Query specific custom date ranges
  - Customize provider and product parameters
- Added clear documentation of the two CSV output files generated by the script
- Improved discoverability of the existing `--start` and `--end` arguments for custom date range queries

## Note
The script already had full support for customizable date ranges via command-line arguments (`--start` and `--end`). This PR updates the default value and significantly improves the help documentation to make this functionality more discoverable for users.

## Test plan
- [x] Verified help documentation displays correctly with `python3 cmr_audit_tropo.py --help`
- [x] Confirmed default start date is now 2016-01-01
- [x] Validated that all command-line arguments work as expected

Fixes #1307

🤖 Generated with [Claude Code](https://claude.com/claude-code)