### PR TITLE
DIST-S1 Final PGE v6.0.0 Integration

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.5.0"
+    "dist_s1"  = "6.0.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -125,7 +125,7 @@ variable "pge_releases" {
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
     "tropo"    = "3.0.0-er.3.0-tropo"
-    "dist_s1"  = "6.0.0-rc.5.0"
+    "dist_s1"  = "6.0.0"
     "disp_ni"  = "6.0.0-er.1.0"
   }
 }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.5.0"
+    "dist_s1"  = "6.0.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -42,7 +42,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.3.0"
-    "dist_s1"  = "6.0.0-rc.5.0"
+    "dist_s1"  = "6.0.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -835,7 +835,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.8"
     "dswx_ni"  = "4.0.0-er.4.0"
-    "dist_s1"  = "6.0.0-rc.5.0"
+    "dist_s1"  = "6.0.0"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.1.0"
   }

--- a/docker/job-spec.json.SCIFLO_L3_DIST_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DIST_S1
@@ -10,8 +10,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dist_s1:6.0.0-rc.5.0",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.5.0.tar.gz",
+      "container_image_name": "opera_pge/dist_s1:6.0.0",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -42,8 +42,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/dist_s1:6.0.0-rc.5.0",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0-rc.5.0.tar.gz",
+          "container_image_name": "opera_pge/dist_s1:6.0.0",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.0.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
## Purpose
This PR integrates the latest "Final" release of the DIST-S1 PGE.

## Testing
- [x] Cluster deploy
- [x] Smoke test
- [x] Pydantic error
  - Trigger a SCIFLO job with a bad runconfig and verify the full pydantic error is visible in Figaro
- [x] Real mode jobs
  - [x] Initial product
  - [x] Chained products
  - [x] Other test cases (VV/VH, HH/HV, Forward mode, etc)