### PR TITLE
OPERA-2393, OPERA-2417: Add disk alarm, increase ES disk to 1TB, integrate ingest pipeline

### DIFF
--- a/cluster_provisioning/int/int-fwd/override.tf
+++ b/cluster_provisioning/int/int-fwd/override.tf
@@ -84,7 +84,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r6i.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.49.10"
     public_ip     = ""
   }
@@ -96,7 +96,7 @@ variable "metrics" {
   default = {
     name          = "metrics"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.49.11"
     public_ip     = ""
   }
@@ -108,7 +108,7 @@ variable "grq" {
   default = {
     name          = "grq"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.49.12"
     public_ip     = ""
   }

--- a/cluster_provisioning/int/int-pop1/override.tf
+++ b/cluster_provisioning/int/int-pop1/override.tf
@@ -73,7 +73,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r6i.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.49.20"
     public_ip     = ""
   }
@@ -85,7 +85,7 @@ variable "metrics" {
   default = {
     name          = "metrics"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.49.21"
     public_ip     = ""
   }
@@ -97,7 +97,7 @@ variable "grq" {
   default = {
     name          = "grq"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.49.22"
     public_ip     = ""
   }

--- a/cluster_provisioning/modules/common/cloudwatch.tf
+++ b/cluster_provisioning/modules/common/cloudwatch.tf
@@ -660,6 +660,28 @@ resource "aws_cloudwatch_metric_alarm" "factotum_diskalarm" {
   }
 }
 
+resource "aws_cloudwatch_metric_alarm" "factotum_data_diskalarm" {
+  alarm_name                = "${var.project}-${var.venue}-${local.counter}-factotum data disk usage"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "disk_used_percent"
+  namespace                 = "CWAgent"
+  period                    = "120"
+  statistic                 = "Average"
+  threshold                 = "75"
+  alarm_description         = "This metric monitors factotum data disk utilization"
+  insufficient_data_actions = []
+  alarm_actions             = [aws_sns_topic.operator_notify.arn]
+  dimensions = {
+    InstanceId   = aws_instance.factotum.id
+    ImageId      = data.aws_ami.factotum_ami.id
+    InstanceType = var.factotum["instance_type"]
+    device       = "nvme1n1"
+    fstype       = "xfs"
+    path         = "/data"
+  }
+}
+
 resource "aws_cloudwatch_metric_alarm" "sqs_cnm_r_dead_letter_alarm" {
   count                     = local.sqs_count
   alarm_name                = "${var.project}-${var.venue}-${local.counter}-mozart CNM-R dead letter queue"

--- a/cluster_provisioning/ops/ops-fwd/override.tf
+++ b/cluster_provisioning/ops/ops-fwd/override.tf
@@ -76,7 +76,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r6i.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.82.20"
     public_ip     = ""
   }
@@ -88,7 +88,7 @@ variable "metrics" {
   default = {
     name          = "metrics"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.82.11"
     public_ip     = ""
   }
@@ -100,7 +100,7 @@ variable "grq" {
   default = {
     name          = "grq"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.82.12"
     public_ip     = ""
   }

--- a/cluster_provisioning/ops/ops-pop1/override.tf
+++ b/cluster_provisioning/ops/ops-pop1/override.tf
@@ -79,7 +79,7 @@ variable "mozart" {
   default = {
     name          = "mozart"
     instance_type = "r6i.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.82.30"
     public_ip     = ""
   }
@@ -91,7 +91,7 @@ variable "metrics" {
   default = {
     name          = "metrics"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.82.31"
     public_ip     = ""
   }
@@ -103,7 +103,7 @@ variable "grq" {
   default = {
     name          = "grq"
     instance_type = "r5.4xlarge"
-    root_dev_size = 200
+    root_dev_size = 1000
     private_ip    = "100.104.82.32"
     public_ip     = ""
   }

--- a/conf/sds/cluster.py
+++ b/conf/sds/cluster.py
@@ -306,6 +306,42 @@ def update_ilm_policy_mozart():
     )
 
 
+@roles("mozart")
+def update_mozart_es():
+    create_ingest_pipeline_mozart()
+    update_mozart_index_templates_with_pipeline()
+
+
+@roles("mozart")
+def create_ingest_pipeline_mozart():
+    _, hysds_dir, _ = resolve_role()
+
+    copy(
+        "~/.sds/files/opensearch/ingest_pipeline_truncate_large_fields.json",
+        f"{hysds_dir}/ops/mozart/configs/ingest_pipeline_truncate_large_fields.json"
+    )
+    run(
+        "curl -f -X PUT 'localhost:9200/_ingest/pipeline/truncate_large_fields?pretty' "
+        "-H 'Content-Type: application/json' "
+        f"-d @{hysds_dir}/ops/mozart/configs/ingest_pipeline_truncate_large_fields.json"
+    )
+
+
+@roles("mozart")
+def update_mozart_index_templates_with_pipeline():
+    for template in ["task_status", "job_status"]:
+        run(
+            f"curl -s localhost:9200/_index_template/{template} "
+            "| python3 -c \""
+            "import json, sys; "
+            "tmpl = json.load(sys.stdin)['index_templates'][0]['index_template']; "
+            "tmpl.setdefault('template', {}).setdefault('settings', {}).setdefault('index', {})['default_pipeline'] = 'truncate_large_fields'; "
+            "print(json.dumps(tmpl))\" "
+            f"| curl -f -X PUT 'localhost:9200/_index_template/{template}' "
+            "-H 'Content-Type: application/json' -d @-"
+        )
+
+
 @roles("grq")
 def update_grq_es():
     context = get_context()

--- a/conf/sds/files/opensearch/ingest_pipeline_truncate_large_fields.json
+++ b/conf/sds/files/opensearch/ingest_pipeline_truncate_large_fields.json
@@ -1,0 +1,19 @@
+{
+  "description": "Truncate oversized event.exception, event.traceback, and remove duplicate top-level context",
+  "processors": [
+    {
+      "script": {
+        "description": "Truncate event.exception and event.traceback to 10KB",
+        "lang": "painless",
+        "source": "int maxLen = 10000; if (ctx.event != null) { if (ctx.event.exception instanceof String && ctx.event.exception.length() > maxLen) { String orig = ctx.event.exception; ctx.event.exception = orig.substring(0, maxLen) + \"... [TRUNCATED from \" + orig.length() + \" chars]\" } if (ctx.event.traceback instanceof String && ctx.event.traceback.length() > maxLen) { String orig = ctx.event.traceback; ctx.event.traceback = orig.substring(0, maxLen) + \"... [TRUNCATED from \" + orig.length() + \" chars]\" } }"
+      }
+    },
+    {
+      "script": {
+        "description": "Remove top-level context (duplicate of job.context)",
+        "lang": "painless",
+        "source": "if (ctx.context != null && ctx.job != null && ctx.job.context != null) { ctx.remove(\"context\") }"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add CloudWatch disk alarm for factotum /data volume, increase ES node disk sizes to 1TB, and integrate the `truncate_large_fields` OpenSearch ingest pipeline into the PCM deployment process.

Resolves [OPERA-2393](https://hysds-core.atlassian.net/browse/OPERA-2393), [OPERA-2417](https://hysds-core.atlassian.net/browse/OPERA-2417)

## Changes

### OPERA-2393: CW alarm and disk size increase

- **`cluster_provisioning/modules/common/cloudwatch.tf`** — Add `factotum_data_diskalarm` for the `/data` volume (`nvme1n1`) at 75% threshold, routed to `operator_notify` SNS topic
- **`cluster_provisioning/ops/ops-fwd/override.tf`** — Increase Mozart, Metrics, GRQ `root_dev_size` from 200 to 1000
- **`cluster_provisioning/ops/ops-pop1/override.tf`** — Increase Mozart, Metrics, GRQ `root_dev_size` from 200 to 1000
- **`cluster_provisioning/int/int-fwd/override.tf`** — Increase Mozart, Metrics, GRQ `root_dev_size` from 200 to 1000
- **`cluster_provisioning/int/int-pop1/override.tf`** — Increase Mozart, Metrics, GRQ `root_dev_size` from 200 to 1000

### OPERA-2417: OpenSearch ingest pipeline integration

- **`conf/sds/files/opensearch/ingest_pipeline_truncate_large_fields.json`** — New pipeline definition with two processors: truncate `event.exception`/`event.traceback` to 10KB, and remove duplicate top-level `context` from job documents
- **`conf/sds/cluster.py`** — Add three Fabric functions:
  - `update_mozart_es()` — Orchestrator for Mozart OpenSearch setup
  - `create_ingest_pipeline_mozart()` — Creates the `truncate_large_fields` pipeline
  - `update_mozart_index_templates_with_pipeline()` — Updates `task_status` and `job_status` composable index templates to use the pipeline as `default_pipeline`

Usage: `fab -f ~/.sds/cluster.py -R mozart update_mozart_es`

## Test plan

- [ ] Verify factotum `/data` disk alarm is created on next Terraform apply
- [ ] Verify disk sizes are 1TB for Mozart, Metrics, GRQ on next deployment
- [ ] Run `fab -f ~/.sds/cluster.py -R mozart update_mozart_es` on a deployed cluster
- [ ] Verify pipeline exists: `curl -s localhost:9200/_ingest/pipeline/truncate_large_fields`
- [ ] Verify templates updated: `curl -s localhost:9200/_index_template/task_status` and `job_status` show `default_pipeline: truncate_large_fields`
- [ ] Submit a test job and confirm documents are ingested through the pipeline
