### PR TITLE
Disable check_ancillary_inputs_coverage in RTC-S1 Runconfig

### DIFF
--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -110,7 +110,7 @@ RunConfig:
           primary_executable:
             product_type: RTC_S1
           processing:
-            check_ancillary_inputs_coverage: True
+            check_ancillary_inputs_coverage: False
             polarization: {{ runconfig.processing.polarization }}
             rtc:
               output_type: gamma0


### PR DESCRIPTION
## Purpose
This setting is inhibiting generation of RTC-S1 bursts near the antimeridian. It's no longer needed as we've validated our ancillary staging, so it should be disabled.

## Issues
- [OPERA-2420](https://hysds-core.atlassian.net/browse/OPERA-2420)
## Testing
- Ran test with SLC `S1C_IW_SLC__1SDV_20260411T183019_20260411T183046_007172_00E883_08C3` and verified an RTC-S1 was produced for burst `T001-000673-IW3` which was flagged by ADT as an example of this issue.
