### PR TITLE
OPERA-2428: dedupe CMR results for RTC

### DIFF
--- a/data_subscriber/asf_rtc_download.py
+++ b/data_subscriber/asf_rtc_download.py
@@ -12,10 +12,9 @@ from more_itertools import first
 
 from data_subscriber.catalog import ProductCatalog
 from data_subscriber.download import BaseDownload
-from data_subscriber.rtc.rtc_catalog import dedupe_rtc_es_docs
 from data_subscriber.rtc.rtc_job_submitter import submit_dswx_s1_job_submissions_tasks
 from data_subscriber.url import _to_urls, _to_https_urls, _rtc_url_to_chunk_id
-from rtc_utils import rtc_product_file_revision_regex
+from rtc_utils import rtc_product_file_revision_regex, dedupe_rtc_es_docs
 from util.aws_util import concurrent_s3_client_try_upload_file
 from util.conf_util import SettingsConf
 from util.ctx_util import JobContext

--- a/data_subscriber/rtc/evaluator.py
+++ b/data_subscriber/rtc/evaluator.py
@@ -16,8 +16,8 @@ from more_itertools import first, flatten
 from data_subscriber import es_conn_util
 from data_subscriber.rtc import evaluator_core
 from data_subscriber.rtc import mgrs_bursts_collection_db_client as mbc_client
-from data_subscriber.rtc.rtc_catalog import RTCProductCatalog, dedupe_rtc_es_docs
-from rtc_utils import rtc_granule_regex, rtc_relative_orbit_number_regex
+from data_subscriber.rtc.rtc_catalog import RTCProductCatalog
+from rtc_utils import rtc_granule_regex, rtc_relative_orbit_number_regex, dedupe_rtc_es_docs
 from util.grq_client import get_body
 
 logger = logging.getLogger(__name__)

--- a/data_subscriber/rtc/rtc_catalog.py
+++ b/data_subscriber/rtc/rtc_catalog.py
@@ -1,4 +1,3 @@
-import re
 from collections import defaultdict
 from datetime import datetime
 
@@ -9,7 +8,6 @@ from more_itertools import last, chunked
 
 from data_subscriber.catalog import ProductCatalog
 from data_subscriber.rtc import mgrs_bursts_collection_db_client
-from rtc_utils import rtc_granule_regex
 from util.conf_util import SettingsConf
 from util.grq_client import get_body
 
@@ -252,30 +250,3 @@ class RTCProductCatalog(ProductCatalog):
             self.es_util.update_document(index=index, body=body, id=doc['id'])
 
 
-def dedupe_rtc_es_docs(es_docs: list[dict], filter_path=False) -> list[dict]:
-    """
-    :param filter_path: functions like `?filter_path=hits.hits._source` in the Elasticsearch HTTP API.
-    """
-
-    dedupe_key_to_doc = {}
-    for doc in es_docs:
-        if not filter_path:
-            b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
-        elif filter_path:
-            b = re.match(rtc_granule_regex, doc["granule_id"]).groupdict()
-        rtc_uniqueness_tuple = (
-            b["burst_id"],
-            b["acquisition_ts"],
-            b["sensor"],
-            b["product_version"]
-        )
-        if not dedupe_key_to_doc.get(rtc_uniqueness_tuple):
-            dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
-        elif dedupe_key_to_doc[rtc_uniqueness_tuple]:
-            if not filter_path:
-                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
-            elif filter_path:
-                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["granule_id"]).groupdict()
-            if a["creation_ts"] < b["creation_ts"]:
-                dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
-    return list(dedupe_key_to_doc.values())

--- a/data_subscriber/rtc/rtc_query.py
+++ b/data_subscriber/rtc/rtc_query.py
@@ -18,7 +18,7 @@ from data_subscriber.rtc import mgrs_bursts_collection_db_client as mbc_client, 
 from data_subscriber.rtc.rtc_download_job_submitter import submit_rtc_download_job_submissions_tasks
 from data_subscriber.url import determine_acquisition_cycle
 from geo.geo_util import does_bbox_intersect_region
