### PR TITLE
OPERA-2470: Cluster destroy ES snapshot actions

### DIFF
--- a/cluster_provisioning/dev-e2e/main.tf
+++ b/cluster_provisioning/dev-e2e/main.tf
@@ -97,7 +97,7 @@ module "common" {
   hlsl30_query_timer_trigger_frequency    = var.hlsl30_query_timer_trigger_frequency
   hlss30_query_timer_trigger_frequency    = var.hlss30_query_timer_trigger_frequency
   batch_query_timer_trigger_frequency     = var.batch_query_timer_trigger_frequency
-  purge_es_snapshot                       = var.purge_es_snapshot
+  es_snapshot_destroy_action              = var.es_snapshot_destroy_action
   es_snapshot_bucket                      = var.es_snapshot_bucket
   es_bucket_role_arn                      = var.es_bucket_role_arn
   run_smoke_test                          = var.run_smoke_test

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -475,6 +475,7 @@ variable "es_snapshot_destroy_action" {
 
   validation {
     condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+    error_message = "es_snapshot_destroy_action must be one of \"leave\", \"purge\", \"create-new\""
   }
 }
 

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -469,8 +469,12 @@ variable "docker_registry_bucket" {
   default = "opera-pcm-registry-bucket"
 }
 
-variable "purge_es_snapshot" {
-  default = true
+variable "es_snapshot_destroy_action" {
+  default = "purge"
+
+  validation {
+    condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+  }
 }
 
 variable "es_snapshot_bucket" {

--- a/cluster_provisioning/dev-int/main.tf
+++ b/cluster_provisioning/dev-int/main.tf
@@ -95,7 +95,7 @@ module "common" {
   hls_download_timer_trigger_frequency    = var.hls_download_timer_trigger_frequency
   hlsl30_query_timer_trigger_frequency    = var.hlsl30_query_timer_trigger_frequency
   hlss30_query_timer_trigger_frequency    = var.hlss30_query_timer_trigger_frequency
-  purge_es_snapshot                       = var.purge_es_snapshot
+  es_snapshot_destroy_action              = var.es_snapshot_destroy_action
   es_snapshot_bucket                      = var.es_snapshot_bucket
   es_bucket_role_arn                      = var.es_bucket_role_arn
   cnm_r_sqs_arn                           = var.cnm_r_sqs_arn

--- a/cluster_provisioning/dev/main.tf
+++ b/cluster_provisioning/dev/main.tf
@@ -110,6 +110,7 @@ module "common" {
   es_bucket_role_arn                      = var.es_bucket_role_arn
   es_cluster_mode                         = var.es_cluster_mode
   duplicates_cronjob_enable               = var.duplicates_cronjob_enable
+  es_snapshot_destroy_action              = var.es_snapshot_destroy_action
 }
 
 locals {

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -445,8 +445,12 @@ variable "run_smoke_test" {
   default = true
 }
 
-variable "purge_es_snapshot" {
-  default = true
+variable "es_snapshot_destroy_action" {
+  default = "purge"
+
+  validation {
+    condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+  }
 }
 
 variable "es_snapshot_bucket" {

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -450,6 +450,7 @@ variable "es_snapshot_destroy_action" {
 
   validation {
     condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+    error_message = "es_snapshot_destroy_action must be one of \"leave\", \"purge\", \"create-new\""
   }
 }
 

--- a/cluster_provisioning/int/main.tf
+++ b/cluster_provisioning/int/main.tf
@@ -103,7 +103,7 @@ module "common" {
   hlsl30_query_timer_trigger_frequency    = var.hlsl30_query_timer_trigger_frequency
   hlss30_query_timer_trigger_frequency    = var.hlss30_query_timer_trigger_frequency
   batch_query_timer_trigger_frequency     = var.batch_query_timer_trigger_frequency
-  purge_es_snapshot                       = var.purge_es_snapshot
+  es_snapshot_destroy_action              = var.es_snapshot_destroy_action
   es_snapshot_bucket                      = var.es_snapshot_bucket
   es_bucket_role_arn                      = var.es_bucket_role_arn
   run_smoke_test                          = var.run_smoke_test

--- a/cluster_provisioning/modules/common/main.tf
+++ b/cluster_provisioning/modules/common/main.tf
@@ -407,7 +407,7 @@ resource "null_resource" "destroy_es_snapshots" {
       "  fi",
       "elif [ \"${self.triggers.es_snapshot_destroy_action}\" = \"create-new\" ]; then",
       "  echo Snapshotting essential ES indices before cluster teardown...",
-      "  ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} create-snapshot --repository snapshot-repo --snapshot ${lower("${self.triggers.project}-${self.triggers.venue}-${self.triggers.counter}_teardown_snapshot_${timestamp()}")} --wait --index-pattern grq_*,*_catalog-*,cmr_rtc_cache,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*",
+      "  ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} create-snapshot --repository snapshot-repo --snapshot ${lower("${self.triggers.project}-${self.triggers.venue}-${self.triggers.counter}_teardown_snapshot_${timestamp()}")} --wait --index-pattern grq_*,*_catalog-*,cmr_rtc_cache,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*,batch_proc",
       "elif [ \"${self.triggers.es_snapshot_destroy_action}\" = \"leave\" ]; then",
       "  echo Skipping ES snapshot cleanup",
       "else",

--- a/cluster_provisioning/modules/common/main.tf
+++ b/cluster_provisioning/modules/common/main.tf
@@ -367,17 +367,20 @@ data "aws_subnets" "lambda_vpc" {
 # sds config  QUEUE block generation
 #####################################
 resource "null_resource" "destroy_es_snapshots" {
+  # This needs to be done before the ES cluster machines are destroyed
+  depends_on = [aws_instance.mozart, aws_instance.metrics, aws_instance.mozart]
+
   triggers = {
-    private_key_file   = var.private_key_file
-    mozart_pvt_ip      = aws_instance.mozart.private_ip
-    grq_aws_es         = var.grq_aws_es
-    purge_es_snapshot  = var.purge_es_snapshot
-    project            = var.project
-    venue              = var.venue
-    counter            = var.counter
-    es_snapshot_bucket = var.es_snapshot_bucket
-    grq_es_url         = "https://${var.grq_aws_es ? var.grq_aws_es_host : aws_instance.grq.private_ip}:${var.grq_aws_es ? var.grq_aws_es_port : 9200}"
-    clear_s3_aws_es    = var.clear_s3_aws_es
+    private_key_file            = var.private_key_file
+    mozart_pvt_ip               = aws_instance.mozart.private_ip
+    grq_aws_es                  = var.grq_aws_es
+    es_snapshot_destroy_action  = var.es_snapshot_destroy_action
+    project                     = var.project
+    venue                       = var.venue
+    counter                     = var.counter
+    es_snapshot_bucket          = var.es_snapshot_bucket
+    grq_es_url                  = "https://${var.grq_aws_es ? var.grq_aws_es_host : aws_instance.grq.private_ip}:${var.grq_aws_es ? var.grq_aws_es_port : 9200}"
+    clear_s3_aws_es             = var.clear_s3_aws_es
   }
 
   connection {
@@ -394,15 +397,22 @@ resource "null_resource" "destroy_es_snapshots" {
       "set -ex",
       "source ~/.bash_profile",
       "# Skip ES snapshot purging for ops environment to protect production data",
-      "if [ \"${self.triggers.venue}\" = \"ops\" ]; then",
-      "  echo 'Skipping ES snapshot purging for ops environment'",
-      "if [ \"${self.triggers.purge_es_snapshot}\" = true ]; then",
+      "if [ \"${self.triggers.es_snapshot_destroy_action}\" = \"purge\" ]; then",
+      "  echo Purging ES snapshots...",
       "  aws s3 rm --recursive s3://${self.triggers.es_snapshot_bucket}/${self.triggers.project}-${self.triggers.venue}-${self.triggers.counter}",
       "  if [ \"${self.triggers.grq_aws_es}\" = true ]; then",
       "    ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} delete-lifecycle --policy-id hourly-snapshot",
       "    ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} delete-all-snapshots --repository grq-snapshot-repo",
       "    ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} delete-repository --repository grq-snapshot-repo",
       "  fi",
+      "elif [ \"${self.triggers.es_snapshot_destroy_action}\" = \"create-new\" ]; then",
+      "  echo Snapshotting essential ES indices before cluster teardown...",
+      "  ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} create-snapshot --repository snapshot-repo --snapshot ${self.triggers.project}-${self.triggers.venue}-${self.triggers.counter}_teardown_snapshot_${timestamp()} --wait --index-pattern grq_*,*_catalog-*,cmr_rtc_cache,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*",
+      "elif [ \"${self.triggers.es_snapshot_destroy_action}\" = \"leave\" ]; then",
+      "  echo Skipping ES snapshot cleanup",
+      "else",
+      "  echo Unrecognized option \"${self.triggers.es_snapshot_destroy_action}\"",
+      "  exit 1",
       "fi"
     ]
   }

--- a/cluster_provisioning/modules/common/main.tf
+++ b/cluster_provisioning/modules/common/main.tf
@@ -407,7 +407,7 @@ resource "null_resource" "destroy_es_snapshots" {
       "  fi",
       "elif [ \"${self.triggers.es_snapshot_destroy_action}\" = \"create-new\" ]; then",
       "  echo Snapshotting essential ES indices before cluster teardown...",
-      "  ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} create-snapshot --repository snapshot-repo --snapshot ${self.triggers.project}-${self.triggers.venue}-${self.triggers.counter}_teardown_snapshot_${timestamp()} --wait --index-pattern grq_*,*_catalog-*,cmr_rtc_cache,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*",
+      "  ~/mozart/bin/snapshot_es_data.py --es-url ${self.triggers.grq_es_url} create-snapshot --repository snapshot-repo --snapshot ${lower("${self.triggers.project}-${self.triggers.venue}-${self.triggers.counter}_teardown_snapshot_${timestamp()}")} --wait --index-pattern grq_*,*_catalog-*,cmr_rtc_cache,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*",
       "elif [ \"${self.triggers.es_snapshot_destroy_action}\" = \"leave\" ]; then",
       "  echo Skipping ES snapshot cleanup",
       "else",

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -900,7 +900,7 @@ resource "aws_instance" "mozart" {
         ~/mozart/bin/snapshot_es_data.py --engine $METRICS_ES_ENGINE --es-url https://${aws_instance.metrics.private_ip}:9200 create-lifecycle --repository metrics-snapshot-repo --policy-id daily-snapshot --snapshot metrics-backup --index-pattern logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-* --schedule="0 0 5 * * ?"
       else
         ~/mozart/bin/snapshot_es_data.py --engine $GRQ_ES_ENGINE --es-url ${local.grq_es_url} create-repository --repository snapshot-repo --bucket ${var.es_snapshot_bucket} --bucket-path ${var.project}-${var.venue}-${var.counter}/cluster --role-arn ${var.es_bucket_role_arn}
-        ~/mozart/bin/snapshot_es_data.py --engine $GRQ_ES_ENGINE --es-url ${local.grq_es_url} create-lifecycle --repository snapshot-repo --policy-id hourly-snapshot --snapshot common-cluster-backup --index-pattern grq_*,*_catalog,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*
+        ~/mozart/bin/snapshot_es_data.py --engine $GRQ_ES_ENGINE --es-url ${local.grq_es_url} create-lifecycle --repository snapshot-repo --policy-id hourly-snapshot --snapshot common-cluster-backup --index-pattern grq_*,*_catalog-*,cmr_rtc_cache,*_status-*,user_rules-*,job_specs,hysds_ios-*,containers,logstash-*,sdswatch-*,mozart-logs-*,factotum-logs-*,grq-logs-*,batch_proc
       fi
     EOT
     ]

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -129,6 +129,7 @@ variable "es_snapshot_destroy_action" {
 
   validation {
     condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+    error_message = "es_snapshot_destroy_action must be one of \"leave\", \"purge\", \"create-new\""
   }
 }
 

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -1093,6 +1093,7 @@ variable "earthdata_uat_pass" {
   default = ""
 }
 
+# TODO: It doesn't look like this is used anywhere. Can we remove it?
 variable "clear_s3_aws_es" {
   type    = bool
   default = true

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -124,8 +124,12 @@ variable "grq_aws_es_host_private_verdi" {
 variable "use_grq_aws_es_private_verdi" {
 }
 
-variable "purge_es_snapshot" {
-  default = true
+variable "es_snapshot_destroy_action" {
+  default = "purge"
+
+  validation {
+    condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+  }
 }
 
 variable "mozart" {

--- a/cluster_provisioning/ops/ops_override.tf
+++ b/cluster_provisioning/ops/ops_override.tf
@@ -172,3 +172,11 @@ variable "autoscale" {
     data_dev_size = 300
   }
 }
+
+variable "es_snapshot_destroy_action" {
+  default = "create-new"
+
+  validation {
+    condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+  }
+}

--- a/cluster_provisioning/pst/override.tf
+++ b/cluster_provisioning/pst/override.tf
@@ -237,3 +237,11 @@ variable "run_smoke_test" {
   type = bool
   default = true
 }
+
+variable "es_snapshot_destroy_action" {
+  default = "create-new"
+
+  validation {
+    condition = contains(["leave", "purge", "create-new"], var.es_snapshot_destroy_action)
+  }
+}


### PR DESCRIPTION
## Purpose
Add 3 selectable actions to perform re: ES snapshots on cluster destroy: `leave` (do nothing), `purge` (delete all snapshot data), `create-new` (forcibly create a new snapshot before the ES cluster is destroyed)

The default action is `purge` on all cluster types except for OPS & PST, which use `create-new`.

In `create-new`, the following index patterns are snapshotted:
- GRQ:
  - `grq_*`
  - `*_catalog-*`
  - `cmr_rtc_cache`
- Mozart:
  - `*_status-*`
  - `user_rules-*`
  - `job_specs`
  - `hysds_ios-*`
  - `containers`
- Metrics:
  - `logstash-*`
  - `sdswatch-*`
  - `mozart-logs-*`
  - `factotum-logs-*`
  - `grq-logs-*`

## Issues
- [OPERA-2470](https://hysds-core.atlassian.net/browse/OPERA-2470)
  - part of: [OPERA-2459](https://hysds-core.atlassian.net/browse/OPERA-2459)
    - part of: [OPERA-2475](https://hysds-core.atlassian.net/browse/OPERA-2475)
## Testing
- Deployed in a cluster, populated some documents and ran `terraform destroy` targeted at the `module.common` null resource managing ES snapshots on destroy
