### PR TITLE
Issue #1326: fix(DSWx-S1): support --use-temporal. update regression tests

### DIFF
--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -247,7 +247,7 @@ def create_parser():
 
     full_parser = subparsers.add_parser("full",
                                         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    full_parser_arg_list = [verbose, quiet, endpoint, collection, product, start_date, end_date,
+    full_parser_arg_list = [verbose, quiet, endpoint, provider, collection, product, start_date, end_date,
                             bbox, minutes, k, m, grace_mins,
                             dry_run, smoke_run, no_schedule_download,
                             release_version, job_queue, chunk_size, max_revision,

--- a/data_subscriber/rtc/rtc_query.py
+++ b/data_subscriber/rtc/rtc_query.py
@@ -128,8 +128,8 @@ class RtcCmrQuery(BaseQuery):
         self.logger.info("Evaluating available burst sets")
         self.logger.debug(f"{sensor_to_affected_mgrs_set_id_acquisition_ts_cycle_indexes=}")
 
-        if self.args.native_id:  # limit query to the 1 or 2 affected sets in backlog
-            self.logger.info("Supplied native-id, limiting evaluation")
+        if self.args.native_id or self.args.use_temporal:  # limit query to the 1 or 2 affected sets in backlog. more sets may be affected depending on time range paired with --use-temporal
+            self.logger.info("Supplied native-id or use-temporal, limiting evaluation")
 
             min_num_bursts = self.args.coverage_target_num
             if not min_num_bursts:

--- a/tests/regression/test_dswx_s1_edge_cases.py
+++ b/tests/regression/test_dswx_s1_edge_cases.py
@@ -88,14 +88,13 @@ async def test_subscriber_rtc_trigger_logic():
     # assert result["mgrs_sets"]["MS_33_26"][0]["coverage_actual"] == 80
     assert result["mgrs_sets"]["MS_135_25"][0]["coverage_actual"] == 77
     assert not result["mgrs_sets"].get("MS_4_8")
-    assert not result["mgrs_sets"].get("MS_4_15")
-    assert not result["mgrs_sets"].get("MS_33_13")
-    assert result["mgrs_sets"]["MS_74_46"][0]["coverage_actual"] == 29
-    assert result["mgrs_sets"].get("MS_1_59")[0]["coverage_actual"] == 39
+    assert result["mgrs_sets"]["MS_4_15"][0]["coverage_actual"] == 17
+    assert result["mgrs_sets"]["MS_33_13"][0]["coverage_actual"] == 17
+    assert result["mgrs_sets"]["MS_74_46"][0]["coverage_actual"] == 100
+    assert result["mgrs_sets"]["MS_1_59"][0]["coverage_actual"] == 100
     assert result["mgrs_sets"]["MS_26_48"][0]["coverage_actual"] == 60
-    assert not result["mgrs_sets"].get("MS_4_8")
     assert result["mgrs_sets"]["MS_1_58"][0]["coverage_actual"] == 53
-    assert not result["mgrs_sets"].get("MS_4_14")
+    assert result["mgrs_sets"]["MS_4_14"][0]["coverage_actual"] == 100
 
     with Path(__file__).parent.parent.parent.joinpath("target", "results_test_subscriber_rtc_trigger_logic").open("w") as fp:
         fp.write("PASS")


### PR DESCRIPTION
## Purpose
fix #1326
## Proposed Changes
- [CHANGE] using temporal time now restricts processing only to the affected products -- excluding the backlog.

## Issues
#1326
## Testing
tested locally and on dev cluster