-from rtc_utils import rtc_granule_regex
+from rtc_utils import rtc_granule_regex, dedupe_rtc_es_docs
 
 DateTimeRange = namedtuple("DateTimeRange", ["start_date", "end_date"])
 
@@ -72,6 +72,10 @@ class RtcCmrQuery(BaseQuery):
             burst_id = mbc_client.product_burst_id_to_mapping_burst_id(match_native_id.group("burst_id"))
 
             native_id_mgrs_burst_set_ids = mbc_client.burst_id_to_mgrs_set_ids(mgrs, mbc_client.product_burst_id_to_mapping_burst_id(burst_id))
+
+        if not self.args.native_id:
+            self.logger.info("Deduping CMR results (RTC for DSWx-S1)")
+            granules = dedupe_rtc_es_docs(granules, filter_path=True)
 
         num_granules = len(granules)
         for i, granule in enumerate(granules):

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -72,12 +72,12 @@ class RtcForDistCmrQuery(BaseQuery):
         '''
         granules_dict = {}
         for granule in granules:
-            key = (granule["burst_id"], granule["acquisition_ts"][:-5])  # within the same hour of day (format 'YYYYMMDDTHH') to mitigate duplicates that are within 1 second.
+            key = (granule["burst_id"], granule["acquisition_ts"].strftime("%Y%m%dT%H"))
             if key not in granules_dict:
                 granules_dict[key] = granule
             else:
                 self.logger.debug(f"Found duplicate granules {granule['granule_id']}, {granules_dict[key]['granule_id']} with the same burst_id and acquisition_ts. Keeping only the latest production one.")
-                if granule["acquisition_ts"][:-5] > granules_dict[key]["acquisition_ts"][:-5]:
+                if granule["acquisition_ts"].strftime("%Y%m%dT%H") > granules_dict[key]["acquisition_ts"].strftime("%Y%m%dT%H"):
                     granules_dict[key] = granule
         return list(granules_dict.values())
 

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -66,15 +66,18 @@ class RtcForDistCmrQuery(BaseQuery):
                 raise AssertionError("--product-id-time must be provided in DIST-S1 reprocessing mode.")
 
     def unique_latest_granules(self, granules):
-        ''' Remove duplicate granules defined by having the same burst_id and acquisition_ts, keep just the latest one'''
+        ''' Remove duplicate granules defined by having the same burst_id and acquisition_ts, keep just the latest one
+
+        On rare occassion, duplicate granules may share acquisition ts within 1 second of each other.
+        '''
         granules_dict = {}
         for granule in granules:
-            key = (granule["burst_id"], granule["acquisition_ts"])
+            key = (granule["burst_id"], granule["acquisition_ts"][:-5])  # within the same hour of day (format 'YYYYMMDDTHH') to mitigate duplicates that are within 1 second.
             if key not in granules_dict:
                 granules_dict[key] = granule
             else:
                 self.logger.debug(f"Found duplicate granules {granule['granule_id']}, {granules_dict[key]['granule_id']} with the same burst_id and acquisition_ts. Keeping only the latest production one.")
-                if granule["acquisition_ts"] > granules_dict[key]["acquisition_ts"]:
+                if granule["acquisition_ts"][:-5] > granules_dict[key]["acquisition_ts"][:-5]:
                     granules_dict[key] = granule
         return list(granules_dict.values())
 

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -72,12 +72,12 @@ class RtcForDistCmrQuery(BaseQuery):
         '''
         granules_dict = {}
         for granule in granules:
-            key = (granule["burst_id"], granule["acquisition_ts"].strftime("%Y%m%dT%H"))
+            key = (granule["burst_id"], granule["acquisition_ts"].strftime("%Y%m%dT%H"))[:-5]
             if key not in granules_dict:
                 granules_dict[key] = granule
             else:
                 self.logger.debug(f"Found duplicate granules {granule['granule_id']}, {granules_dict[key]['granule_id']} with the same burst_id and acquisition_ts. Keeping only the latest production one.")
