### PR TITLE
Ensure map staging fails with GDAL errors

### DIFF
--- a/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
@@ -53,8 +53,11 @@ set_daac_product_type:
   template: OPERA_L3_DIST_S1_{cnm_version}
 
 get_dist_s1_mask_file:
-  s3_bucket: "opera-umd-water-mask"
-  s3_key: "v1/EPSG4326.vrt"
+  #  s3_bucket: "opera-umd-water-mask"
+  #  s3_key: "v1/EPSG4326.vrt"
+  # DO NOT MERGE THIS CHANGE
+  s3_bucket: "opera-dev-lts-rileykk"
+  s3_key: "opera-umd-water-mask/corrupted_tile_test/EPSG4326.vrt"
 
 get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DISP-S1

--- a/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
@@ -53,11 +53,8 @@ set_daac_product_type:
   template: OPERA_L3_DIST_S1_{cnm_version}
 
 get_dist_s1_mask_file:
-  #  s3_bucket: "opera-umd-water-mask"
-  #  s3_key: "v1/EPSG4326.vrt"
-  # DO NOT MERGE THIS CHANGE
-  s3_bucket: "opera-dev-lts-rileykk"
-  s3_key: "opera-umd-water-mask/corrupted_tile_test/EPSG4326.vrt"
+  s3_bucket: "opera-umd-water-mask"
+  s3_key: "v1/EPSG4326.vrt"
 
 get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DISP-S1

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1669,6 +1669,9 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         loc_dur = (loc_t2 - loc_t1).total_seconds()
         path_disk_usage = 0
 
+        if not os.path.exists(output_filepath):
+            raise FileNotFoundError(output_filepath)
+
         # Use a wildcard pattern to ensure we get transfer size of all ancillary map
         # files, not just the .vrt file referenced in output_filepath
         output_dir = os.path.dirname(output_filepath)

--- a/tools/stage_ancillary_map.py
+++ b/tools/stage_ancillary_map.py
@@ -74,6 +74,9 @@ def download_map(polys, map_bucket, map_vrt_key, outfile):
         Path to where the output map VRT (and corresponding tifs) will be staged.
 
     """
+    # Re-call UseExceptions because we're still seeing exceptions ignored
+    gdal.UseExceptions()
+
     # Download the map for each provided Polygon
     file_prefix = os.path.splitext(outfile)[0]
     region_list = []

--- a/tools/stage_ancillary_map.py
+++ b/tools/stage_ancillary_map.py
@@ -12,6 +12,7 @@ from osgeo import gdal, osr
 from opera_commons.logger import logger
 from opera_commons.logger import LogLevels
 from util.geo_util import (check_dateline,
+                           check_gdal_output,
                            polygon_from_bounding_box)
 from util.pge_util import check_aws_connection
 
@@ -98,6 +99,7 @@ def download_map(polys, map_bucket, map_vrt_key, outfile):
         gdal.Translate(
             output_path, ds, format='GTiff', projWin=[x_min, y_max, x_max, y_min]
         )
+        check_gdal_output(output_path)
 
         # stage_ancillary_map.py takes a bbox as an input. The longitude coordinates
         # of this bbox are unwrapped i.e., range in [0, 360] deg. If the
@@ -119,6 +121,7 @@ def download_map(polys, map_bucket, map_vrt_key, outfile):
 
     # Build VRT with downloaded sub-regions
     gdal.BuildVRT(outfile, region_list)
+    check_gdal_output(outfile)
 
 
 def main(args):

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -210,6 +210,9 @@ def download_dem(polys, epsgs, dem_location, outfile):
         Path to the where the output DEM file is to be staged.
 
     """
+    # Re-call UseExceptions because we're still seeing exceptions ignored
+    gdal.UseExceptions()
+
     # set epsg to 4326 for each element in the list
     epsgs = [4326] * len(epsgs)
 

--- a/tools/stage_dem.py
+++ b/tools/stage_dem.py
@@ -12,6 +12,7 @@ from osgeo import gdal, osr
 from opera_commons.logger import LogLevels
 from opera_commons.logger import logger
 from util.geo_util import (check_dateline,
+                           check_gdal_output,
                            epsg_from_polygon,
                            polygon_from_bounding_box,
                            polygon_from_mgrs_tile)
@@ -172,8 +173,11 @@ def translate_dem(vrt_filename, output_path, x_min, x_max, y_min, y_max):
             gdal.Translate(
                 output_path, ds, format='GTiff', projWin=[x_min, y_max, x_max, y_min]
             )
+            check_gdal_output(output_path)
         else:
             raise
