### PR TITLE
OPERA-0000: pre-commit hook for validating job-specs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: local
+  hooks:
+  - id: validate_hysds-io_job-spec
+    name: Validate HySDS IO and Job Specifications
+    entry: ./validate_hysds-io_job-spec.sh
+#    language: unsupported_script
+    language: system

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ setup(
         "h5py"
     ],
     extras_require={
+        "dev": [
+            "pre-commit",
+            "hysds-commons@https://github.com/hysds/hysds_commons/archive/refs/tags/v1.1.6.tar.gz",
+        ],
         "docker": [
             # The list of dependencies that are additionally installed as part of the opera-pcm docker image.
             #  See ./docker/Dockerfile

--- a/validate_hysds-io_job-spec.sh
+++ b/validate_hysds-io_job-spec.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+python ../hysds_commons/hysds_commons/validate.py docker


### PR DESCRIPTION
## Purpose
mitigate deployment errors by validating hysds-io and job-spec files pre-commit
## Proposed Changes
- [ADD] pre-commit hook for validating HySDS files.

## Issues
N/A
## Testing
tested locally