### PR TITLE
add cluster-local Verdi AMI SSM parameter support for ops

### DIFF
--- a/cluster_provisioning/dev-e2e/main.tf
+++ b/cluster_provisioning/dev-e2e/main.tf
@@ -56,6 +56,7 @@ module "common" {
   private_asg_vpc                         = var.private_asg_vpc
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   lambda_package_release                  = var.lambda_package_release
   environment                             = var.environment
   use_artifactory                         = var.use_artifactory

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -325,6 +325,11 @@ variable "ssm_account_id" {
 
 }
 
+variable "use_cluster_verdi_ssm" {
+  type    = bool
+  default = false
+}
+
 variable "lambda_package_release" {
   default = "develop"
 }

--- a/cluster_provisioning/dev-int/main.tf
+++ b/cluster_provisioning/dev-int/main.tf
@@ -56,6 +56,7 @@ module "common" {
   private_asg_vpc                         = var.private_asg_vpc
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   lambda_package_release                  = var.lambda_package_release
   environment                             = var.environment
   use_artifactory                         = var.use_artifactory

--- a/cluster_provisioning/dev-releaser/main.tf
+++ b/cluster_provisioning/dev-releaser/main.tf
@@ -57,6 +57,7 @@ module "common" {
   private_asg_vpc                         = var.private_asg_vpc
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   lambda_package_release                  = var.lambda_package_release
   environment                             = var.environment
   use_artifactory                         = var.use_artifactory

--- a/cluster_provisioning/dev-releaser/variables.tf
+++ b/cluster_provisioning/dev-releaser/variables.tf
@@ -322,6 +322,11 @@ variable "aws_account_id" {
 variable "ssm_account_id" {
 }
 
+variable "use_cluster_verdi_ssm" {
+  type    = bool
+  default = false
+}
+
 variable "lambda_package_release" {
   default = "develop"
 }

--- a/cluster_provisioning/dev/main.tf
+++ b/cluster_provisioning/dev/main.tf
@@ -65,6 +65,7 @@ module "common" {
   private_asg_vpc                         = var.private_asg_vpc
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   lambda_package_release                  = var.lambda_package_release
   environment                             = var.environment
   use_artifactory                         = var.use_artifactory

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -325,6 +325,11 @@ variable "aws_account_id" {
 variable "ssm_account_id" {
 }
 
+variable "use_cluster_verdi_ssm" {
+  type    = bool
+  default = false
+}
+
 variable "lambda_package_release" {
   default = "develop"
 }

--- a/cluster_provisioning/int/int-fwd/main.tf
+++ b/cluster_provisioning/int/int-fwd/main.tf
@@ -52,5 +52,6 @@ module "int-main" {
   aws_account_id                          = var.aws_account_id
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }

--- a/cluster_provisioning/int/main.tf
+++ b/cluster_provisioning/int/main.tf
@@ -62,6 +62,7 @@ module "common" {
   private_asg_vpc                         = var.private_asg_vpc
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   lambda_package_release                  = var.lambda_package_release
   environment                             = var.environment
   use_artifactory                         = var.use_artifactory

--- a/cluster_provisioning/modules/common/main.tf
+++ b/cluster_provisioning/modules/common/main.tf
@@ -70,11 +70,23 @@ locals {
   asf_cnm_s_id_prod           = var.asf_cnm_s_id_prod
 
   ami_versions = length(var.ami_versions) != 0 ? var.ami_versions : var.default_ami_versions # tflint-ignore: terraform_unused_declarations
-  # resolve:ssm:arn:aws:ssm:us-west-2:${var.ssm_account_id}:parameter/iems/pcm/verdi/v5.3
-  verdi_ssm_arn               = "resolve:ssm:arn:aws:ssm:${var.region}:${var.ssm_account_id}:parameter/iems/pcm/verdi/${local.ami_versions["autoscale"]}"
+  default_verdi_ssm_arn       = "arn:aws:ssm:${var.region}:${var.ssm_account_id}:parameter/iems/pcm/verdi/${local.ami_versions["autoscale"]}"
+  verdi_ssm_arn               = var.use_cluster_verdi_ssm == true ? "resolve:ssm:arn:aws:ssm:${var.region}:${var.aws_account_id}:parameter/iems/pcm/verdi/${var.project}-${var.venue}-${local.counter}/${local.ami_versions["autoscale"]}" : "resolve:ssm:${local.default_verdi_ssm_arn}"
   es_cluster_mode             = var.grq_aws_es == false ? var.es_cluster_mode : false
   es_identifier               = local.es_cluster_mode == true ? "${var.venue}-${local.counter}" : null
   use_mozart_es               = false
+}
+
+resource "null_resource" "create_cluster_verdi_ssm" {
+  provisioner "local-exec" {
+    command = <<EOT
+    set -ex
+    if [ "${var.use_cluster_verdi_ssm}" = true ]; then
+      VERDI_AMI=$(aws ssm get-parameter --name "${local.default_verdi_ssm_arn}" --with-decryption --query "Parameter.Value" --output text) || exit 1
+      aws ssm put-parameter --region ${var.region} --name "/iems/pcm/verdi/${var.project}-${var.venue}-${local.counter}/${local.ami_versions["autoscale"]}" --data-type 'aws:ec2:image' --type 'String' --value $${VERDI_AMI} --overwrite || exit 1
+    fi
+    EOT
+  }
 }
 
 resource "null_resource" "download_lambdas" {

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -1064,6 +1064,11 @@ variable "default_ami_versions" {
   }
 }
 
+variable "use_cluster_verdi_ssm" {
+  type    = bool
+  default = false
+}
+
 variable "es_cluster_mode" {
   type    = bool
   default = false

--- a/cluster_provisioning/ops/ops-fwd/main.tf
+++ b/cluster_provisioning/ops/ops-fwd/main.tf
@@ -53,6 +53,7 @@ module "int-main" {
   es_bucket_role_arn                      = var.es_bucket_role_arn
   aws_account_id                          = var.aws_account_id
   ssm_account_id                          = var.ssm_account_id
+  use_cluster_verdi_ssm                   = var.use_cluster_verdi_ssm
   asf_cnm_s_id_test                       = var.asf_cnm_s_id_test
   duplicates_cronjob_enable               = var.duplicates_cronjob_enable
 }

--- a/cluster_provisioning/ops/ops_override.tf
+++ b/cluster_provisioning/ops/ops_override.tf
@@ -156,6 +156,11 @@ variable "common_ci" {
   }
 }
 
+variable "use_cluster_verdi_ssm" {
+  type    = bool
+  default = true
+}
+
 # autoscale vars
 variable "autoscale" {
   type = map(string)


### PR DESCRIPTION
Copied from NISAR and SWOT.
                                                                                                          
Decouple ops from the central IEMS SSM parameter for Verdi AMI to prevent unintended weekly patching and insulate ops from central build failures. When use_cluster_verdi_ssm is enabled, Terraform copies the AMI ID from the central admin account into a cluster-scoped local SSM parameter and references that instead.                                              
                                                                                                                 
This mirrors the NISAR-PCM implementation:                                                                     
- New boolean variable use_cluster_verdi_ssm (default: false)                                                  
- null_resource copies AMI from central to local SSM at deploy time                                            
- Local SSM path: /iems/pcm/verdi/{project}-{venue}-{counter}/{version}                                        
- Ops override sets use_cluster_verdi_ssm = true                                                               
- All other environments unchanged (still use central parameter)