### PR TITLE
DIST-S1 CalVal PGE v6.0.0-rc.4.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.3.0"
+    "dist_s1"  = "6.0.0-rc.4.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -125,7 +125,7 @@ variable "pge_releases" {
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
     "tropo"    = "3.0.0-er.3.0-tropo"
-    "dist_s1"  = "6.0.0-rc.3.0"
+    "dist_s1"  = "6.0.0-rc.4.0"
     "disp_ni"  = "6.0.0-er.1.0"
   }
 }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.3.0"
+    "dist_s1"  = "6.0.0-rc.4.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -42,7 +42,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.3.0"
-    "dist_s1"  = "6.0.0-rc.3.0"
+    "dist_s1"  = "6.0.0-rc.4.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -837,7 +837,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.3-dswx-s1"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.3.0"
+    "dist_s1"  = "6.0.0-rc.4.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -236,7 +236,11 @@ DIST_S1:
   ANCILLARY_MARGIN: 50
 
   # S3 path to the algorithm parameters YAML file
-  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.7/algorithm_parameters_transformer_optimized.yaml"
+  # ADT-provided, supports up to 4-3-3
+  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.8/algorithm_parameters_transformer_optimized.yaml"
+
+  # For testing with 8-6-6
+  # ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.8/algorithm_parameters_transformer_v1_32.yaml"
 
 TROPO:
   # Number of workers to allocate to the "n_workers" field of the TROPO RunConfig

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -237,10 +237,10 @@ DIST_S1:
 
   # S3 path to the algorithm parameters YAML file
   # ADT-provided, supports up to 4-3-3
-  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.8/algorithm_parameters_transformer_optimized.yaml"
+  # ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.8/algorithm_parameters_transformer_optimized.yaml"
 
   # For testing with 8-6-6
-  # ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.8/algorithm_parameters_transformer_v1_32.yaml"
+  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.8/algorithm_parameters_transformer_v1_32.yaml"
 
 TROPO:
   # Number of workers to allocate to the "n_workers" field of the TROPO RunConfig

--- a/docker/job-spec.json.SCIFLO_L3_DIST_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DIST_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dist_s1:6.0.0-rc.3.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.3.0.tar.gz",
+      "container_image_name": "opera_pge/dist_s1:6.0.0-rc.4.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.4.0.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -42,8 +42,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/dist_s1:6.0.0-rc.3.0",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.3.0.tar.gz",
+          "container_image_name": "opera_pge/dist_s1:6.0.0-rc.4.0",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.4.0.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
             "validators",
             "cachetools==5.2.0",
 
-            "boto3-stubs",
+            "boto3-stubs==1.42.5",
             "boto3-stubs-lite[essential]==1.42.5",  # for ec2, s3, rds, lambda, sqs, dynamo and cloudformation
 
             "aws-requests-auth",

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
             "boto3-stubs",
             "boto3-stubs-lite[essential]",  # for ec2, s3, rds, lambda, sqs, dynamo and cloudformation
 
-            "aws-requests-auth",
+            "aws-requests-auth==0.4.3",
 
             # for ECMWF merger
             "rioxarray",

--- a/setup.py
+++ b/setup.py
@@ -44,8 +44,8 @@ setup(
             "validators",
             "cachetools==5.2.0",
 
-            "boto3-stubs==1.42.5",
-            "boto3-stubs-lite[essential]==1.42.5",  # for ec2, s3, rds, lambda, sqs, dynamo and cloudformation
+            "boto3-stubs",
+            "boto3-stubs-lite[essential]",  # for ec2, s3, rds, lambda, sqs, dynamo and cloudformation
 
             "aws-requests-auth",
 

--- a/setup.py
+++ b/setup.py
@@ -45,9 +45,9 @@ setup(
             "cachetools==5.2.0",
 
             "boto3-stubs",
-            "boto3-stubs-lite[essential]",  # for ec2, s3, rds, lambda, sqs, dynamo and cloudformation
+            "boto3-stubs-lite[essential]==1.42.5",  # for ec2, s3, rds, lambda, sqs, dynamo and cloudformation
 
-            "aws-requests-auth==0.4.3",
+            "aws-requests-auth",
 
             # for ECMWF merger
             "rioxarray",


### PR DESCRIPTION
## Purpose
This PR integrates the latest "CalVal" release of the DIST-S1 PGE.

## Testing
- [x] Cluster deploy
- [x] Smoke test
- [x] Real mode jobs
  - [x] 4-3-3
    - [x] Initial product
    - [x] Chained products
    - [x] Other test cases (VV/VH, HH/HV, Forward mode, etc)
  - [x] 8-6-6
    - [x] Initial product
    - [x] Chained products
    - [x] Other test cases (VV/VH, HH/HV, Forward mode, etc)