### PR TITLE
Issue 1314: feat(DSWx-S1): explicitly dedupe RTC when evaluating coverage

### DIFF
--- a/data_subscriber/asf_rtc_download.py
+++ b/data_subscriber/asf_rtc_download.py
@@ -11,6 +11,7 @@ from more_itertools import first
 
 from data_subscriber.catalog import ProductCatalog
 from data_subscriber.download import BaseDownload
+from data_subscriber.rtc.evaluator import dedupe_rtc_es_docs
 from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.url import _to_urls, _to_https_urls, _rtc_url_to_chunk_id
 from rtc_utils import rtc_product_file_revision_regex
@@ -42,7 +43,7 @@ class AsfDaacRtcDownload(BaseDownload):
             sensor, affected_mgrs_set_id_acquisition_ts_cycle_index = batch_id.split("$", maxsplit=1)
             self.logger.info(f"{affected_mgrs_set_id_acquisition_ts_cycle_index=}")
             es_docs = es_conn.filter_catalog_by_sets([affected_mgrs_set_id_acquisition_ts_cycle_index], sensor=sensor)
-            batch_id_to_products_map[batch_id] = es_docs
+            batch_id_to_products_map[batch_id] = dedupe_rtc_es_docs(es_docs, filter_path=True)
 
         succeeded = []
         failed = []

--- a/data_subscriber/asf_rtc_download.py
+++ b/data_subscriber/asf_rtc_download.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import os
 import re
+import shutil
 import uuid
 from collections import defaultdict, namedtuple
 from itertools import chain
@@ -11,13 +12,14 @@ from more_itertools import first
 
 from data_subscriber.catalog import ProductCatalog
 from data_subscriber.download import BaseDownload
-from data_subscriber.rtc.evaluator import dedupe_rtc_es_docs
+from data_subscriber.rtc.rtc_catalog import dedupe_rtc_es_docs
 from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.url import _to_urls, _to_https_urls, _rtc_url_to_chunk_id
 from rtc_utils import rtc_product_file_revision_regex
 from util.aws_util import concurrent_s3_client_try_upload_file
 from util.conf_util import SettingsConf
 from util.ctx_util import JobContext
+from util.edl_util import SessionWithHeaderRedirection
 from util.job_util import is_running_outside_verdi_worker_context
 
 
@@ -43,7 +45,7 @@ class AsfDaacRtcDownload(BaseDownload):
             sensor, affected_mgrs_set_id_acquisition_ts_cycle_index = batch_id.split("$", maxsplit=1)
             self.logger.info(f"{affected_mgrs_set_id_acquisition_ts_cycle_index=}")
             es_docs = es_conn.filter_catalog_by_sets([affected_mgrs_set_id_acquisition_ts_cycle_index], sensor=sensor)
-            batch_id_to_products_map[batch_id] = dedupe_rtc_es_docs(es_docs, filter_path=True)
+            batch_id_to_products_map[batch_id] = es_docs
 
         succeeded = []
         failed = []
@@ -78,7 +80,7 @@ class AsfDaacRtcDownload(BaseDownload):
                 "job_id": job_id
             }
 
-            product_to_product_filepaths_map: dict[str, set[Path]] = super().run_download(
+            product_to_product_filepaths_map: dict[str, set[Path]] = self.run_download_helper(
                 args=args_for_downloader, **run_download_kwargs, rm_downloads_dir=False
             )
 
@@ -152,6 +154,33 @@ class AsfDaacRtcDownload(BaseDownload):
             "success": succeeded,
             "fail": failed
         }
+
+    def run_download_helper(self, args, token, es_conn, netloc, username, password, cmr,
+                           job_id, rm_downloads_dir=True):
+        """Copied from `super.run_download`. Only modification is to perform dedupe."""
+        product_to_product_filepaths_map = {}
+        downloads = self.get_downloads(args, es_conn)
+        downloads = dedupe_rtc_es_docs(downloads, filter_path=True)
+
+        if not downloads:
+            self.logger.info(f"No undownloaded files found in index.")
+            return product_to_product_filepaths_map
+
+        if args.dry_run:
+            self.logger.info(f"{args.dry_run=}. Skipping downloads.")
+            return product_to_product_filepaths_map
+
+        session = SessionWithHeaderRedirection(username, password, netloc)
+
+        product_to_product_filepaths_map = self.perform_download(
+            session, es_conn, downloads, args, token, job_id
+        )
+
+        if rm_downloads_dir:
+            self.logger.info(f"Removing directory tree {os.path.abspath(self.downloads_dir)}")
+            shutil.rmtree(self.downloads_dir)
+
+        return product_to_product_filepaths_map
 
     def perform_download(self, session: requests.Session, es_conn: ProductCatalog,
                          downloads: list[dict], args, token, job_id):

