### PR TITLE
DIST-S1 Types - Adjust for cost

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -391,9 +391,10 @@ variable "queues" {
       "name"          = "opera-job_worker-sciflo-l3_dist_s1"
       "log_file_name" = "run_sciflo_L3_DIST_S1"
 
-      // Compute optimized 4x large - about 20/32 GB of memory used
+      // Compute optimized 4x large & GP 2xlarge - about 20/32 GB of memory used
       // Good for 4-3-3 on SAS v2.0.11
-      "instance_type" = ["c8i.4xlarge", "c7i.4xlarge", "c6i.4xlarge", "c8a.4xlarge", "c7a.4xlarge", "c6a.4xlarge", "c5a.4xlarge"]
+      "instance_type" = ["c8a.4xlarge", "c8i.4xlarge", "c7a.4xlarge", "c7i.4xlarge", "c6a.4xlarge", "c6i.4xlarge", 
+                         "m8a.2xlarge", "m8i.2xlarge", "m7a.2xlarge", "m7i.2xlarge", "m6a.2xlarge", "m6i.2xlarge"]
 
       // General purpose 8x large - works well with 8-6-6 w/ stride=7 & parallel npe=4 (tested on m8a)
       // Last used for 8-6-6 on SAS v2.0.9


### PR DESCRIPTION
Drop c5* and m5* as they are the most expensive per-job

## Issues
- Links to relevant issues
- Example: issue-XYZ
## Testing
- [OPERA-2376](https://hysds-core.atlassian.net/browse/OPERA-2376). Adjustments made for DIST-S1 based on metrics data from INT test runs
