### PR TITLE
Install Duplicates check + DSWx-HLS accountability as metrics cron job

### DIFF
--- a/cluster_provisioning/dev-e2e/main.tf
+++ b/cluster_provisioning/dev-e2e/main.tf
@@ -107,6 +107,7 @@ module "common" {
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
   asf_cnm_s_id_prod                       = var.asf_cnm_s_id_prod
   es_cluster_mode                         = var.es_cluster_mode
+  duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }
 
 locals {

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -528,3 +528,9 @@ variable "es_cluster_mode" {
   type    = bool
   default = false
 }
+
+variable "duplicates_cronjob_enable" {
+  type    = bool
+  default = false
+}
+

--- a/cluster_provisioning/dev-int/main.tf
+++ b/cluster_provisioning/dev-int/main.tf
@@ -104,6 +104,7 @@ module "common" {
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
   asf_cnm_s_id_prod                       = var.asf_cnm_s_id_prod
   es_cluster_mode                         = var.es_cluster_mode
+  duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }
 
 locals {

--- a/cluster_provisioning/dev/main.tf
+++ b/cluster_provisioning/dev/main.tf
@@ -108,6 +108,7 @@ module "common" {
   cnm_r_sqs_arn                           = var.cnm_r_sqs_arn
   es_bucket_role_arn                      = var.es_bucket_role_arn
   es_cluster_mode                         = var.es_cluster_mode
+  duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }
 
 locals {

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -502,3 +502,9 @@ variable "es_cluster_mode" {
   type    = bool
   default = false
 }
+
+variable "duplicates_cronjob_enable" {
+  type    = bool
+  default = false
+}
+

--- a/cluster_provisioning/int/int-fwd/main.tf
+++ b/cluster_provisioning/int/int-fwd/main.tf
@@ -52,4 +52,5 @@ module "int-main" {
   aws_account_id                          = var.aws_account_id
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
   ssm_account_id                          = var.ssm_account_id
+  duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }

--- a/cluster_provisioning/int/main.tf
+++ b/cluster_provisioning/int/main.tf
@@ -112,6 +112,7 @@ module "common" {
   asf_cnm_s_id_dev_int                    = var.asf_cnm_s_id_dev_int
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
   asf_cnm_s_id_prod                       = var.asf_cnm_s_id_prod
+  duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }
 
 locals {

--- a/cluster_provisioning/modules/common/grq_factotum_metrics.tf
+++ b/cluster_provisioning/modules/common/grq_factotum_metrics.tf
@@ -247,6 +247,14 @@ resource "null_resource" "setup_cron" {
       chmod +x ~/metrics/conf/sds/files/metrics/cron/run_cmr_audit.sh
       mv ~/metrics/conf/sds/files/metrics/cron/run_cmr_audit.sh ~/.local/bin/cron/
 
+      chmod +x ~/metrics/conf/sds/files/metrics/cron/install_duplicates_audit.sh
+      ~/metrics/conf/sds/files/metrics/cron/install_duplicates_audit.sh
+
+      chmod +x ~/metrics/conf/sds/files/metrics/cron/run_duplicates_audit.sh
+      mv ~/metrics/conf/sds/files/metrics/cron/run_duplicates_audit.sh ~/.local/bin/cron/
+      echo "export ES_URL=http://${aws_instance.metrics.private_ip}:9200" >> ~/metrics/conf/sds/files/metrics/cron/duplicates.env
+      echo "export S3_BUCKET=${var.lts_bucket}" >> ~/metrics/conf/sds/files/metrics/cron/duplicates.env
+
       crontab ~/metrics/conf/sds/files/metrics/cron/hysdsops
     EOT
     ]

--- a/cluster_provisioning/modules/common/grq_factotum_metrics.tf
+++ b/cluster_provisioning/modules/common/grq_factotum_metrics.tf
@@ -209,6 +209,7 @@ resource "aws_instance" "metrics" {
 
 resource "null_resource" "setup_cron" {
   depends_on = [aws_instance.metrics]
+  count      = var.duplicates_cronjob_enable ? 1 : 0
 
   connection {
     type        = "ssh"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -1050,3 +1050,8 @@ variable "disp_s1_hist_status" {
   type    = bool
   default = false
 }
+
+variable "duplicates_cronjob_enable" {
+  type    = bool
+  default = false
+}

--- a/cluster_provisioning/ops/ops-fwd/main.tf
+++ b/cluster_provisioning/ops/ops-fwd/main.tf
@@ -54,4 +54,5 @@ module "int-main" {
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
+  duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }

--- a/conf/sds/files/metrics/cron/hysdsops
+++ b/conf/sds/files/metrics/cron/hysdsops
@@ -13,3 +13,4 @@ SHELL=/bin/bash
 
 #@weekly $HOME/.local/bin/cron/run_cmr_audit.sh --hls 2>&1 | logger -i -p user.notice -t cmr_audit_hls-task
 #@weekly $HOME/.local/bin/cron/run_cmr_audit.sh --slc 2>&1 | logger -i -p user.notice -t cmr_audit_slc-task
+0 0 * * * $HOME/.local/bin/cron/run_duplicates_audit.sh 2>&1 | logger -i -p user.notice -t cmr_audit_duplicates_and_accountability-task

--- a/conf/sds/files/metrics/cron/install_duplicates_audit.sh
+++ b/conf/sds/files/metrics/cron/install_duplicates_audit.sh
@@ -5,7 +5,7 @@ deactivate
 set -e
 
 cd /export/home/hysdsops/
-git clone --quiet --single-branch -b 'feature/duplicates_cron' https://github.com/nasa/opera-sds-ops.git
+git clone --quiet --single-branch -b 'main' https://github.com/nasa/opera-sds-ops.git
 cd opera-sds-ops/duplicates/
 
 python --version

--- a/conf/sds/files/metrics/cron/install_duplicates_audit.sh
+++ b/conf/sds/files/metrics/cron/install_duplicates_audit.sh
@@ -4,7 +4,7 @@ set +e
 deactivate
 set -e
 
-cd cd /export/home/hysdsops/
+cd /export/home/hysdsops/
 git clone --quiet --single-branch -b 'feature/duplicates_cron' https://github.com/nasa/opera-sds-ops.git
 cd opera-sds-ops/duplicates/
 

--- a/conf/sds/files/metrics/cron/install_duplicates_audit.sh
+++ b/conf/sds/files/metrics/cron/install_duplicates_audit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set +e
+deactivate
+set -e
+
+cd cd /export/home/hysdsops/
+git clone --quiet --single-branch -b 'feature/duplicates_cron' https://github.com/nasa/opera-sds-ops.git
+cd opera-sds-ops/duplicates/
+
+python --version
+python -m venv venv
+
+source ./venv/bin/activate
+pip install -r requirements.txt
+
+deactivate

--- a/conf/sds/files/metrics/cron/run_duplicates_audit.sh
+++ b/conf/sds/files/metrics/cron/run_duplicates_audit.sh
@@ -4,7 +4,7 @@ set +e
 deactivate
 set -ex
 
-cd cd /export/home/hysdsops/opera-sds-ops/duplicates/
+cd /export/home/hysdsops/opera-sds-ops/duplicates/
 source ./venv/bin/activate
 
 source /export/home/hysdsops/metrics/conf/sds/files/metrics/cron/duplicates.env

--- a/conf/sds/files/metrics/cron/run_duplicates_audit.sh
+++ b/conf/sds/files/metrics/cron/run_duplicates_audit.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set +e
+deactivate
+set -ex
+
+cd cd /export/home/hysdsops/opera-sds-ops/duplicates/
+source ./venv/bin/activate
+
+source /export/home/hysdsops/metrics/conf/sds/files/metrics/cron/duplicates.env
+
+python duplicate_and_accountability_cron.py DSWX_HLS CSLC_S1 RTC_S1 DSWX_S1 DISP_S1 TROPO -d 14 \
+       --report-dir cron_reports --s3-report-path "s3://${S3_BUCKET}/duplicate_reports/" --opensearch "${ES_URL}" \
+       --plot-dir cron_plots --s3-plot-path "s3://${S3_BUCKET}/duplicate_plots/"


### PR DESCRIPTION
## Purpose
- Install duplicates + DSWx-HLS accountability scripts from nasa/opera-sds-ops#42 to metrics as a cron job running daily at midnight UTC