--- a/data_subscriber/rtc/evaluator.py
+++ b/data_subscriber/rtc/evaluator.py
@@ -96,6 +96,8 @@ def main(
             }):
                 es_docs.extend(burst_set)
 
+    es_docs = dedupe_rtc_es_docs(es_docs)
+
     evaluator_results = {
         "coverage_target": coverage_target,
         "mgrs_sets": defaultdict(list)
@@ -186,6 +188,25 @@ def main(
     evaluator_results["mgrs_sets"] = dict(evaluator_results["mgrs_sets"])
 
     return evaluator_results
+
+
+def dedupe_rtc_es_docs(es_docs: list[dict]) -> list[dict]:
+    dedupe_key_to_doc = {}
+    for doc in es_docs:
+        b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
+        rtc_uniqueness_tuple = (
+            b["burst_id"],
+            b["acquisition_ts"],
+            b["sensor"],
+            b["product_version"]
+        )
+        if not dedupe_key_to_doc.get(rtc_uniqueness_tuple):
+            dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
+        elif dedupe_key_to_doc[rtc_uniqueness_tuple]:
+            a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
+            if a["creation_ts"] < b["creation_ts"]:
+                dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
+    return list(dedupe_key_to_doc.values())
 
 
 def current_evaluation_datetime():

--- a/data_subscriber/rtc/evaluator.py
+++ b/data_subscriber/rtc/evaluator.py
@@ -190,10 +190,17 @@ def main(
     return evaluator_results
 
 
-def dedupe_rtc_es_docs(es_docs: list[dict]) -> list[dict]:
+def dedupe_rtc_es_docs(es_docs: list[dict], filter_path=False) -> list[dict]:
+    """
+    :param filter_path: functions like `?filter_path=hits.hits._source` in the Elasticsearch HTTP API.
+    """
+
     dedupe_key_to_doc = {}
     for doc in es_docs:
-        b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
+        if not filter_path:
+            b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
+        elif filter_path:
+            b = re.match(rtc_granule_regex, doc["granule_id"]).groupdict()
         rtc_uniqueness_tuple = (
             b["burst_id"],
             b["acquisition_ts"],
@@ -203,7 +210,10 @@ def dedupe_rtc_es_docs(es_docs: list[dict]) -> list[dict]:
         if not dedupe_key_to_doc.get(rtc_uniqueness_tuple):
             dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
         elif dedupe_key_to_doc[rtc_uniqueness_tuple]:
-            a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
+            if not filter_path:
+                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
+            elif filter_path:
+                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["granule_id"]).groupdict()
             if a["creation_ts"] < b["creation_ts"]:
                 dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
     return list(dedupe_key_to_doc.values())

--- a/data_subscriber/rtc/evaluator.py
+++ b/data_subscriber/rtc/evaluator.py
@@ -16,7 +16,7 @@ from more_itertools import first, flatten
 from data_subscriber import es_conn_util
 from data_subscriber.rtc import evaluator_core
 from data_subscriber.rtc import mgrs_bursts_collection_db_client as mbc_client
-from data_subscriber.rtc.rtc_catalog import RTCProductCatalog
+from data_subscriber.rtc.rtc_catalog import RTCProductCatalog, dedupe_rtc_es_docs
 from rtc_utils import rtc_granule_regex, rtc_relative_orbit_number_regex
 from util.grq_client import get_body
 
@@ -188,35 +188,6 @@ def main(
     evaluator_results["mgrs_sets"] = dict(evaluator_results["mgrs_sets"])
 
     return evaluator_results
-
-
-def dedupe_rtc_es_docs(es_docs: list[dict], filter_path=False) -> list[dict]:
-    """
-    :param filter_path: functions like `?filter_path=hits.hits._source` in the Elasticsearch HTTP API.
-    """
-
-    dedupe_key_to_doc = {}
-    for doc in es_docs:
-        if not filter_path:
-            b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
-        elif filter_path:
-            b = re.match(rtc_granule_regex, doc["granule_id"]).groupdict()
-        rtc_uniqueness_tuple = (
-            b["burst_id"],
-            b["acquisition_ts"],
-            b["sensor"],
-            b["product_version"]
-        )
-        if not dedupe_key_to_doc.get(rtc_uniqueness_tuple):
-            dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
-        elif dedupe_key_to_doc[rtc_uniqueness_tuple]:
-            if not filter_path:
-                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
-            elif filter_path:
-                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["granule_id"]).groupdict()
-            if a["creation_ts"] < b["creation_ts"]:
-                dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
-    return list(dedupe_key_to_doc.values())
 
 
 def current_evaluation_datetime():

--- a/data_subscriber/rtc/rtc_catalog.py
+++ b/data_subscriber/rtc/rtc_catalog.py
@@ -1,4 +1,4 @@
-
+import re
 from collections import defaultdict
 from datetime import datetime
 
@@ -9,6 +9,7 @@ from more_itertools import last, chunked
 
 from data_subscriber.catalog import ProductCatalog
 from data_subscriber.rtc import mgrs_bursts_collection_db_client
+from rtc_utils import rtc_granule_regex
 from util.conf_util import SettingsConf
 from util.grq_client import get_body
 
@@ -249,3 +250,32 @@ class RTCProductCatalog(ProductCatalog):
             }
 
             self.es_util.update_document(index=index, body=body, id=doc['id'])
+
+
+def dedupe_rtc_es_docs(es_docs: list[dict], filter_path=False) -> list[dict]:
+    """
+    :param filter_path: functions like `?filter_path=hits.hits._source` in the Elasticsearch HTTP API.
+    """
+
+    dedupe_key_to_doc = {}
+    for doc in es_docs:
+        if not filter_path:
+            b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
+        elif filter_path:
+            b = re.match(rtc_granule_regex, doc["granule_id"]).groupdict()
+        rtc_uniqueness_tuple = (
+            b["burst_id"],
+            b["acquisition_ts"],
+            b["sensor"],
+            b["product_version"]
+        )
+        if not dedupe_key_to_doc.get(rtc_uniqueness_tuple):
+            dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
+        elif dedupe_key_to_doc[rtc_uniqueness_tuple]:
+            if not filter_path:
+                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
+            elif filter_path:
+                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["granule_id"]).groupdict()
+            if a["creation_ts"] < b["creation_ts"]:
+                dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
+    return list(dedupe_key_to_doc.values())

--- a/tests/unit/data_subscriber/rtc/test_evaluator.py
+++ b/tests/unit/data_subscriber/rtc/test_evaluator.py
@@ -5,6 +5,7 @@ import pytest
 from mock import patch
 from more_itertools import only
 
+import data_subscriber.rtc.rtc_catalog
 from data_subscriber.rtc import evaluator
 
 
@@ -231,7 +232,7 @@ def test_dedupe_rtc_es_docs():
         {"_source": {"granule_id": f"{common_prefix}_{older_datetime}_{common_suffix}"}}
     ]
 