+
+    check_gdal_output(output_path)
 
     # stage_dem.py takes a bbox as an input. The longitude coordinates
     # of this bbox are unwrapped i.e., range in [0, 360] deg. If the
@@ -229,6 +233,7 @@ def download_dem(polys, epsgs, dem_location, outfile):
 
     # Build vrt with downloaded DEMs
     gdal.BuildVRT(outfile, dem_list)
+    check_gdal_output(outfile)
 
 
 def main(opts):

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -189,6 +189,8 @@ def download_worldcover(polys, worldcover_bucket, worldcover_ver,
         Path to the where the output Worldcover file is to be staged.
 
     """
+    # Re-call UseExceptions because we're still seeing exceptions ignored
+    gdal.UseExceptions()
 
     # Download Worldcover map for each polygon/epsg
     file_prefix = os.path.splitext(outfile)[0]

--- a/tools/stage_worldcover.py
+++ b/tools/stage_worldcover.py
@@ -12,6 +12,7 @@ from shapely.geometry import box
 from opera_commons.logger import logger
 from opera_commons.logger import LogLevels
 from util.geo_util import (check_dateline,
+                           check_gdal_output,
                            polygon_from_mgrs_tile)
 from util.pge_util import check_aws_connection
 
@@ -163,9 +164,12 @@ def translate_worldcover(vrt_filename, output_path, x_min, x_max, y_min, y_max):
             gdal.Translate(
                 output_path, ds, format='GTiff', projWin=[x_min, y_max, x_max, y_min]
             )
+            check_gdal_output(output_path)
             return
 
         raise
+
+    check_gdal_output(output_path)
 
 
 def download_worldcover(polys, worldcover_bucket, worldcover_ver,
@@ -209,6 +213,7 @@ def download_worldcover(polys, worldcover_bucket, worldcover_ver,
 
     # Build vrt with downloaded maps
     gdal.BuildVRT(outfile, wc_list)
+    check_gdal_output(outfile)
 
 
 def main(opts):

--- a/util/geo_util.py
+++ b/util/geo_util.py
@@ -17,6 +17,7 @@ from shapely.geometry import box, LinearRing, Point, Polygon
 EARTH_APPROX_CIRCUMFERENCE = 40075017.
 EARTH_RADIUS = EARTH_APPROX_CIRCUMFERENCE / (2 * np.pi)
 
+
 def margin_km_to_deg(margin_in_km):
     """Converts a margin value from kilometers to degrees"""
     km_to_deg_at_equator = 1000. / (EARTH_APPROX_CIRCUMFERENCE / 360.)
@@ -24,12 +25,14 @@ def margin_km_to_deg(margin_in_km):
 
     return margin_in_deg
 
+
 def margin_km_to_longitude_deg(margin_in_km, lat=0):
     """Converts a margin value from kilometers to degrees as a function of latitude"""
     delta_lon = (180 * 1000 * margin_in_km /
                  (np.pi * EARTH_RADIUS * np.cos(np.pi * lat / 180)))
 
     return delta_lon
+
 
 def bounding_box_from_slc_granule(safe_file_path):
     """Extracts the bounding box footprint from the given SLC SAFE archive"""
@@ -70,6 +73,7 @@ def bounding_box_from_slc_granule(safe_file_path):
     bbox = (lon_min, lat_min, lon_max, lat_max)  # WSEN order
 
     return bbox
+
 
 def polygon_from_bounding_box(bounding_box, margin_in_km):
     """
@@ -489,3 +493,10 @@ def transform_polygon_coords_to_epsg(polys, epsgs):
                      (max(x_max), max(y_max)), (max(x_max), min(y_min))])]
 
     return poly
+
+
+def check_gdal_output(gdal_output_path):
+    """Simple file existence check for GDAL outputs."""
+    if not os.path.exists(gdal_output_path):
+        raise RuntimeError(f'GDAL output path {gdal_output_path} does not exist. GDAL likely failed without raising '
+                           f'an exception. Please report this (OPERA-2499)')


### PR DESCRIPTION
## Purpose
Fully ensure against silent GDAL failures in the tiled ancillary map staging tools.

- Explicitly re-call `gdal.UseExceptions()` at the start of each download function
- Check each expected GDAL output file exists after each GDAL call, raising a `RuntimeError` if not

## Issues
- [OPERA-2499](https://hysds-core.atlassian.net/browse/OPERA-2499)
## Testing
- Tested with a DIST-S1 SCIFLO job with a custom UMD water mask input with a corrupted tile over the DIST tile being generated. An exception was properly raised.
