### PR TITLE
Fix baseline construction with a polarization switch

### DIFF
--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -393,7 +393,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
     def download_job_submission_handler(self, total_granules, query_timerange):
 
         def add_filtered_urls(granule, filtered_urls: list, polarization_preference: Union[set, None] =None):
-            self.logger.info(f'add_filtered_urls:: {polarization_preference=})')
+            self.logger.info(f'add_filtered_urls:: {polarization_preference=} {granule["granule_id"]}')
             if granule.get("filtered_urls"):
                 # ignore single polarizations. declared polarization
                 if len(granule.get("polarization", [])) == 1:

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -651,6 +651,9 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
             current_burst_set = set([url_to_burst_id(url) for url in batch_current_urls])
             baseline_burst_set = set([url_to_burst_id(url) for url in batch_baseline_urls])
 
+            self.logger.info(f'{current_burst_set=}')
+            self.logger.info(f'{baseline_burst_set=}')
+
             if current_burst_set != baseline_burst_set:
                 if current_burst_set - baseline_burst_set:
                     raise ValueError(f'There are missing bursts from the '

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -469,7 +469,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
                         if any(filter_url.endswith(s) for s in ["HH.tif", "HV.tif"]):
                             filtered_urls.append(filter_url)
-                        return frozenset({"VV", "VH"})
+                        return frozenset({"HH", "HV"})
                 else:
                     self.logger.error(f"Unexpected polarization {most_common_polarization=}. Falling back to regular filtering.")
                     for filter_url in granule.get("filtered_urls"):

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -438,7 +438,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
                             if any(filter_url.endswith(s) for s in ["VV.tif", "VH.tif"]):
                                 filtered_urls.append(filter_url)
-                        return
+                        return frozenset({"VV", "VH"})
                     elif polarization_preference == {"HH", "HV"}:
                         self.logger.info('Filtering to pol pref HH/HV')
                         for filter_url in granule.get("filtered_urls"):
@@ -448,7 +448,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
                             if any(filter_url.endswith(s) for s in ["HH.tif", "HV.tif"]):
                                 filtered_urls.append(filter_url)
-                        return
+                        return frozenset({"HH", "HV"})
 
                 if most_common_polarization and most_common_polarization[0][0] == {"VV", "VH"}:
                     self.logger.info('Filtering to common pol VV/VH')
@@ -459,6 +459,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
                         if any(filter_url.endswith(s) for s in ["VV.tif", "VH.tif"]):
                             filtered_urls.append(filter_url)
+                    return frozenset({"VV", "VH"})
                 elif most_common_polarization and most_common_polarization[0][0] == {"HH", "HV"}:
                     self.logger.info('Filtering to common pol HH/HV')
                     for filter_url in granule.get("filtered_urls"):
@@ -468,6 +469,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
                         if any(filter_url.endswith(s) for s in ["HH.tif", "HV.tif"]):
                             filtered_urls.append(filter_url)
+                        return frozenset({"VV", "VH"})
                 else:
                     self.logger.error(f"Unexpected polarization {most_common_polarization=}. Falling back to regular filtering.")
                     for filter_url in granule.get("filtered_urls"):
@@ -539,8 +541,8 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
             else:
                 continue
             burst_id = granule['granule_id'].split('_')[3]
-            burst_to_pol[burst_id] = pol_pref
-            add_filtered_urls(granule, batch_id_to_current_urls_map[granule["download_batch_id"]], polarization_preference=pol_pref)
+            # burst_to_pol[burst_id] = pol_pref
+            burst_to_pol[burst_id] = add_filtered_urls(granule, batch_id_to_current_urls_map[granule["download_batch_id"]], polarization_preference=pol_pref)
 
         batch_id_to_baseline_urls = defaultdict(list)
         for download_batch_id, granules in self.download_batch_id_to_k_granules.items():

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -469,7 +469,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
                         if any(filter_url.endswith(s) for s in ["HH.tif", "HV.tif"]):
                             filtered_urls.append(filter_url)
-                        return frozenset({"HH", "HV"})
+                    return frozenset({"HH", "HV"})
                 else:
                     self.logger.error(f"Unexpected polarization {most_common_polarization=}. Falling back to regular filtering.")
                     for filter_url in granule.get("filtered_urls"):

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -652,7 +652,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
             baseline_burst_set = set([url_to_burst_id(url) for url in batch_baseline_urls])
 
             if current_burst_set != baseline_burst_set:
-                if current_burst_set.issuperset(baseline_burst_set):
+                if current_burst_set - baseline_burst_set:
                     raise ValueError(f'There are missing bursts from the '
                                      f'baseline set: {current_burst_set - baseline_burst_set}')
 

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -553,7 +553,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
                 #self.logger.info(granule["download_batch_id"])
                 pol_pref = first(product_id_to_polarization_map.get(granule["product_id"]))
                 burst_id = granule['granule_id'].split('_')[3]
-                pol_pref = burst_to_pol[burst_id]
+                pol_pref = burst_to_pol.get(burst_id, pol_pref)
                 #print(download_batch_id, granule["download_batch_id"])
                 add_filtered_urls(granule, batch_id_to_baseline_urls[download_batch_id], polarization_preference=pol_pref)
         #print(batch_id_to_baseline_urls)

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -519,6 +519,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
             for granule in total_granules for filter_url in granule.get("filtered_urls")
         ]
         common_pol = Counter(current_set_polarizations).most_common(1)[0][0]