-                if granule["acquisition_ts"].strftime("%Y%m%dT%H") > granules_dict[key]["acquisition_ts"].strftime("%Y%m%dT%H"):
+                if granule["acquisition_ts"].strftime("%Y%m%dT%H%M%S")[:-5] > granules_dict[key]["acquisition_ts"].strftime("%Y%m%dT%H%M%S")[:-5]:
                     granules_dict[key] = granule
         return list(granules_dict.values())
 

--- a/rtc_utils.py
+++ b/rtc_utils.py
@@ -134,6 +134,8 @@ def dedupe_rtc_es_docs(es_docs: list[dict], filter_path=False, sort=False) -> li
             if a["creation_ts"] < b["creation_ts"]:
                 dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
     if sort:
-        return sorted(dedupe_key_to_doc.values(), key=lambda g: g["granule_id"])
-    else:
-        return list(dedupe_key_to_doc.values())
+        if not filter_path:
+            return sorted(dedupe_key_to_doc.values(), key=lambda g: g["_source"]["granule_id"])
+        elif filter_path:
+            return sorted(dedupe_key_to_doc.values(), key=lambda g: g["granule_id"])
+    return list(dedupe_key_to_doc.values())

--- a/rtc_utils.py
+++ b/rtc_utils.py
@@ -103,19 +103,37 @@ def determine_acquisition_cycle(burst_id, acquisition_dts, granule_id, epoch = N
 
 def dedupe_rtc(rtcs: list[dict]):
     """Dedupes a list of RTC granule objects, typically CMR responses that have been processed (i.e. not raw response)"""
-    dedupe_key_to_rtc = {}
-    for rtc in rtcs:
-        b = re.match(rtc_granule_regex, rtc["granule_id"]).groupdict()
+    return dedupe_rtc_es_docs(rtcs, filter_path=True, sort=True)
+
+
+def dedupe_rtc_es_docs(es_docs: list[dict], filter_path=False, sort=False) -> list[dict]:
+    """
+    :param filter_path: functions like `?filter_path=hits.hits._source` in the Elasticsearch HTTP API.
+    :param sort: sort the results by granule ID (i.e. chronological ascending).
+    """
+
+    dedupe_key_to_doc = {}
+    for doc in es_docs:
+        if not filter_path:
+            b = re.match(rtc_granule_regex, doc["_source"]["granule_id"]).groupdict()
+        elif filter_path:
+            b = re.match(rtc_granule_regex, doc["granule_id"]).groupdict()
         rtc_uniqueness_tuple = (
             b["burst_id"],
             b["acquisition_ts"],
             b["sensor"],
             b["product_version"]
         )
-        if not dedupe_key_to_rtc.get(rtc_uniqueness_tuple):
-            dedupe_key_to_rtc[rtc_uniqueness_tuple] = rtc
-        elif dedupe_key_to_rtc[rtc_uniqueness_tuple]:
-            a = re.match(rtc_granule_regex, dedupe_key_to_rtc[rtc_uniqueness_tuple]["granule_id"]).groupdict()
+        if not dedupe_key_to_doc.get(rtc_uniqueness_tuple):
+            dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
+        elif dedupe_key_to_doc[rtc_uniqueness_tuple]:
+            if not filter_path:
+                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["_source"]["granule_id"]).groupdict()
+            elif filter_path:
+                a = re.match(rtc_granule_regex, dedupe_key_to_doc[rtc_uniqueness_tuple]["granule_id"]).groupdict()
             if a["creation_ts"] < b["creation_ts"]:
-                dedupe_key_to_rtc[rtc_uniqueness_tuple] = rtc
-    return sorted(dedupe_key_to_rtc.values(), key=lambda g: g["granule_id"])
+                dedupe_key_to_doc[rtc_uniqueness_tuple] = doc
+    if sort:
+        return sorted(dedupe_key_to_doc.values(), key=lambda g: g["granule_id"])
+    else:
+        return list(dedupe_key_to_doc.values())

--- a/tests/unit/data_subscriber/rtc/test_evaluator.py
+++ b/tests/unit/data_subscriber/rtc/test_evaluator.py
@@ -5,9 +5,8 @@ import pytest
 from mock import patch
 from more_itertools import only
 
-import data_subscriber.rtc.rtc_catalog
+import rtc_utils
 from data_subscriber.rtc import evaluator
