### PR TITLE
Parallelize Input URL localization in SCIFLO jobs

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -377,14 +377,17 @@ variable "queues" {
 
       //NOTE: As of RC2.0 we are restricted to AMD instances
 
-      // Compute optimized 4x large - about 20/32 GB of memory used, reasonable amount of cores
-      "instance_type"     = ["c6a.4xlarge", "c7a.4xlarge", "c5a.4xlarge"]
+      // Compute optimized 4x large - about 20/32 GB of memory used, reasonable amount of cores for 4-3-3
+      // "instance_type"     = ["c7a.4xlarge", "c6a.4xlarge", "c5a.4xlarge"]
 
       // Compute optimized 8x large - now probably overkill for SAS v2.0.5
-      //"instance_type"     = ["c6a.8xlarge", "c7a.8xlarge", "c5a.8xlarge"]
+      // "instance_type"     = ["c7a.8xlarge", "c6a.8xlarge", "c5a.8xlarge"]
 
-      // General purpose 4x large - good ammount of compute but perhaps excessive memory for SAS v2.0.5
-      #"instance_type"     = ["m6a.4xlarge", "m7a.4xlarge", "m5a.4xlarge"]
+      // General purpose 4x large - good amount of compute but perhaps excessive memory for 4-3-3 but good for 8-6-6(?)
+      // "instance_type"     = ["m8a.4xlarge", "m7a.4xlarge", "m6a.4xlarge", "m5a.4xlarge"]
+
+      // General purpose 8x large - works well with 8-6-6 w/ stride=7 & parallel npe=4 (tested on m8a)
+      "instance_type"     = ["m8a.8xlarge", "m7a.8xlarge", "m6a.8xlarge", "m5a.8xlarge"]
 
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -6,7 +6,7 @@ import traceback
 from datetime import datetime
 
 from chimera.pge_job_submitter import PgeJobSubmitter
-from opera_commons.logger import logger
+from opera_commons.logger import logger, init_pool_logger
 from hysds.utils import get_disk_usage, makedirs
 from opera_chimera.constants.opera_chimera_const import (
     OperaChimeraConstants as oc_const,
@@ -14,7 +14,27 @@ from opera_chimera.constants.opera_chimera_const import (
 from util.pge_util import download_file_with_hysds, write_pge_metrics
 from wrapper.opera_pge_wrapper import run_pipeline
 
+from multiprocessing import Manager, get_context, cpu_count
+
 ISO_DATETIME_PATTERN = "%Y-%m-%dT%H:%M:%S.%f"
+
+
+def _download_wrapper(url, path, event=None):
+    if event and event.is_set():
+        logger.warning("Previous localize task failed, skipping %s..." % url)
+        return
+
+    try:
+        metrics = download_file_with_hysds(url, path)
+        metrics = metrics['download'][0]
+    except Exception as e:
+        if event:
+            event.set()
+        tb = traceback.format_exc()
+        logger.error(tb)
+        raise RuntimeError("Failed to download {}: {}\n{}".format(url, str(e), tb))
+
+    return metrics
 
 
 class OperaPgeJobSubmitter(PgeJobSubmitter):
@@ -72,34 +92,59 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
         if self._wuid is None and self._job_num is None:
             # download urls
             pge_metrics = {"download": [], "upload": []}
+            num_procs = min(max(cpu_count() - 2, 1), len(job_json['localize_urls']))
 
-            for localize_url in job_json["localize_urls"]:
-                url = localize_url["url"]
-                path = localize_url.get("local_path", None)
+            logger.info(f'TEMP: {logger.handlers}')
 
-                if url.startswith("/"):
-                    if os.path.isfile(url):
-                        logger.info("{} already exists, not localizing".format(url))
-                        continue
+            with get_context("spawn").Pool(
+                num_procs, initializer=init_pool_logger
+            ) as pool, Manager() as manager:
+                event = manager.Event()
+                async_tasks = []
 
-                if path is None:
-                    path = "%s/" % self._base_work_dir
-                else:
-                    if not path.startswith("/"):
-                        path = os.path.join(self._base_work_dir, path)
+                for localize_url in job_json["localize_urls"]:
+                    url = localize_url["url"]
+                    path = localize_url.get("local_path", None)
 
-                if os.path.isdir(path) or path.endswith("/"):
-                    path = os.path.join(path, os.path.basename(url))
+                    if url.startswith("/"):
+                        if os.path.isfile(url):
+                            logger.info("{} already exists, not localizing".format(url))
+                            continue
 
-                dir_path = os.path.dirname(path)
-                makedirs(dir_path)
+                    if path is None:
+                        path = "%s/" % self._base_work_dir
+                    else:
+                        if not path.startswith("/"):
+                            path = os.path.join(self._base_work_dir, path)
 
-                logger.info("Localizing {}".format(url))
+                    if os.path.isdir(path) or path.endswith("/"):
+                        path = os.path.join(path, os.path.basename(url))
 
-                # Download the current file and update current PGE download metrics
-                # with results of transfer
-                new_pge_metrics = download_file_with_hysds(url, path)
-                pge_metrics["download"].extend(new_pge_metrics["download"])
+                    dir_path = os.path.dirname(path)
+                    makedirs(dir_path)
+
+                    logger.info("Localizing {}".format(url))
+                    async_task = pool.apply_async(_download_wrapper, args=(url, path, event), kwds={"event": event})
+                    async_tasks.append(async_task)
+
+                pool.close()
+                logger.info("Waiting for dataset localization tasks to complete...")
+                pool.join()
+
+                has_error, err = False, ""
+                for t in async_tasks:
+                    if t.successful():
+                        result = t.get()
+                        if result:
+                            pge_metrics["download"].append(result)
+                    else:
+                        has_error = True
+                        logger.error(t._value)  # noqa
+                        err = t._value  # noqa
+                if has_error is True:
+                    raise RuntimeError("Failed to download {}".format(err))
+
+            logger.handlers.clear()
 
             # Commit metrics for all downloaded files back to disk
             write_pge_metrics(os.path.join(self._base_work_dir, "pge_metrics.json"), pge_metrics)

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -124,7 +124,7 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
                     makedirs(dir_path)
 
                     logger.info("Localizing {}".format(url))
-                    async_task = pool.apply_async(_download_wrapper, args=(url, path, event), kwds={"event": event})
+                    async_task = pool.apply_async(_download_wrapper, args=(url, path), kwds={"event": event})
                     async_tasks.append(async_task)
 
                 pool.close()

--- a/opera_commons/logger.py
+++ b/opera_commons/logger.py
@@ -9,6 +9,15 @@ log_format = "[%(asctime)s: %(levelname)s/%(funcName)s] %(message)s"
 logging.basicConfig(format=log_format, level=logging.INFO)
 
 
+def init_pool_logger():
+    handler = logging.StreamHandler()
+    handler.setFormatter(
+        logging.Formatter("[%(asctime)s: %(levelname)s/%(name)s] %(message)s")
+    )
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+
+
 class LogLevels(Enum):
     DEBUG = "DEBUG"
     INFO = "INFO"

--- a/tools/populate_cmr_rtc_cache.py
+++ b/tools/populate_cmr_rtc_cache.py
@@ -18,6 +18,8 @@ from data_subscriber.dist_s1_utils import parse_local_burst_db_pickle, localize_
 import re
 from data_subscriber.rtc_for_dist.dist_dependency import CMR_RTC_CACHE_INDEX
 from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
 
 '''Given a cmr survey csv file, populate the cmr_rtc_cache index with RTC granules from it'''
 
@@ -131,27 +133,28 @@ def populate_cmr_rtc_cache(granules: List[Dict[str, Any]], es_conn) -> None:
     
     # Index granules
     logger.info(f"Indexing {len(granules)} granules to {index_name}")
-    
-    for i, granule in enumerate(tqdm(granules)):
 
-        # Use granule_id as document ID
-        doc_id = granule["granule_id"]
-        
-        # Prepare document for indexing
-        doc = {
-            "@timestamp": datetime.now(),
-            "granule_id": granule["granule_id"],
-            "burst_id": granule["burst_id"],
-            "acquisition_timestamp": granule["acquisition_timestamp"],
-            "revision_timestamp": granule["revision_timestamp"],
-            "sensor": granule["sensor"],
-            "product_version": granule["product_version"],
-            "acquisition_cycle": granule["acquisition_cycle"],
-            "creation_timestamp": datetime.now()
-        }
-        
-        # Index document
-        es_conn.es.index(index=index_name, id=doc_id, body=doc)
+    with logging_redirect_tqdm():
+        for i, granule in enumerate(tqdm(granules)):
+
+            # Use granule_id as document ID
+            doc_id = granule["granule_id"]
+
+            # Prepare document for indexing
+            doc = {
+                "@timestamp": datetime.now(),
+                "granule_id": granule["granule_id"],
+                "burst_id": granule["burst_id"],
+                "acquisition_timestamp": granule["acquisition_timestamp"],
+                "revision_timestamp": granule["revision_timestamp"],
+                "sensor": granule["sensor"],
+                "product_version": granule["product_version"],
+                "acquisition_cycle": granule["acquisition_cycle"],
+                "creation_timestamp": datetime.now()
+            }
+
+            # Index document
+            es_conn.es.index(index=index_name, id=doc_id, body=doc)
     
     # Refresh index
     es_conn.es.indices.refresh(index=index_name)

--- a/tools/populate_cmr_rtc_cache.py
+++ b/tools/populate_cmr_rtc_cache.py
@@ -17,6 +17,7 @@ from rtc_utils import rtc_granule_regex, determine_acquisition_cycle
 from data_subscriber.dist_s1_utils import parse_local_burst_db_pickle, localize_dist_burst_db
 import re
 from data_subscriber.rtc_for_dist.dist_dependency import CMR_RTC_CACHE_INDEX
+from tqdm import tqdm
 
 '''Given a cmr survey csv file, populate the cmr_rtc_cache index with RTC granules from it'''
 
@@ -131,7 +132,7 @@ def populate_cmr_rtc_cache(granules: List[Dict[str, Any]], es_conn) -> None:
     # Index granules
     logger.info(f"Indexing {len(granules)} granules to {index_name}")
     
-    for i, granule in enumerate(granules):
+    for i, granule in enumerate(tqdm(granules)):
 
         # Use granule_id as document ID
         doc_id = granule["granule_id"]


### PR DESCRIPTION
This PR adapts parallel input URL localization from [NISAR PCM](https://github.jpl.nasa.gov/IEMS-SDS/nisar-pcm/blob/e1e5ea0d2efdfe84491d25e656a08ba3280edad0/nisar_chimera/nisar_pge_job_submitter.py#L174-L239), which greatly reduces job startup time for jobs with large numbers of input files such as DISP-S1 or DIST-S1.

(Also added a progress bar to the RTC cache populate tool to make it a little friendlier to run)

## Issues
- Closes #1316 
## Testing
- Deployed cluster and tested with DIST jobs that did and did not include confirmation. Confirmed input files were downloaded in parallel.