-    result = evaluator.dedupe_rtc_es_docs(es_docs)
+    result = data_subscriber.rtc.rtc_catalog.dedupe_rtc_es_docs(es_docs)
 
     assert only(result) == {"_source": {"granule_id": f"{common_prefix}_{newer_datetime}_{common_suffix}"}
     }

--- a/tests/unit/data_subscriber/rtc/test_evaluator.py
+++ b/tests/unit/data_subscriber/rtc/test_evaluator.py
@@ -1,8 +1,9 @@
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import dateutil.parser
 import pytest
 from mock import patch
+from more_itertools import only
 
 from data_subscriber.rtc import evaluator
 
@@ -35,7 +36,8 @@ def test_grace_period__when_bursts_out_of_grace_period__then_kept_in_evaluator_r
                 "granule_id": test_granule_id,
                 # 3-minute-old result, created BEFORE grace period window
                 "creation_timestamp": (dateutil.parser.parse("2024-01-01T00:00:00") - timedelta(minutes=3)).isoformat(timespec="seconds"),
-                "mgrs_set_id_acquisition_ts_cycle_index": "dummy"
+                "mgrs_set_id_acquisition_ts_cycle_index": "dummy",
+                "instrument": "S1A"
             }
         }
     ]
@@ -74,7 +76,8 @@ def test_grace_period__when_bursts_in_grace_period__then_omitted_from_evaluator_
                 "granule_id": test_granule_id,
                 # 1-minute-old result, created WITHIN grace period window
                 "creation_timestamp": (dateutil.parser.parse("2024-01-01T00:00:00") - timedelta(minutes=1)).isoformat(timespec="seconds"),
