### PR TITLE
Reduce size of tracebacks in Figaro

### DIFF
--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -183,9 +183,8 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
             except Exception as e:
                 trace = traceback.format_exc()
                 error = str(e)
-                raise RuntimeError(
-                    "Failed to run pipeline {}: {}\n{}".format(job_json, error, trace)
-                )
+                logger.critical("Failed to run pipeline {}: {}\n{}".format(job_json, error, trace))
+                raise RuntimeError(e)
 
             logger.debug("dataset_files: {}".format(output_datasets))
 

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -64,7 +64,8 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["status"] = e.returncode
         info_dict["stdout"] = ""
         info_dict["stderr"] = e.output.decode()
-        raise RuntimeError("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
+        logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
+        raise RuntimeError(e.output.decode())
     except Exception as e:
         logr.error("Got exception running:\n{}\nException: {}".format(cmd, str(e)))
         logr.error("Traceback: {}".format(traceback.format_exc()))


### PR DESCRIPTION
Reduce the size of tracebacks for failed jobs in Figaro.

There's still duplicated tracebacks, but I suspect that may be caused deeper in HySDS.

## Issues
- Contributes to [OPERA-2464](https://hysds-core.atlassian.net/browse/OPERA-2464)
## Testing
- Tested in dev cluster

Example:
<img width="1577" height="1153" alt="image" src="https://github.com/user-attachments/assets/de3aff61-4450-4003-92dd-a5a5cfdff26a" />
