### PR TITLE
OPERA-2318: feat(DIST-S1): make product-id-time param a proper list

### DIFF
--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -167,6 +167,7 @@ def create_parser():
     # DIST-S1 params
     product_id_time = {"positionals": ["--product-id-time"],
                  "kwargs": {"dest": "product_id_time",
+                            "nargs": "+",
                             "help": "Used in DIST-S1 reprocessing only. "
                                     "Specify the Product ID and acquisition time pair for which to reprocess "
                                     "e.g. '54SUG_1,20250507T204314Z' Product ID is Tile ID + Acq Group ID. "}}

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -154,7 +154,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
 
             #TODO: We probably want something more graceful than the product_id_time looking like 31SGR_3,20231217T053132Z
             # TODO: The fact that this is a loop makes sense if we ever decide to trigger by native_id instead of product_id_time
-            for pit in self.args.product_id_time.split("-"):
+            for pit in self.args.product_id_time:
                 product_id = pit.split(",")[0]
                 acquisition_dts = pit.split(",")[1]
 


### PR DESCRIPTION
## Purpose
- enhanced reprocessing capabilities
## Proposed Changes
- [CHANGE] allow more than one product-id-time to be specified through the CLI.

## Issues
https://hysds-core.atlassian.net/browse/OPERA-2318
## Testing
tested locally