-                "mgrs_set_id_acquisition_ts_cycle_index": "dummy"
+                "mgrs_set_id_acquisition_ts_cycle_index": "dummy",
+                "instrument": "S1A"
             }
         }
     ]
@@ -112,7 +115,8 @@ def test_coverage_target__when_bursts_out_of_grace_period__then_kept_in_evaluato
                 "granule_id": test_granule_id,
                 # 3-minute-old result, created BEFORE grace period window
                 "creation_timestamp": (dateutil.parser.parse("2024-01-01T00:00:00") - timedelta(minutes=3)).isoformat(timespec="seconds"),
-                "mgrs_set_id_acquisition_ts_cycle_index": "dummy"
+                "mgrs_set_id_acquisition_ts_cycle_index": "dummy",
+                "instrument": "S1A"
             }
         }
     ]
@@ -151,7 +155,8 @@ def test_coverage_target__when_bursts_in_grace_period__then_omitted_from_evaluat
                 "granule_id": test_granule_id,
                 # 1-minute-old result, created WITHIN grace period window
                 "creation_timestamp": (dateutil.parser.parse("2024-01-01T00:00:00") - timedelta(minutes=1)).isoformat(timespec="seconds"),
-                "mgrs_set_id_acquisition_ts_cycle_index": "dummy"
+                "mgrs_set_id_acquisition_ts_cycle_index": "dummy",
+                "instrument": "S1A"
             }
         }
     ]
@@ -184,7 +189,8 @@ def test_native_id__when_coverage_target_A__and_bursts_found_B(es_conn_util, tes
             "_source": {
                 "granule_id": "OPERA_L2_RTC-S1_T020-041121-IW1_20231101T013115Z_20231104T041913Z_S1A_30_v1.0",
                 "creation_timestamp": "2024-01-01T00:00:00",
-                "mgrs_set_id_acquisition_ts_cycle_index": "dummy"
+                "mgrs_set_id_acquisition_ts_cycle_index": "dummy",
+                "instrument": "S1A"
             }
         }
     ]
@@ -206,9 +212,26 @@ def test_native_id__when_min_bursts_A__and__bursts_found_B(es_conn_util, test_mi
             "_source": {
                 "granule_id": "OPERA_L2_RTC-S1_T020-041121-IW1_20231101T013115Z_20231104T041913Z_S1A_30_v1.0",
                 "creation_timestamp": "2024-01-01T00:00:00",
-                "mgrs_set_id_acquisition_ts_cycle_index": "dummy"
+                "mgrs_set_id_acquisition_ts_cycle_index": "dummy",
+                "instrument": "S1A"
             }
         }
     ]
     evaluator_results = evaluator.main(min_num_bursts=test_min_num_bursts, coverage_target=None, sensor="S1A")
     assert evaluator_results["mgrs_sets"] == expected_sets or evaluator_results["mgrs_sets"].keys() == expected_sets
+
+def test_dedupe_rtc_es_docs():
+    acquisition_dts = "20210927T100649Z"
+    common_prefix = f'OPERA_L2_RTC-S1_T123-123456-IW3_{acquisition_dts}'
+    common_suffix = "S1A_30_v1.0"
+    newer_datetime = "20251231T235959Z"
+    older_datetime = "20240101T000000Z"
+    es_docs = [
+        {"_source": {"granule_id": f"{common_prefix}_{newer_datetime}_{common_suffix}"}},
+        {"_source": {"granule_id": f"{common_prefix}_{older_datetime}_{common_suffix}"}}
+    ]
+
+    result = evaluator.dedupe_rtc_es_docs(es_docs)
+
+    assert only(result) == {"_source": {"granule_id": f"{common_prefix}_{newer_datetime}_{common_suffix}"}
+    }


### PR DESCRIPTION
## Purpose
fix #1314, duplicate RTCs used in evaluating coverage for DSWx-S1 product generation
## Proposed Changes
- [CHANGE] evaluation logic to filter for duplicates.

## Issues
#1314
## Testing
tested locally
