### PR TITLE
OPERA-2423: backoff explicitly on timeout errors.

### DIFF
--- a/data_subscriber/aws_token.py
+++ b/data_subscriber/aws_token.py
@@ -41,6 +41,7 @@ def _get_tokens(edl: str, username: str, password: str) -> list[dict]:
     max_tries=3,
     on_backoff=backoff_logger,
 )
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _requests_get_tokens(edl: str, username: str, password: str):
     return requests.get(f"https://{edl}/api/users/tokens", auth=HTTPBasicAuth(username, password))
 
@@ -79,6 +80,7 @@ def _create_token(edl: str, username: str, password: str) -> str:
     max_tries=3,
     on_backoff=backoff_logger,
 )
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _requests_post_tokens(edl: str, username: str, password: str):
     return requests.post(f"https://{edl}/api/users/token", auth=HTTPBasicAuth(username, password))
 

--- a/data_subscriber/dataspace_download.py
+++ b/data_subscriber/dataspace_download.py
@@ -135,6 +135,7 @@ class DataspaceDownload(AsfDaacSlcDownload):
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=300)
+    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
     def _do_request(self, url, token):
         headers = {"Authorization": f"Bearer {token}"}
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -161,6 +161,7 @@ class BaseDownload:
                           # jitter=None,
                           giveup=fatal_code,
                           on_backoff=backoff_logger)
+    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
     def _get_aws_creds(self, token, endpoint=None):
         settings_daac_s3_cred_urls_key = "UAT_DAAC_S3_CRED_URLS" if endpoint == "UAT" else "DAAC_S3_CRED_URLS"
         self.logger.info(f'Getting AWS creds from {self.cfg[settings_daac_s3_cred_urls_key][self.daac_s3_cred_settings_key]}')

--- a/product_update/disp_s1_r4_bperp/update.py
+++ b/product_update/disp_s1_r4_bperp/update.py
@@ -182,6 +182,7 @@ def _validate_frames(frame_list):
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _do_cmr_query(url, params, headers=None):
     if headers is None:
         headers = {}

--- a/tools/dataspace_s1_download.py
+++ b/tools/dataspace_s1_download.py
@@ -149,6 +149,7 @@ def build_query_filter(*args, platforms=('A',), sort_by='ContentDate/Start', sor
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _do_query(url, **kwargs):
     response = requests.get(url, **kwargs)
 
@@ -219,6 +220,7 @@ def main():
                                   giveup=fatal_code,
                                   on_backoff=backoff_logger,
                                   interval=15)
+            @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
             def do_download(gid, filename):
                 start_t = datetime.now()
                 filename = f"{os.path.splitext(filename)[0]}.zip"

--- a/tools/ops/cmr_audit/cmr_client.py
+++ b/tools/ops/cmr_audit/cmr_client.py
@@ -113,6 +113,7 @@ def giveup_cmr_requests(e):
     jitter=None,
     giveup=giveup_cmr_requests
 )
+@backoff.on_exception(backoff.expo, aiohttp.ServerTimeoutError, max_tries=2)
 async def fetch_post_url(session: aiohttp.ClientSession, url, data: str, headers):
     return await session.post(url, data=data, headers=headers, raise_for_status=True)
 
@@ -124,6 +125,7 @@ async def fetch_post_url(session: aiohttp.ClientSession, url, data: str, headers
     jitter=None,
     giveup=giveup_cmr_requests
 )
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def try_request_get(request_url, params, headers=None, raise_for_status=True):
     response = requests.get(request_url, params=params, headers=headers)
     if raise_for_status:

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -132,6 +132,7 @@ def _cmr_items_to_dicts(items):
 
 @backoff.on_exception(backoff.constant, requests.exceptions.RequestException,
                       max_time=300, giveup=_fatal_code, on_backoff=_backoff_logger, interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _do_cmr_query(url, params, func=None, headers=None):
     if headers is None:
         headers = {}

--- a/tools/ops/duplicates/dswx-hls/dswx-hls-input-map.py
+++ b/tools/ops/duplicates/dswx-hls/dswx-hls-input-map.py
@@ -64,6 +64,7 @@ def _backoff_logger(details):
                       giveup=_fatal_code,
                       on_backoff=_backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _do_cmr_query(url, params, func=None, headers=None):
     if headers is None:
         headers = {}

--- a/tools/ops/duplicates/duplicate_check.py
+++ b/tools/ops/duplicates/duplicate_check.py
@@ -195,6 +195,7 @@ def _backoff_logger(details):
                       giveup=_fatal_code,
                       on_backoff=_backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _do_cmr_query(url, params, headers=None):
     if headers is None:
         headers = {}

--- a/tools/slc_latency_survey.py
+++ b/tools/slc_latency_survey.py
@@ -101,6 +101,7 @@ def get_parser():
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def _do_cmr_query(url, params, headers=None):
     if headers is None:
         headers = {}

--- a/tools/stage_orbit_file.py
+++ b/tools/stage_orbit_file.py
@@ -254,6 +254,7 @@ def construct_orbit_file_query(mission_id, orbit_type, search_start_time, search
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def query_orbit_file_service(endpoint_url, query):
     """
     Submits a request to the Orbit file query REST service, and returns the
@@ -412,6 +413,7 @@ def select_orbit_file(query_results, req_start_time, req_stop_time):
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
+@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
 def download_orbit_file(request_url, output_directory, orbit_file_name, access_token):
     """
     Downloads an Orbit file using the provided request URL, which should contain

--- a/util/dataspace_util.py
+++ b/util/dataspace_util.py
@@ -64,6 +64,7 @@ class DataspaceSession:
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=15)
+    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
     def _refresh(self) -> Tuple[str, str, str, datetime]:
         """
         Performs an access token refresh request using the refresh token acquired
@@ -116,6 +117,7 @@ class DataspaceSession:
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=15)
+    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
     def _get_token(self, username: str, password: str) -> Tuple[str, str, str, datetime]:
         """
         Acquires an access token from the CDSE authentication endpoint using the
@@ -183,6 +185,7 @@ class DataspaceSession:
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=15)
+    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
     def _delete_token(self):
         """
         Submits a delete request on the provided endpoint URL for the provided


### PR DESCRIPTION
Note slight difference for aiohttp.

## Purpose
retry on transient connection errors
## Proposed Changes
- [CHANGE] API calls retry on connection/timeout errors

## Issues
https://hysds-core.atlassian.net/browse/OPERA-2423
## Testing
tested locally