+        burst_to_pol = {}
 
         for granule in total_granules:
             # prefer to filter granules based on this "base" polarization
@@ -537,6 +538,8 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
                 self.logger.info(f'Multiple polarizations {set(pol_pref)} detected in current granules for {granule["download_batch_id"]}. A download job will not be submitted.')
             else:
                 continue
+            burst_id = granule['granule_id'].split('_')[3]
+            burst_to_pol[burst_id] = pol_pref
             add_filtered_urls(granule, batch_id_to_current_urls_map[granule["download_batch_id"]], polarization_preference=pol_pref)
 
         batch_id_to_baseline_urls = defaultdict(list)
@@ -549,6 +552,8 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
                 #self.logger.info(download_batch_id)
                 #self.logger.info(granule["download_batch_id"])
                 pol_pref = first(product_id_to_polarization_map.get(granule["product_id"]))
+                burst_id = granule['granule_id'].split('_')[3]
+                pol_pref = burst_to_pol[burst_id]
                 #print(download_batch_id, granule["download_batch_id"])
                 add_filtered_urls(granule, batch_id_to_baseline_urls[download_batch_id], polarization_preference=pol_pref)
         #print(batch_id_to_baseline_urls)

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -560,8 +560,10 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
         #self.logger.debug(f"{batch_id_to_urls_map=}")
 
-        batch_id_to_baseline_urls = self._restrict_baseline_bursts_by_batch(batch_id_to_current_urls_map,
-                                                                            batch_id_to_baseline_urls)
+        batch_id_to_current_urls_map, batch_id_to_baseline_urls = self._restrict_batch_urls_by_common_bursts(
+            batch_id_to_current_urls_map,
+            batch_id_to_baseline_urls
+        )
 
         job_submission_tasks = []
         product_metadata = {}
@@ -627,8 +629,8 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
         return job_submission_tasks
 
-    def _restrict_baseline_bursts_by_batch(self, batch_to_current, batch_to_baseline):
-        self.logger.info(f'Restricting baseline bursts to current set bursts')
+    def _restrict_batch_urls_by_common_bursts(self, batch_to_current, batch_to_baseline):
+        self.logger.info(f'Restricting URLs to common bursts')
 
         def url_to_burst_id(url):
             match = re.match(rtc_product_file_regex, basename(url))
@@ -655,23 +657,40 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
             self.logger.info(f'{baseline_burst_set=}')
 
             if current_burst_set != baseline_burst_set:
-                if current_burst_set - baseline_burst_set:
-                    raise ValueError(f'There are missing bursts from the '
-                                     f'baseline set: {current_burst_set - baseline_burst_set}')
+                common_burst_set = current_burst_set & baseline_burst_set
+                self.logger.warning(f'Detected a mismatch in bursts between the current and baseline RTC sets. '
+                                    f'The common bursts are: {common_burst_set}')
+                self.logger.info('Checking current set for extra bursts')
+
+                extra_bursts = current_burst_set - baseline_burst_set
+
+                if extra_bursts:
+                    self.logger.warning(f'Found {len(extra_bursts)} bursts to remove '
+                                        f'from the current set: {extra_bursts}')
+
+                    batch_to_current[batch_id] = [url for url in batch_current_urls
+                                                  if url_to_burst_id(url) in common_burst_set]
+
+                    self.logger.info(f'Reduced baseline URL set for {batch_id=} from {len(batch_current_urls)} to '
+                                     f'{len(batch_to_current[batch_id])}')
+
+                self.logger.info('Checking current set for extra bursts')
 
                 extra_bursts = baseline_burst_set - current_burst_set
 
-                self.logger.warning(f'Found {len(extra_bursts)} bursts to remove from the baseline set: {extra_bursts}')
+                if extra_bursts:
+                    self.logger.warning(f'Found {len(extra_bursts)} bursts to remove '
+                                        f'from the baseline set: {extra_bursts}')
 
-                batch_to_baseline[batch_id] = [url for url in batch_baseline_urls
-                                               if url_to_burst_id(url) in current_burst_set]
+                    batch_to_baseline[batch_id] = [url for url in batch_baseline_urls
+                                                   if url_to_burst_id(url) in common_burst_set]
 
-                self.logger.info(f'Reduced baseline URL set for {batch_id=} from {len(batch_baseline_urls)} to '
-                                 f'{len(batch_to_baseline[batch_id])}')
+                    self.logger.info(f'Reduced baseline URL set for {batch_id=} from {len(batch_baseline_urls)} to '
+                                     f'{len(batch_to_baseline[batch_id])}')
             else:
-                self.logger.info(f'Baseline for {batch_id=} contains no extra bursts')
+                self.logger.info(f'Baseline and current sets for {batch_id=} contain no extra bursts')
 
-        return batch_to_baseline
+        return batch_to_current, batch_to_baseline
 
     @staticmethod
     def create_batch_id_to_polarizations_map(batch_to_granules_map):


### PR DESCRIPTION
This PR ensures each RTC burst in the current set gets a baseline constructed with bursts with the same polarization.

This is an important fix for #1361 
