### PR TITLE
First-pass ASG Instance Type Updates

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -260,7 +260,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_cslc_s1" = {
       "name"              = "opera-job_worker-sciflo-l2_cslc_s1"
       "log_file_name"     = "run_sciflo_L2_CSLC_S1"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "c6i.2xlarge"]
+      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 300
@@ -271,7 +271,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_cslc_s1_hist" = {
       "name"              = "opera-job_worker-sciflo-l2_cslc_s1_hist"
       "log_file_name"     = "run_sciflo_L2_CSLC_S1"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "c6i.2xlarge"]
+      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 300
@@ -282,7 +282,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_rtc_s1" = {
       "name"              = "opera-job_worker-sciflo-l2_rtc_s1"
       "log_file_name"     = "run_sciflo_L2_RTC_S1"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "c6i.2xlarge", "c6a.4xlarge", "c6i.4xlarge"]
+      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "c6a.4xlarge", "c6i.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -304,7 +304,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_dswx_hls" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_hls"
       "log_file_name"     = "run_sciflo_L3_DSWx_HLS"
-      "instance_type"     = ["c7a.large", "c6a.large", "c6i.large"]
+      "instance_type"     = ["c6a.large", "c6i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -316,7 +316,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_dswx_s1" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_s1"
       "log_file_name"     = "run_sciflo_L3_DSWx_S1"
-      "instance_type"     = ["c7i.xlarge", "c7i.2xlarge", "c7i.4xlarge", "c7i.8xlarge", "m7i.xlarge", "m7i.2xlarge", "m7i.4xlarge", "m7i.8xlarge"]
+      "instance_type"     = ["c7i.xlarge", "c7i.2xlarge", "c7i.4xlarge", "m7i.xlarge", "m7i.2xlarge", "m7i.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -395,7 +395,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l4_tropo" = {
       "name"              = "opera-job_worker-sciflo-l4_tropo"
       "log_file_name"     = "run_sciflo_L4_TROPO"
-      "instance_type"     = ["m7i.4xlarge", "m7a.4xlarge", "r7a.2xlarge", "r7i.2xlarge", "r6a.2xlarge", "r6i.2xlarge", "r5.2xlarge"]
+      "instance_type"     = ["m7i.4xlarge", "r7a.2xlarge", "r7i.2xlarge", "r6a.2xlarge", "r6i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 100
@@ -444,7 +444,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l4_tropo" = {
       "name"              = "opera-job_worker-send_cnm_notify_l4_tropo"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -454,7 +454,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_hls" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_hls"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -464,7 +464,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_s1"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -474,7 +474,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dist_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dist_s1"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -484,7 +484,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_ni" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_ni"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -494,7 +494,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_disp_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_disp_s1"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -504,7 +504,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_disp_s1_static" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_disp_s1_static"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -514,7 +514,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_cslc_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_cslc_s1"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -524,7 +524,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_cslc_s1_static" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_cslc_s1_static"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -534,7 +534,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_rtc_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_rtc_s1"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -544,7 +544,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_rtc_s1_static" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_rtc_s1_static"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -554,7 +554,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_disp_ni" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_disp_ni"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -564,7 +564,7 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l4_cal_disp" = {
       "name"              = "opera-job_worker-send_cnm_notify_l4_cal_disp"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -574,7 +574,7 @@ variable "queues" {
     }
     "opera-job_worker-rcv_cnm_notify" = {
       "name"              = "opera-job_worker-rcv_cnm_notify"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -584,7 +584,7 @@ variable "queues" {
     }
     "opera-job_worker-hls_data_query" = {
       "name"              = "opera-job_worker-hls_data_query"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -608,7 +608,7 @@ variable "queues" {
     }
     "opera-job_worker-slc_data_query" = {
       "name"              = "opera-job_worker-slc_data_query"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -620,7 +620,7 @@ variable "queues" {
     }
     "opera-job_worker-slc_data_query_hist" = {
       "name"              = "opera-job_worker-slc_data_query_hist"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "r7i.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -740,7 +740,7 @@ variable "queues" {
     }
     "opera-job_worker-cslc_data_query" = {
       "name"              = "opera-job_worker-cslc_data_query"
-      "instance_type"     = ["c6i.xlarge", "m6a.xlarge", "c6a.xlarge", "c5a.xlarge", "r7i.xlarge", "c7i.xlarge"]
+      "instance_type"     = ["c6i.xlarge", "c6a.xlarge", "c5a.xlarge", "c7i.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -764,7 +764,7 @@ variable "queues" {
     }
     "opera-job_worker-gcov_query" = {
       "name"              = "opera-job_worker-gcov_query"
-      "instance_type"     = ["c6i.xlarge", "m6a.xlarge", "c6a.xlarge", "c5a.xlarge", "r7i.xlarge", "c7i.xlarge"]
+      "instance_type"     = ["c6i.xlarge", "c6a.xlarge", "c5a.xlarge", "c7i.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -812,7 +812,7 @@ variable "queues" {
     }
     "opera-job_worker-submit_pending_jobs" = {
       "name"              = "opera-job_worker-submit_pending_jobs"
-      "instance_type"     = ["c6i.large", "m6a.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -824,7 +824,7 @@ variable "queues" {
     }
     "opera-job_worker-rtc_data_download" = {
       "name"              = "opera-job_worker-rtc_data_download"
-      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large", "m5n.large"]
+      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -836,7 +836,7 @@ variable "queues" {
     }
     "opera-job_worker-disp_static_query" = {
       "name"              = "opera-job_worker-disp_static_query"
-      "instance_type"     = ["c6i.xlarge", "m6a.xlarge", "c6a.xlarge", "c5a.xlarge", "r7i.xlarge", "c7i.xlarge"]
+      "instance_type"     = ["c6i.xlarge", "c6a.xlarge", "c5a.xlarge", "c7i.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -848,7 +848,7 @@ variable "queues" {
     }
     "opera-job_worker-rtc_for_dist_data_download" = {
       "name"              = "opera-job_worker-rtc_for_dist_data_download"
-      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large", "m5n.large"]
+      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -860,7 +860,7 @@ variable "queues" {
     }
     "opera-job_worker-rtc_for_dist_data_download_hist" = {
       "name"              = "opera-job_worker-rtc_for_dist_data_download_hist"
-      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large", "m5n.large"]
+      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -872,7 +872,7 @@ variable "queues" {
     }
     "opera-job_worker-ecmwf-merger" = {
       "name"              = "opera-job_worker-ecmwf-merger"
-      "instance_type"     = ["r5a.4xlarge", "r6a.4xlarge", "r5.4xlarge", "r6i.4xlarge", "r7i.4xlarge", "r7a.4xlarge", "r6a.2xlarge"]
+      "instance_type"     = ["r5a.4xlarge", "r6a.4xlarge", "r5.4xlarge", "r6i.4xlarge", "r7i.4xlarge", "r7a.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 600

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -260,7 +260,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_cslc_s1" = {
       "name"              = "opera-job_worker-sciflo-l2_cslc_s1"
       "log_file_name"     = "run_sciflo_L2_CSLC_S1"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge"]
+      "instance_type"     = ["c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 300
@@ -271,7 +271,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_cslc_s1_hist" = {
       "name"              = "opera-job_worker-sciflo-l2_cslc_s1_hist"
       "log_file_name"     = "run_sciflo_L2_CSLC_S1"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge"]
+      "instance_type"     = ["c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 300
@@ -282,7 +282,8 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_rtc_s1" = {
       "name"              = "opera-job_worker-sciflo-l2_rtc_s1"
       "log_file_name"     = "run_sciflo_L2_RTC_S1"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "c6a.4xlarge", "c6i.4xlarge"]
+      "instance_type"     = ["c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8i.2xlarge",
+        "c5a.4xlarge", "c6a.4xlarge", "c6i.4xlarge", "c7a.4xlarge", "c7i.4xlarge", "c8a.4xlarge", "c8i.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -293,7 +294,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l2_rtc_s1_static" = {
       "name"              = "opera-job_worker-sciflo-l2_rtc_s1_static"
       "log_file_name"     = "run_sciflo_L2_RTC_S1"
-      "instance_type"     = ["r6a.2xlarge", "r6i.2xlarge"]
+      "instance_type"     = ["r5a.2xlarge", "r6a.2xlarge", "r6i.2xlarge", "r7a.2xlarge", "r7i.2xlarge", "r8a.2xlarge", "r8i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -304,7 +305,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_dswx_hls" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_hls"
       "log_file_name"     = "run_sciflo_L3_DSWx_HLS"
-      "instance_type"     = ["c6a.large", "c6i.large"]
+      "instance_type"     = ["c5a.large", "c6a.large", "c6i.large", "c7a.large", "c7i.large", "c8a.large", "c8i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -316,7 +317,8 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_dswx_s1" = {
       "name"              = "opera-job_worker-sciflo-l3_dswx_s1"
       "log_file_name"     = "run_sciflo_L3_DSWx_S1"
-      "instance_type"     = ["c7i.xlarge", "c7i.2xlarge", "c7i.4xlarge", "m7i.xlarge", "m7i.2xlarge", "m7i.4xlarge"]
+      "instance_type"     = ["c6i.2xlarge", "c7i.2xlarge", "c8i.2xlarge", "c6i.4xlarge", "c7i.4xlarge", "c8i.4xlarge",
+                             "m6i.2xlarge", "m7i.2xlarge", "m8i.2xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8i.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -328,7 +330,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_disp_s1" = {
       "name"              = "opera-job_worker-sciflo-l3_disp_s1"
       "log_file_name"     = "run_sciflo_L3_DISP_S1"
-      "instance_type"     = ["m7i.8xlarge", "m6i.8xlarge", "c7i.8xlarge"]
+      "instance_type"     = ["m7i.8xlarge", "c6i.8xlarge", "c7i.8xlarge", "c8i.8xlarge", "m6i.8xlarge", "m8i.8xlarge"]
       "user_data"         = "launch_template_user_data_disp_s1.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 500
@@ -339,7 +341,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_disp_s1_hist" = {
       "name"              = "opera-job_worker-sciflo-l3_disp_s1_hist"
       "log_file_name"     = "run_sciflo_L3_DISP_S1"
-      "instance_type"     = ["m7i.8xlarge", "m6i.8xlarge", "c7i.8xlarge"]
+      "instance_type"     = ["m7i.8xlarge", "c6i.8xlarge", "c7i.8xlarge", "c8i.8xlarge", "m6i.8xlarge", "m8i.8xlarge"]
       "user_data"         = "launch_template_user_data_disp_s1.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 500
@@ -350,7 +352,7 @@ variable "queues" {
     "opera-job_worker-sciflo-l3_disp_s1_static" = {
       "name"              = "opera-job_worker-sciflo-l3_disp_s1_static"
       "log_file_name"     = "run_sciflo_L3_DISP_S1_STATIC"
-      "instance_type"     = ["c7a.large", "c6a.large", "c6i.large"]
+      "instance_type"     = ["c5a.large", "c6a.large", "c6i.large", "c7a.large", "c7i.large", "c8a.large", "c8i.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 100
@@ -395,7 +397,9 @@ variable "queues" {
     "opera-job_worker-sciflo-l4_tropo" = {
       "name"              = "opera-job_worker-sciflo-l4_tropo"
       "log_file_name"     = "run_sciflo_L4_TROPO"
-      "instance_type"     = ["m7i.4xlarge", "r7a.2xlarge", "r7i.2xlarge", "r6a.2xlarge", "r6i.2xlarge"]
+      "instance_type"     = ["m5a.4xlarge", "m6a.4xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8a.4xlarge", "m8i.4xlarge",
+                             "r5a.2xlarge", "r6a.2xlarge", "r6i.2xlarge", "r7a.2xlarge", "r7i.2xlarge", "r8a.2xlarge",
+                             "r8i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 100
@@ -454,7 +458,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_hls" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_hls"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -464,7 +471,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_s1"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -474,7 +484,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dist_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dist_s1"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -484,7 +497,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_ni" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_ni"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -494,7 +510,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_disp_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_disp_s1"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -504,7 +523,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_disp_s1_static" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_disp_s1_static"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -514,7 +536,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_cslc_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_cslc_s1"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -524,7 +549,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_cslc_s1_static" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_cslc_s1_static"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -534,7 +562,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_rtc_s1" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_rtc_s1"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -544,7 +575,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l2_rtc_s1_static" = {
       "name"              = "opera-job_worker-send_cnm_notify_l2_rtc_s1_static"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -554,7 +588,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l3_disp_ni" = {
       "name"              = "opera-job_worker-send_cnm_notify_l3_disp_ni"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -564,7 +601,10 @@ variable "queues" {
     }
     "opera-job_worker-send_cnm_notify_l4_cal_disp" = {
       "name"              = "opera-job_worker-send_cnm_notify_l4_cal_disp"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -574,7 +614,10 @@ variable "queues" {
     }
     "opera-job_worker-rcv_cnm_notify" = {
       "name"              = "opera-job_worker-rcv_cnm_notify"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -584,7 +627,10 @@ variable "queues" {
     }
     "opera-job_worker-hls_data_query" = {
       "name"              = "opera-job_worker-hls_data_query"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -596,7 +642,13 @@ variable "queues" {
     }
     "opera-job_worker-hls_data_download" = {
       "name"              = "opera-job_worker-hls_data_download"
-      "instance_type"     = ["c5n.large", "m5dn.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
+        "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
+        "c8i.large", "c8id.large", "c5n.large", "m5.large", "m5a.large", "m5ad.large", "m5d.large", "m5dn.large", "m5n.large",
+        "m5zn.large", "m6a.large", "m6g.large", "m6gd.large", "m6i.large", "m6id.large", "m6idn.large", "m6in.large", "m7a.large",
+        "m7g.large", "m7gd.large", "m7i-flex.large", "m7i.large", "m8a.large", "m8azn.large", "m8g.large", "m8gb.large",
+        "m8gd.large", "m8gn.large", "m8i-flex.large", "m8i.large", "m8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -608,7 +660,10 @@ variable "queues" {
     }
     "opera-job_worker-slc_data_query" = {
       "name"              = "opera-job_worker-slc_data_query"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -620,7 +675,10 @@ variable "queues" {
     }
     "opera-job_worker-slc_data_query_hist" = {
       "name"              = "opera-job_worker-slc_data_query_hist"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -632,7 +690,14 @@ variable "queues" {
     }
     "opera-job_worker-slc_data_download" = {
       "name"              = "opera-job_worker-slc_data_download"
-      "instance_type"     = ["m6in.2xlarge", "c5n.2xlarge"]
+      "instance_type"     = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge",
+        "c6gd.2xlarge", "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge",
+        "c7gd.2xlarge", "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
+        "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge", "c5n.2xlarge", "m5.2xlarge",
+        "m5a.2xlarge", "m5ad.2xlarge", "m5d.2xlarge", "m5dn.2xlarge", "m5n.2xlarge", "m5zn.2xlarge", "m6a.2xlarge",
+        "m6g.2xlarge", "m6gd.2xlarge", "m6i.2xlarge", "m6id.2xlarge", "m6idn.2xlarge", "m6in.2xlarge", "m7a.2xlarge",
+        "m7g.2xlarge", "m7gd.2xlarge", "m7i-flex.2xlarge", "m7i.2xlarge", "m8a.2xlarge", "m8g.2xlarge", "m8gb.2xlarge",
+        "m8gd.2xlarge", "m8gn.2xlarge", "m8i-flex.2xlarge", "m8i.2xlarge", "m8id.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -644,7 +709,14 @@ variable "queues" {
     }
     "opera-job_worker-slc_data_download_hist" = {
       "name"              = "opera-job_worker-slc_data_download_hist"
-      "instance_type"     = ["m6in.2xlarge", "c5n.2xlarge"]
+      "instance_type"     = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge",
+        "c6gd.2xlarge", "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge",
+        "c7gd.2xlarge", "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
+        "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge", "c5n.2xlarge", "m5.2xlarge",
+        "m5a.2xlarge", "m5ad.2xlarge", "m5d.2xlarge", "m5dn.2xlarge", "m5n.2xlarge", "m5zn.2xlarge", "m6a.2xlarge",
+        "m6g.2xlarge", "m6gd.2xlarge", "m6i.2xlarge", "m6id.2xlarge", "m6idn.2xlarge", "m6in.2xlarge", "m7a.2xlarge",
+        "m7g.2xlarge", "m7gd.2xlarge", "m7i-flex.2xlarge", "m7i.2xlarge", "m8a.2xlarge", "m8g.2xlarge", "m8gb.2xlarge",
+        "m8gd.2xlarge", "m8gn.2xlarge", "m8i-flex.2xlarge", "m8i.2xlarge", "m8id.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -740,7 +812,10 @@ variable "queues" {
     }
     "opera-job_worker-cslc_data_query" = {
       "name"              = "opera-job_worker-cslc_data_query"
-      "instance_type"     = ["c6i.xlarge", "c6a.xlarge", "c5a.xlarge", "c7i.xlarge"]
+      "instance_type"     = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
+                             "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
+                             "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
+                             "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -752,7 +827,10 @@ variable "queues" {
     }
     "opera-job_worker-cslc_data_query_hist" = {
       "name"              = "opera-job_worker-cslc_data_query_hist"
-      "instance_type"     = ["c6i.2xlarge", "c6a.2xlarge", "c5a.2xlarge", "c7i.2xlarge"]
+      "instance_type"     = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge", "c6gd.2xlarge",
+                             "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge", "c7gd.2xlarge",
+                             "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
+                             "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -764,7 +842,10 @@ variable "queues" {
     }
     "opera-job_worker-gcov_query" = {
       "name"              = "opera-job_worker-gcov_query"
-      "instance_type"     = ["c6i.xlarge", "c6a.xlarge", "c5a.xlarge", "c7i.xlarge"]
+      "instance_type"     = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
+                             "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
+                             "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
+                             "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -812,7 +893,10 @@ variable "queues" {
     }
     "opera-job_worker-submit_pending_jobs" = {
       "name"              = "opera-job_worker-submit_pending_jobs"
-      "instance_type"     = ["c6i.large", "c6a.large", "c5a.large", "c7i.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -824,7 +908,10 @@ variable "queues" {
     }
     "opera-job_worker-rtc_data_download" = {
       "name"              = "opera-job_worker-rtc_data_download"
-      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
+        "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
+        "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -836,7 +923,10 @@ variable "queues" {
     }
     "opera-job_worker-disp_static_query" = {
       "name"              = "opera-job_worker-disp_static_query"
-      "instance_type"     = ["c6i.xlarge", "c6a.xlarge", "c5a.xlarge", "c7i.xlarge"]
+      "instance_type"     = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
+                             "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
+                             "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
+                             "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -848,7 +938,10 @@ variable "queues" {
     }
     "opera-job_worker-rtc_for_dist_data_download" = {
       "name"              = "opera-job_worker-rtc_for_dist_data_download"
-      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
+        "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
+        "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -860,7 +953,10 @@ variable "queues" {
     }
     "opera-job_worker-rtc_for_dist_data_download_hist" = {
       "name"              = "opera-job_worker-rtc_for_dist_data_download_hist"
-      "instance_type"     = ["c6in.large", "c5n.large", "m6in.large"]
+      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
+        "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
+        "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -280,10 +280,10 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-l2_rtc_s1" = {
-      "name"              = "opera-job_worker-sciflo-l2_rtc_s1"
-      "log_file_name"     = "run_sciflo_L2_RTC_S1"
-      "instance_type"     = ["c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8i.2xlarge",
-        "c5a.4xlarge", "c6a.4xlarge", "c6i.4xlarge", "c7a.4xlarge", "c7i.4xlarge", "c8a.4xlarge", "c8i.4xlarge"]
+      "name"          = "opera-job_worker-sciflo-l2_rtc_s1"
+      "log_file_name" = "run_sciflo_L2_RTC_S1"
+      "instance_type" = ["c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8i.2xlarge",
+      "c5a.4xlarge", "c6a.4xlarge", "c6i.4xlarge", "c7a.4xlarge", "c7i.4xlarge", "c8a.4xlarge", "c8i.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -315,10 +315,10 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-l3_dswx_s1" = {
-      "name"              = "opera-job_worker-sciflo-l3_dswx_s1"
-      "log_file_name"     = "run_sciflo_L3_DSWx_S1"
-      "instance_type"     = ["c6i.2xlarge", "c7i.2xlarge", "c8i.2xlarge", "c6i.4xlarge", "c7i.4xlarge", "c8i.4xlarge",
-                             "m6i.2xlarge", "m7i.2xlarge", "m8i.2xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8i.4xlarge"]
+      "name"          = "opera-job_worker-sciflo-l3_dswx_s1"
+      "log_file_name" = "run_sciflo_L3_DSWx_S1"
+      "instance_type" = ["c6i.2xlarge", "c7i.2xlarge", "c8i.2xlarge", "c6i.4xlarge", "c7i.4xlarge", "c8i.4xlarge",
+      "m6i.2xlarge", "m7i.2xlarge", "m8i.2xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8i.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -362,9 +362,10 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-l3_dswx_ni" = {
-      "name"              = "opera-job_worker-sciflo-l3_dswx_ni"
-      "log_file_name"     = "run_sciflo_L3_DSWx_NI"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "m7i.2xlarge", "m7a.2xlarge", "c7a.2xlarge", "m6a.2xlarge", "c6i.2xlarge", "c5.2xlarge", "m6i.2xlarge", "c5a.2xlarge", "c5ad.2xlarge"]
+      "name"          = "opera-job_worker-sciflo-l3_dswx_ni"
+      "log_file_name" = "run_sciflo_L3_DSWx_NI"
+      "instance_type" = ["c7i.2xlarge", "c6a.2xlarge", "m7i.2xlarge", "m7a.2xlarge", "c7a.2xlarge", "m6a.2xlarge",
+      "c6i.2xlarge", "c5.2xlarge", "m6i.2xlarge", "c5a.2xlarge", "c5ad.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 100
@@ -374,13 +375,13 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-l3_dist_s1" = {
-      "name"              = "opera-job_worker-sciflo-l3_dist_s1"
-      "log_file_name"     = "run_sciflo_L3_DIST_S1"
+      "name"          = "opera-job_worker-sciflo-l3_dist_s1"
+      "log_file_name" = "run_sciflo_L3_DIST_S1"
       //NOTE: As of RC2.0 we are restricted to AMD instances
 
       // Compute optimized 4x large - about 20/32 GB of memory used
       // Good for 4-3-3 on SAS v2.0.11
-      "instance_type"     = ["c8a.4xlarge", "c7a.4xlarge", "c6a.4xlarge", "c5a.4xlarge"]
+      "instance_type" = ["c8a.4xlarge", "c7a.4xlarge", "c6a.4xlarge", "c5a.4xlarge"]
 
       // General purpose 8x large - works well with 8-6-6 w/ stride=7 & parallel npe=4 (tested on m8a)
       // Last used for 8-6-6 on SAS v2.0.9
@@ -395,11 +396,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-l4_tropo" = {
-      "name"              = "opera-job_worker-sciflo-l4_tropo"
-      "log_file_name"     = "run_sciflo_L4_TROPO"
-      "instance_type"     = ["m5a.4xlarge", "m6a.4xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8a.4xlarge", "m8i.4xlarge",
-                             "r5a.2xlarge", "r6a.2xlarge", "r6i.2xlarge", "r7a.2xlarge", "r7i.2xlarge", "r8a.2xlarge",
-                             "r8i.2xlarge"]
+      "name"          = "opera-job_worker-sciflo-l4_tropo"
+      "log_file_name" = "run_sciflo_L4_TROPO"
+      "instance_type" = ["m5a.4xlarge", "m6a.4xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8a.4xlarge", "m8i.4xlarge",
+        "r5a.2xlarge", "r6a.2xlarge", "r6i.2xlarge", "r7a.2xlarge", "r7i.2xlarge", "r8a.2xlarge",
+      "r8i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 100
@@ -409,10 +410,10 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-l3_disp_ni" = {
-      "name"              = "opera-job_worker-sciflo-l3_disp_ni"
-      "log_file_name"     = "run_sciflo_L3_DISP_NI"
-      "instance_type"     = ["m6a.8xlarge", "m7a.8xlarge", "m8a.8xlarge",
-                             "r6a.4xlarge", "r7a.4xlarge", "r8a.4xlarge"]
+      "name"          = "opera-job_worker-sciflo-l3_disp_ni"
+      "log_file_name" = "run_sciflo_L3_DISP_NI"
+      "instance_type" = ["m6a.8xlarge", "m7a.8xlarge", "m8a.8xlarge",
+      "r6a.4xlarge", "r7a.4xlarge", "r8a.4xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 900
@@ -422,10 +423,10 @@ variable "queues" {
       "use_on_demand"     = true
     }
     "opera-job_worker-sciflo-l4_cal_disp" = {
-      "name"              = "opera-job_worker-sciflo-l4_cal_disp"
-      "log_file_name"     = "run_sciflo_L4_CAL_DISP"
-      "instance_type"     = ["c6i.xlarge", "c7i.xlarge", "c8i.xlarge", "c5a.xlarge", "c6a.xlarge", "c7a.xlarge", "c8a.xlarge",
-                             "c6i.2xlarge", "c7i.2xlarge", "c8i.2xlarge", "c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c8a.2xlarge",]
+      "name"          = "opera-job_worker-sciflo-l4_cal_disp"
+      "log_file_name" = "run_sciflo_L4_CAL_DISP"
+      "instance_type" = ["c6i.xlarge", "c7i.xlarge", "c8i.xlarge", "c5a.xlarge", "c6a.xlarge", "c7a.xlarge", "c8a.xlarge",
+      "c6i.2xlarge", "c7i.2xlarge", "c8i.2xlarge", "c5a.2xlarge", "c6a.2xlarge", "c7a.2xlarge", "c8a.2xlarge", ]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 50
@@ -435,14 +436,15 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-sciflo-product_update" = {
-      "name"              = "opera-job_worker-sciflo-product_update"
-      "log_file_name"     = "run_sciflo_product_update"
-      "instance_type"     = ["c7i.2xlarge", "c6a.2xlarge", "m7i.2xlarge", "m7a.2xlarge", "c7a.2xlarge", "m6a.2xlarge", "c6i.2xlarge", "c5.2xlarge", "m6i.2xlarge", "c5a.2xlarge", "c5ad.2xlarge"]
+      "name"          = "opera-job_worker-sciflo-product_update"
+      "log_file_name" = "run_sciflo_product_update"
+      "instance_type" = ["c7i.2xlarge", "c6a.2xlarge", "m7i.2xlarge", "m7a.2xlarge", "c7a.2xlarge", "m6a.2xlarge",
+      "c6i.2xlarge", "c5.2xlarge", "m6i.2xlarge", "c5a.2xlarge", "c5ad.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 100
       "data_dev_size"     = 150
       "min_size"          = 0
-      "max_size"          = 150  // Make this large because it needs to bulk process a lot of data
+      "max_size"          = 150 // Make this large because it needs to bulk process a lot of data
       "total_jobs_metric" = true
       "use_on_demand"     = false
     }
@@ -457,11 +459,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_hls" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_hls"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_dswx_hls"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -470,11 +472,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_s1" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_s1"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_dswx_s1"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -483,11 +485,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_dist_s1" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_dist_s1"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_dist_s1"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -496,11 +498,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_dswx_ni" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_dswx_ni"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_dswx_ni"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -509,11 +511,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_disp_s1" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_disp_s1"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_disp_s1"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -522,11 +524,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_disp_s1_static" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_disp_s1_static"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_disp_s1_static"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -535,11 +537,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l2_cslc_s1" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l2_cslc_s1"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l2_cslc_s1"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -548,11 +550,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l2_cslc_s1_static" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l2_cslc_s1_static"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l2_cslc_s1_static"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -561,11 +563,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l2_rtc_s1" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l2_rtc_s1"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l2_rtc_s1"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -574,11 +576,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l2_rtc_s1_static" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l2_rtc_s1_static"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l2_rtc_s1_static"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -587,11 +589,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l3_disp_ni" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l3_disp_ni"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l3_disp_ni"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -600,11 +602,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-send_cnm_notify_l4_cal_disp" = {
-      "name"              = "opera-job_worker-send_cnm_notify_l4_cal_disp"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-send_cnm_notify_l4_cal_disp"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -613,11 +615,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-rcv_cnm_notify" = {
-      "name"              = "opera-job_worker-rcv_cnm_notify"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-rcv_cnm_notify"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -626,11 +628,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-hls_data_query" = {
-      "name"              = "opera-job_worker-hls_data_query"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-hls_data_query"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -641,14 +643,14 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-hls_data_download" = {
-      "name"              = "opera-job_worker-hls_data_download"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+      "name" = "opera-job_worker-hls_data_download"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
         "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
         "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
         "c8i.large", "c8id.large", "c5n.large", "m5.large", "m5a.large", "m5ad.large", "m5d.large", "m5dn.large", "m5n.large",
         "m5zn.large", "m6a.large", "m6g.large", "m6gd.large", "m6i.large", "m6id.large", "m6idn.large", "m6in.large", "m7a.large",
         "m7g.large", "m7gd.large", "m7i-flex.large", "m7i.large", "m8a.large", "m8azn.large", "m8g.large", "m8gb.large",
-        "m8gd.large", "m8gn.large", "m8i-flex.large", "m8i.large", "m8id.large"]
+      "m8gd.large", "m8gn.large", "m8i-flex.large", "m8i.large", "m8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -659,11 +661,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-slc_data_query" = {
-      "name"              = "opera-job_worker-slc_data_query"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-slc_data_query"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -674,11 +676,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-slc_data_query_hist" = {
-      "name"              = "opera-job_worker-slc_data_query_hist"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-slc_data_query_hist"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -689,15 +691,15 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-slc_data_download" = {
-      "name"              = "opera-job_worker-slc_data_download"
-      "instance_type"     = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge",
+      "name" = "opera-job_worker-slc_data_download"
+      "instance_type" = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge",
         "c6gd.2xlarge", "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge",
         "c7gd.2xlarge", "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
         "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge", "c5n.2xlarge", "m5.2xlarge",
         "m5a.2xlarge", "m5ad.2xlarge", "m5d.2xlarge", "m5dn.2xlarge", "m5n.2xlarge", "m5zn.2xlarge", "m6a.2xlarge",
         "m6g.2xlarge", "m6gd.2xlarge", "m6i.2xlarge", "m6id.2xlarge", "m6idn.2xlarge", "m6in.2xlarge", "m7a.2xlarge",
         "m7g.2xlarge", "m7gd.2xlarge", "m7i-flex.2xlarge", "m7i.2xlarge", "m8a.2xlarge", "m8g.2xlarge", "m8gb.2xlarge",
-        "m8gd.2xlarge", "m8gn.2xlarge", "m8i-flex.2xlarge", "m8i.2xlarge", "m8id.2xlarge"]
+      "m8gd.2xlarge", "m8gn.2xlarge", "m8i-flex.2xlarge", "m8i.2xlarge", "m8id.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -708,15 +710,15 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-slc_data_download_hist" = {
-      "name"              = "opera-job_worker-slc_data_download_hist"
-      "instance_type"     = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge",
+      "name" = "opera-job_worker-slc_data_download_hist"
+      "instance_type" = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge",
         "c6gd.2xlarge", "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge",
         "c7gd.2xlarge", "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
         "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge", "c5n.2xlarge", "m5.2xlarge",
         "m5a.2xlarge", "m5ad.2xlarge", "m5d.2xlarge", "m5dn.2xlarge", "m5n.2xlarge", "m5zn.2xlarge", "m6a.2xlarge",
         "m6g.2xlarge", "m6gd.2xlarge", "m6i.2xlarge", "m6id.2xlarge", "m6idn.2xlarge", "m6in.2xlarge", "m7a.2xlarge",
         "m7g.2xlarge", "m7gd.2xlarge", "m7i-flex.2xlarge", "m7i.2xlarge", "m8a.2xlarge", "m8g.2xlarge", "m8gb.2xlarge",
-        "m8gd.2xlarge", "m8gn.2xlarge", "m8i-flex.2xlarge", "m8i.2xlarge", "m8id.2xlarge"]
+      "m8gd.2xlarge", "m8gn.2xlarge", "m8i-flex.2xlarge", "m8i.2xlarge", "m8id.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -763,8 +765,9 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-rtc_for_dist_data_query_hist" = {
-      "name"              = "opera-job_worker-rtc_for_dist_data_query_hist"
-      "instance_type"     = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large", "m6a.large", "m5.large", "m5a.large"]
+      "name" = "opera-job_worker-rtc_for_dist_data_query_hist"
+      "instance_type" = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large",
+      "m6a.large", "m5.large", "m5a.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -775,8 +778,9 @@ variable "queues" {
       "use_on_demand"     = true
     }
     "opera-job_worker-dist_s1_hist_on_first" = {
-      "name"              = "opera-job_worker-dist_s1_hist_on_first"
-      "instance_type"     = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large", "m6a.large", "m5.large", "m5a.large"]
+      "name" = "opera-job_worker-dist_s1_hist_on_first"
+      "instance_type" = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large",
+      "m6a.large", "m5.large", "m5a.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -787,8 +791,9 @@ variable "queues" {
       "use_on_demand"     = true
     }
     "opera-job_worker-dist_s1_hist_on_publication" = {
-      "name"              = "opera-job_worker-dist_s1_hist_on_publication"
-      "instance_type"     = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large", "m6a.large", "m5.large", "m5a.large"]
+      "name" = "opera-job_worker-dist_s1_hist_on_publication"
+      "instance_type" = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large",
+      "m6a.large", "m5.large", "m5a.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -799,8 +804,9 @@ variable "queues" {
       "use_on_demand"     = true
     }
     "opera-job_worker-dist_s1_hist_on_complete" = {
-      "name"              = "opera-job_worker-dist_s1_hist_on_complete"
-      "instance_type"     = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large", "m6a.large", "m5.large", "m5a.large"]
+      "name" = "opera-job_worker-dist_s1_hist_on_complete"
+      "instance_type" = ["m8a.large", "m8i-flex.large", "m8i.large", "m7a.large", "m7i-flex.large", "m6i.large",
+      "m6a.large", "m5.large", "m5a.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -811,11 +817,11 @@ variable "queues" {
       "use_on_demand"     = true
     }
     "opera-job_worker-cslc_data_query" = {
-      "name"              = "opera-job_worker-cslc_data_query"
-      "instance_type"     = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
-                             "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
-                             "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
-                             "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
+      "name" = "opera-job_worker-cslc_data_query"
+      "instance_type" = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
+        "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
+        "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
+      "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -826,11 +832,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-cslc_data_query_hist" = {
-      "name"              = "opera-job_worker-cslc_data_query_hist"
-      "instance_type"     = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge", "c6gd.2xlarge",
-                             "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge", "c7gd.2xlarge",
-                             "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
-                             "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge"]
+      "name" = "opera-job_worker-cslc_data_query_hist"
+      "instance_type" = ["c5.2xlarge", "c5a.2xlarge", "c5ad.2xlarge", "c5d.2xlarge", "c6a.2xlarge", "c6g.2xlarge", "c6gd.2xlarge",
+        "c6gn.2xlarge", "c6i.2xlarge", "c6id.2xlarge", "c6in.2xlarge", "c7a.2xlarge", "c7g.2xlarge", "c7gd.2xlarge",
+        "c7gn.2xlarge", "c7i-flex.2xlarge", "c7i.2xlarge", "c8a.2xlarge", "c8g.2xlarge", "c8gb.2xlarge",
+      "c8gd.2xlarge", "c8gn.2xlarge", "c8i-flex.2xlarge", "c8i.2xlarge", "c8id.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -841,11 +847,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-gcov_query" = {
-      "name"              = "opera-job_worker-gcov_query"
-      "instance_type"     = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
-                             "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
-                             "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
-                             "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
+      "name" = "opera-job_worker-gcov_query"
+      "instance_type" = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
+        "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
+        "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
+      "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -892,11 +898,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-submit_pending_jobs" = {
-      "name"              = "opera-job_worker-submit_pending_jobs"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
-                             "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
-                             "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
-                             "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
+      "name" = "opera-job_worker-submit_pending_jobs"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+        "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large",
+        "c7gn.large", "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large",
+      "c8gn.large", "c8i-flex.large", "c8i.large", "c8id.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -907,11 +913,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-rtc_data_download" = {
-      "name"              = "opera-job_worker-rtc_data_download"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+      "name" = "opera-job_worker-rtc_data_download"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
         "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
         "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
-        "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
+      "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100
@@ -922,11 +928,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-disp_static_query" = {
-      "name"              = "opera-job_worker-disp_static_query"
-      "instance_type"     = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
-                             "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
-                             "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
-                             "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
+      "name" = "opera-job_worker-disp_static_query"
+      "instance_type" = ["c5.xlarge", "c5a.xlarge", "c5ad.xlarge", "c5d.xlarge", "c6a.xlarge", "c6g.xlarge", "c6gd.xlarge",
+        "c6gn.xlarge", "c6i.xlarge", "c6id.xlarge", "c6in.xlarge", "c7a.xlarge", "c7g.xlarge", "c7gd.xlarge",
+        "c7gn.xlarge", "c7i-flex.xlarge", "c7i.xlarge", "c8a.xlarge", "c8g.xlarge", "c8gb.xlarge",
+      "c8gd.xlarge", "c8gn.xlarge", "c8i-flex.xlarge", "c8i.xlarge", "c8id.xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -937,11 +943,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-rtc_for_dist_data_download" = {
-      "name"              = "opera-job_worker-rtc_for_dist_data_download"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+      "name" = "opera-job_worker-rtc_for_dist_data_download"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
         "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
         "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
-        "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
+      "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -952,11 +958,11 @@ variable "queues" {
       "use_on_demand"     = false
     }
     "opera-job_worker-rtc_for_dist_data_download_hist" = {
-      "name"              = "opera-job_worker-rtc_for_dist_data_download_hist"
-      "instance_type"     = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
+      "name" = "opera-job_worker-rtc_for_dist_data_download_hist"
+      "instance_type" = ["c5.large", "c5a.large", "c5ad.large", "c5d.large", "c6a.large", "c6g.large", "c6gd.large",
         "c6gn.large", "c6i.large", "c6id.large", "c6in.large", "c7a.large", "c7g.large", "c7gd.large", "c7gn.large",
         "c7i-flex.large", "c7i.large", "c8a.large", "c8g.large", "c8gb.large", "c8gd.large", "c8gn.large", "c8i-flex.large",
-        "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
+      "c8i.large", "c8id.large", "c5n.large", "m6in.large"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 25
@@ -1230,7 +1236,7 @@ variable "asf_cnm_s_id_prod" {
 }
 
 variable "ami_versions" {
-  type = map(string)
+  type    = map(string)
   default = {}
 }
 


### PR DESCRIPTION
## Purpose
- For all ASG queues:
  - Removed instance types that differ from most other types in the queue (ie, if most types are c.2xlarge and there's a c.4xlarge or c.xlarge)
  - Removed instance types that have been more expensive in the cost analyses (cost per job >= 1 stdev above mean)
- For all queues with < 4 instance types, that were modified above and all SCIFLO queues (except for DSWxNI, DIST-S1, DISP-*, and Product Update) + some others:
  - Massively expanded instance type lists with all types similar to those already present (ie, family & size + intel/AMD if required)

## Issues
- First pass changes for [OPERA-2376](https://hysds-core.atlassian.net/browse/OPERA-2376), will re-evaluate against cost metrics after this is deployed in OPS