-
 
 try:
     import boto3
@@ -239,7 +238,7 @@ def test_dedupe_rtc_es_docs():
         {"_source": {"granule_id": f"{common_prefix}_{older_datetime}_{common_suffix}"}}
     ]
 
-    result = data_subscriber.rtc.rtc_catalog.dedupe_rtc_es_docs(es_docs)
+    result = rtc_utils.dedupe_rtc_es_docs(es_docs)
 
     assert only(result) == {"_source": {"granule_id": f"{common_prefix}_{newer_datetime}_{common_suffix}"}
     }

--- a/tests/unit/test_rtc_utils.py
+++ b/tests/unit/test_rtc_utils.py
@@ -1,7 +1,7 @@
 import re
 
 from rtc_utils import rtc_product_file_regex, determine_acquisition_cycle_for_rtc_product_file, \
-    determine_acquisition_cycle_for_rtc_granule, rtc_granule_regex
+    determine_acquisition_cycle_for_rtc_granule, rtc_granule_regex, dedupe_rtc_es_docs
 
 
 def test_determine_acquisition_cycle_for_rtc_product_file():
@@ -18,3 +18,88 @@ def test_determine_acquisition_cycle_for_rtc_granule():
     granule_id = "OPERA_L2_RTC-S1_T118-252624-IW1_20250512T193408Z_20250513T011557Z_S1A_30_v1.0"
     match = re.match(rtc_granule_regex, granule_id)
     assert 345 == determine_acquisition_cycle_for_rtc_granule(match_granule_id=match)
+
+def test_dedupe_rtc_es_docs__when_es_docs__and_no_filter_path__and_no_sort():
+    granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    rtcs = []
+    for granule_id in granule_ids:
+        rtcs.append({"_source": {"granule_id": granule_id}})
+
+    result_granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    result_rtcs = []
+    for granule_id in result_granule_ids:
+        result_rtcs.append({"_source": {"granule_id": granule_id}})
+
+    assert dedupe_rtc_es_docs(rtcs, filter_path=False, sort=False) == result_rtcs
+
+def test_dedupe_rtc_es_docs__when_es_docs__and_no_filter_path__and_sort():
+    granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    rtcs = []
+    for granule_id in granule_ids:
+        rtcs.append({"_source": {"granule_id": granule_id}})
+
+    result_granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    result_rtcs = []
+    for granule_id in result_granule_ids:
+        result_rtcs.append({"_source": {"granule_id": granule_id}})
+
+    assert dedupe_rtc_es_docs(rtcs, filter_path=False, sort=True) == result_rtcs
+
+
+def test_dedupe_rtc_es_docs__when_es_docs__and_filter_path__and_no_sort():
+    granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    rtcs = []
+    for granule_id in granule_ids:
+        rtcs.append({"granule_id": granule_id})
+
+    result_granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    result_rtcs = []
+    for granule_id in result_granule_ids:
+        result_rtcs.append({"granule_id": granule_id})
+
+    assert dedupe_rtc_es_docs(rtcs, filter_path=True, sort=False) == result_rtcs
+
+def test_dedupe_rtc_es_docs__when_es_docs__and_filter_path__and_sort():
+    granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    rtcs = []
+    for granule_id in granule_ids:
+        rtcs.append({"granule_id": granule_id})
+
+    result_granule_ids = [
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123456Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123457Z_20260101T123456Z_S1A_30_v1.0",
+        "OPERA_L2_RTC-S1_T123-123456-IW1_20260101T123458Z_20260101T123456Z_S1A_30_v1.0",
+    ]
+    result_rtcs = []
+    for granule_id in result_granule_ids:
+        result_rtcs.append({"granule_id": granule_id})
+
+    assert dedupe_rtc_es_docs(rtcs, filter_path=True, sort=True) == result_rtcs


### PR DESCRIPTION
## Purpose
Mitigate duplicate RTC records from accumulating.
## Proposed Changes
- [CHANGE] dedupe results within the same CMR query

## Issues
https://hysds-core.atlassian.net/browse/OPERA-2428
## Testing
tested on dev cluster
