### PR TITLE
Add environment information banner to Figaro and Tosca GUIs

### DIFF
--- a/conf/sds/files/facetview.html
+++ b/conf/sds/files/facetview.html
@@ -1305,6 +1305,15 @@ jQuery(document).ready(function($) {
   </div>
 </div>
 
+    <!-- Environment Information Banner -->
+    {% if config.get('SHOW_ENV_BANNER', False) %}
+    <div class="alert alert-info" style="margin: 60px 20px 0 20px; text-align: center; border-radius: 4px;">
+      <strong>Environment:</strong> {{ config.get('CLUSTER_NAME', 'Unknown') }} |
+      <strong>PCM Version:</strong> {{ config.get('PCM_VERSION', 'Unknown') }} |
+      <strong>HySDS Version:</strong> {{ config.get('HYSDS_VERSION', 'Unknown') }}
+    </div>
+    {% endif %}
+
     <!--Alerts-->
     {% with messages = get_flashed_messages(category_filter=["message"]) %}
     {% if messages %}

--- a/conf/sds/files/figaro_settings.cfg.tmpl
+++ b/conf/sds/files/figaro_settings.cfg.tmpl
@@ -59,3 +59,9 @@ JOB_SUBMISSION_QUEUE = "{{ SYSTEM_JOBS_QUEUE }}"
 # ES plugins
 ES_HEAD_URL = "http://{{ MOZART_ES_FQDN }}/es/_plugin/head/"
 ES_KOPF_URL = "http://{{ MOZART_ES_FQDN }}/es/_plugin/kopf/"
+
+# Environment identification
+CLUSTER_NAME = "{{ PROJECT }}-{{ VENUE }}"
+PCM_VERSION = "{{ PCM_VERSION }}"
+HYSDS_VERSION = "{{ HYSDS_VERSION }}"
+SHOW_ENV_BANNER = True

--- a/conf/sds/files/tosca_facetview.html
+++ b/conf/sds/files/tosca_facetview.html
@@ -1301,6 +1301,15 @@ jQuery(document).ready(function($) {
   </div>
 </div>
 
+    <!-- Environment Information Banner -->
+    {% if config.get('SHOW_ENV_BANNER', False) %}
+    <div class="alert alert-info" style="margin: 60px 20px 0 20px; text-align: center; border-radius: 4px;">
+      <strong>Environment:</strong> {{ config.get('CLUSTER_NAME', 'Unknown') }} |
+      <strong>PCM Version:</strong> {{ config.get('PCM_VERSION', 'Unknown') }} |
+      <strong>HySDS Version:</strong> {{ config.get('HYSDS_VERSION', 'Unknown') }}
+    </div>
+    {% endif %}
+
     <!--Alerts-->
     {% with messages = get_flashed_messages(category_filter=["message"]) %}
     {% if messages %}

--- a/conf/sds/files/tosca_settings.cfg.tmpl
+++ b/conf/sds/files/tosca_settings.cfg.tmpl
@@ -65,3 +65,9 @@ TOSCA_TITLE = "HySDS Facet Search"
 TOSCA_SUBTITLE = "Datasets"
 TOSCA_TITLE_BADGE = "BETA"
 SHOW_BADGE = False
+
+# Environment identification
+CLUSTER_NAME = "{{ PROJECT }}-{{ VENUE }}"
+PCM_VERSION = "{{ PCM_VERSION }}"
+HYSDS_VERSION = "{{ HYSDS_VERSION }}"
+SHOW_ENV_BANNER = True


### PR DESCRIPTION
This commit addresses issue #1290 by adding a prominent environment identification banner to both Figaro (Job Management) and Tosca (Dataset FacetView) user interfaces.

Changes made:
- Updated tosca_settings.cfg.tmpl to include CLUSTER_NAME, PCM_VERSION, HYSDS_VERSION, and SHOW_ENV_BANNER configuration variables
- Updated figaro_settings.cfg.tmpl with the same environment variables
- Added environment information banner to facetview.html template
- Added environment information banner to tosca_facetview.html template

The banner displays:
- Cluster name (derived from PROJECT-VENUE, e.g., opera-ops-fwd)
- PCM version (e.g., 3.2.0)
- HySDS version (e.g., v4.0.1-beta.8)

This helps operators distinguish between multiple clusters (ops-fwd, ops-pop1, int-fwd, int-pop1, pst) when working with 2-3 environments simultaneously, addressing the confusion caused by IP-based URLs.

The banner can be toggled via the SHOW_ENV_BANNER configuration flag.

## Purpose
- Clear, easy-to-understand sentences outlining the purpose of the PR
## Proposed Changes
- [ADD] ...
- [CHANGE] ...
- [REMOVE] ...

## Issues
- Links to relevant issues
- Example: issue-XYZ
## Testing
- Provide some proof you've tested your changes 
- Example: test results available at ...
- Example: tested on operating system ...
