### PR TITLE
DIST-S1 delete highly-replicated fields from dataset met

### DIFF
--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -347,12 +347,31 @@ def convert(
                 for l in dataset_met_json["lineage"]:
                     lineage_arr.append(l.split('/')[-1])
                 dataset_met_json["lineage"] = lineage_arr
+        elif pge_name == 'L3_DIST_S1':
+            scrub_dataset_met(dataset_met_json)
 
         logger.info(f"Creating combined dataset metadata file {dataset_met_json_path}")
         with open(dataset_met_json_path, 'w') as outfile:
             json.dump(dataset_met_json, outfile, indent=2)
 
     return list(created_datasets)
+
+
+def scrub_dataset_met(dataset_met):
+    """Purge highly duplicated fields from dataset met"""
+    def _del_if_exists(d: dict, k):
+        if k in d:
+            del d[k]
+
+    _del_if_exists(dataset_met['runconfig'], 'localize')
+    _del_if_exists(dataset_met["runconfig"]["input_file_group"], 'input_file_paths')
+
+    for file in dataset_met["Files"]:
+        logger.info("Removing runconfig and lineage from each file")
+        _del_if_exists(file, 'runconfig')
+        _del_if_exists(file, 'lineage')
+
+    return dataset_met
 
 
 def get_collection_info(dataset_id: str, settings: dict):

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -349,6 +349,7 @@ def convert(
                 dataset_met_json["lineage"] = lineage_arr
         elif pge_name == 'L3_DIST_S1':
             scrub_dataset_met(dataset_met_json)
+            dataset_met_simplify_lineage(dataset_met_json)
 
         logger.info(f"Creating combined dataset metadata file {dataset_met_json_path}")
         with open(dataset_met_json_path, 'w') as outfile:
@@ -370,6 +371,19 @@ def scrub_dataset_met(dataset_met):
         logger.info("Removing runconfig and lineage from each file")
         _del_if_exists(file, 'runconfig')
         _del_if_exists(file, 'lineage')
+
+    return dataset_met
+
+
+def dataset_met_simplify_lineage(dataset_met):
+    logger.info("Reducing lineage string size by truncating basepath of lineage entries")
+    logger.info("dataset_met_json keys: " + str(dataset_met.keys()))
+    if len(dataset_met["lineage"]) > 0:
+        dataset_met["lineage_basepath"] = '/'.join(dataset_met["lineage"][0].split('/')[:-1])
+        lineage_arr = []
+        for l in dataset_met["lineage"]:
+            lineage_arr.append(l.split('/')[-1])
+        dataset_met["lineage"] = lineage_arr
 
     return dataset_met
 

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -330,24 +330,10 @@ def convert(
         if pge_name == "L3_DISP_S1" and job_json_dict["params"]["wf_name"] != 'Product_Update':
             # Get rid of bunch of data that we don't care about but takes up a lot of space
             logger.info("Removing superfluous data from DISP-S1 metadata")
-            dataset_met_json["runconfig"]["localize"] = None # This list is the same as lineage so no point in duplicatingq
-            dataset_met_json["runconfig"]["input_file_group"]["input_file_paths"] = None # This list is the same as lineage so no point in duplicating
-
-            for file in dataset_met_json["Files"]:
-                logger.info(file.keys())
-                logger.info("Removing runconfig and lineage from each file")
-                file["runconfig"] = None  # Runconfig for the entire product is already at metadata level so no point in duplicating for each file
-                file["lineage"] = None  # Lineage for the entire product is already at metadata level so no point in duplicating for each file
-
-            logger.info("Reducing lineage string size by truncating basepath of lineage entries")
-            logger.info("dataset_met_json keys: " + str(dataset_met_json.keys()))
-            if len(dataset_met_json["lineage"]) > 0:
-                dataset_met_json["lineage_basepath"] = '/'.join(dataset_met_json["lineage"][0].split('/')[:-1])
-                lineage_arr = []
-                for l in dataset_met_json["lineage"]:
-                    lineage_arr.append(l.split('/')[-1])
-                dataset_met_json["lineage"] = lineage_arr
+            scrub_dataset_met(dataset_met_json)
+            dataset_met_simplify_lineage(dataset_met_json)
         elif pge_name == 'L3_DIST_S1':
+            logger.info("Removing superfluous data from DIST-S1 metadata")
             scrub_dataset_met(dataset_met_json)
             dataset_met_simplify_lineage(dataset_met_json)
 
@@ -364,12 +350,16 @@ def scrub_dataset_met(dataset_met):
         if k in d:
             del d[k]
 
+    # This list is the same as lineage so no point in duplicatingq
     _del_if_exists(dataset_met['runconfig'], 'localize')
+    # This list is the same as lineage so no point in duplicating
     _del_if_exists(dataset_met["runconfig"]["input_file_group"], 'input_file_paths')
 
     for file in dataset_met["Files"]:
         logger.info("Removing runconfig and lineage from each file")
+        # Runconfig for the entire product is already at metadata level so no point in duplicating for each file
         _del_if_exists(file, 'runconfig')
+        # Lineage for the entire product is already at metadata level so no point in duplicating for each file
         _del_if_exists(file, 'lineage')
 
     return dataset_met


### PR DESCRIPTION
## Purpose
Similar to DISP-S1, remove the following from the dataset metadata:
- `runconfig.localize` and `runconfig.input_file_group.input_file_paths` as they're equivalent to lineage
- For each entry in `files`, remove `runconfig` and `lineage` as copies of these items exist in the top-level met
- In lineage, stripped out the common path prefix to a separate met entry

With DIST-S1, these removed fields can be very large due to hundreds of RTC inputs per DIST product. This unfortunately does not solve the issues with the mozart job status indices, as they contain many copies of the job context & product metadata (massive RTC lists). I believe this may be a HySDS-level issue.

## Issues
- Contributes to [OPERA-2482](https://hysds-core.atlassian.net/browse/OPERA-2482)
## Testing
- Verified reduction in GRQ document size
