### PR TITLE
Further reduce size of tracebacks in Figaro

### DIFF
--- a/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
@@ -53,8 +53,11 @@ set_daac_product_type:
   template: OPERA_L3_DIST_S1_{cnm_version}
 
 get_dist_s1_mask_file:
-  s3_bucket: "opera-umd-water-mask"
-  s3_key: "v1/EPSG4326.vrt"
+  #  s3_bucket: "opera-umd-water-mask"
+  #  s3_key: "v1/EPSG4326.vrt"
+  # DO NOT MERGE THIS CHANGE
+  s3_bucket: "opera-dev-lts-rileykk"
+  s3_key: "opera-umd-water-mask/corrupted_tile_test/EPSG4326.vrt"
 
 get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DISP-S1

--- a/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L3_DIST_S1.yaml
@@ -53,11 +53,8 @@ set_daac_product_type:
   template: OPERA_L3_DIST_S1_{cnm_version}
 
 get_dist_s1_mask_file:
-  #  s3_bucket: "opera-umd-water-mask"
-  #  s3_key: "v1/EPSG4326.vrt"
-  # DO NOT MERGE THIS CHANGE
-  s3_bucket: "opera-dev-lts-rileykk"
-  s3_key: "opera-umd-water-mask/corrupted_tile_test/EPSG4326.vrt"
+  s3_bucket: "opera-umd-water-mask"
+  s3_key: "v1/EPSG4326.vrt"
 
 get_static_ancillary_files:
   # The s3 locations of each of the static ancillary file types used by DISP-S1

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -184,7 +184,7 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
                 trace = traceback.format_exc()
                 error = str(e)
                 logger.critical("Failed to run pipeline {}: {}\n{}".format(job_json, error, trace))
-                raise RuntimeError(e)
+                raise e
 
             logger.debug("dataset_files: {}".format(output_datasets))
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1642,9 +1642,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
                 "Could not extract metadata from input "
                 "context: {}".format(traceback.format_exc())
             )
-            raise RuntimeError(
-                "Could not extract metadata from input context: {}".format(e)
-            )
+            raise RuntimeError("Could not extract metadata from input context") from e
 
     def get_opera_ancillary(self, ancillary_type, output_filepath, staging_func, staging_func_args):
         """
@@ -1661,9 +1659,8 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         except Exception as e:
             trace = traceback.format_exc()
             error = str(e)
-            raise RuntimeError(
-                f"Failed to download {ancillary_type} file, reason: {error}\n{trace}"
-            )
+            logger.critical(f"Failed to download {ancillary_type} file, reason: {error}\n{trace}")
+            raise e
 
         loc_t2 = datetime.now(timezone.utc).replace(tzinfo=None)
         loc_dur = (loc_t2 - loc_t1).total_seconds()

--- a/opera_chimera/run_sciflo.py
+++ b/opera_chimera/run_sciflo.py
@@ -34,7 +34,7 @@ def __write_error_files(error, traceback):
 
     try:
         with open(alt_error_file, "w") as f:
-            f.write("%s" % get_short_error(error))
+            f.write("%s" % get_short_error(error, strip=True))
         with open(alt_tb_file, "w") as f:
             f.write("%s" % traceback)
     except OSError as oe:

--- a/opera_chimera/run_sciflo.py
+++ b/opera_chimera/run_sciflo.py
@@ -34,9 +34,9 @@ def __write_error_files(error, traceback):
 
     try:
         with open(alt_error_file, "w") as f:
-            f.write("%s\n" % get_short_error(error))
+            f.write("%s" % get_short_error(error))
         with open(alt_tb_file, "w") as f:
-            f.write("%s\n" % traceback)
+            f.write("%s" % traceback)
     except OSError as oe:
         print(
             f"OSError encountered: {str(oe)}. Will write errors to placeholder files."

--- a/opera_chimera/run_sciflo.py
+++ b/opera_chimera/run_sciflo.py
@@ -12,13 +12,61 @@ import subprocess
 from importlib import import_module
 
 from opera_commons.logger import logger
+from util.exec_util import get_short_error
 from chimera.commons.accountability import Accountability
+from chimera.commons import sciflo_util
 from chimera.commons.sciflo_util import (
   __create_placeholder_alt_files,
   __cleanup_placeholder_alt_files,
   extract_error,
-  copy_sciflo_work
+  copy_sciflo_work,
+  PLACEHOLDER_ERROR_FILE,
+  PLACEHOLDER_TB_FILE,
+  MAX_PLACEHOLDER_FILE_SIZE,
+  PLACEHOLDER_DOCKER_STATS_FILE
 )
+
+
+def __write_error_files(error, traceback):
+    alt_error_file = "_alt_error.txt"
+    alt_tb_file = "_alt_traceback.txt"
+    docker_stats_file = "_docker_stats.json"
+
+    try:
+        with open(alt_error_file, "w") as f:
+            f.write("%s\n" % get_short_error(error))
+        with open(alt_tb_file, "w") as f:
+            f.write("%s\n" % traceback)
+    except OSError as oe:
+        print(
+            f"OSError encountered: {str(oe)}. Will write errors to placeholder files."
+        )
+        print(f"Renaming {PLACEHOLDER_ERROR_FILE} to {alt_error_file}.")
+        os.rename(PLACEHOLDER_ERROR_FILE, alt_error_file)
+        print(f"Renaming {PLACEHOLDER_TB_FILE} to {alt_tb_file}.")
+        os.rename(PLACEHOLDER_TB_FILE, alt_tb_file)
+
+        with open(alt_error_file, "w") as f:
+            f.write("%s\n" % error[:MAX_PLACEHOLDER_FILE_SIZE])
+
+        with open(alt_tb_file, "w") as f:
+            f.write("%s\n" % traceback[:MAX_PLACEHOLDER_FILE_SIZE])
+        print(f"Successfully wrote the errors to {alt_error_file} and {alt_tb_file}")
+
+        if (
+            os.path.exists(docker_stats_file)
+            and os.path.getsize(docker_stats_file) == 0
+        ):
+            print(f"Renaming {PLACEHOLDER_DOCKER_STATS_FILE} to {docker_stats_file}")
+            os.rename(PLACEHOLDER_DOCKER_STATS_FILE, docker_stats_file)
+            print(
+                f"Successfully renamed {PLACEHOLDER_DOCKER_STATS_FILE} to {docker_stats_file}"
+            )
+
+
+# Try to patch the __write_error_files func to use custom _alt_error elision
+sciflo_util.__write_error_files = __write_error_files
+
 
 def run_sciflo(sfl_file, sfl_args, output_dir, timeout):
     """

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -55,7 +55,7 @@ def exec_wrapper(func):
                 status = await func(*args, **kwargs)
             except (Exception, SystemExit) as e:
                 with open("_alt_error.txt", "w") as f:
-                    f.write("%s\n" % get_short_error(e))
+                    f.write("%s" % get_short_error(e))
                 with open("_alt_traceback.txt", "w") as f:
                     f.write("%s\n" % traceback.format_exc())
                 raise
@@ -66,7 +66,7 @@ def exec_wrapper(func):
                 status = func(*args, **kwargs)
             except (Exception, SystemExit) as e:
                 with open("_alt_error.txt", "w") as f:
-                    f.write("%s\n" % get_short_error(e))
+                    f.write("%s" % get_short_error(e))
                 with open("_alt_traceback.txt", "w") as f:
                     f.write("%s\n" % traceback.format_exc())
                 raise

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -66,7 +66,7 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["stderr"] = e.output.decode()
         logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
         # raise RuntimeError(e.output.decode())
-        raise RuntimeError().with_traceback(e.output.decode())
+        raise RuntimeError().add_note(e.output.decode())
         # raise e.with_traceback(e.output.decode())
     except Exception as e:
         logr.error("Got exception running:\n{}\nException: {}".format(cmd, str(e)))

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -66,7 +66,9 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["stderr"] = e.output.decode()
         logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
         # raise RuntimeError(e.output.decode())
-        raise RuntimeError().add_note(e.output.decode())
+        err = RuntimeError()
+        err.add_note(e.output.decode())
+        raise err
         # raise e.with_traceback(e.output.decode())
     except Exception as e:
         logr.error("Got exception running:\n{}\nException: {}".format(cmd, str(e)))

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -65,11 +65,10 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["stdout"] = ""
         info_dict["stderr"] = e.output.decode()
         logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
-        # raise RuntimeError(e.output.decode())
+
         err = RuntimeError('PGE/SAS subprocess failure')
         err.add_note(e.output.decode())
         raise err from e
-        # raise e.with_traceback(e.output.decode())
     except Exception as e:
         logr.error("Got exception running:\n{}\nException: {}".format(cmd, str(e)))
         logr.error("Traceback: {}".format(traceback.format_exc()))

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -65,7 +65,9 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["stdout"] = ""
         info_dict["stderr"] = e.output.decode()
         logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
-        raise RuntimeError(e.output.decode())
+        # raise RuntimeError(e.output.decode())
+        raise RuntimeError().with_traceback(e.output.decode())
+        # raise e.with_traceback(e.output.decode())
     except Exception as e:
         logr.error("Got exception running:\n{}\nException: {}".format(cmd, str(e)))
         logr.error("Traceback: {}".format(traceback.format_exc()))

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -68,7 +68,7 @@ def call_noerr(cmd, work_dir, logr=logger):
         # raise RuntimeError(e.output.decode())
         err = RuntimeError()
         err.add_note(e.output.decode())
-        raise err
+        raise err from e
         # raise e.with_traceback(e.output.decode())
     except Exception as e:
         logr.error("Got exception running:\n{}\nException: {}".format(cmd, str(e)))

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -66,7 +66,7 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["stderr"] = e.output.decode()
         logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
         # raise RuntimeError(e.output.decode())
-        err = RuntimeError()
+        err = RuntimeError('PGE/SAS subprocess failure')
         err.add_note(e.output.decode())
         raise err from e
         # raise e.with_traceback(e.output.decode())

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -97,7 +97,7 @@ def call_noerr(cmd, work_dir, logr=logger):
         info_dict["stderr"] = e.output.decode()
         logr.critical("Got exception running:\n{}\nSTDOUT/STDERR:\n{}".format(cmd, e.output.decode()))
 
-        err = RuntimeError('PGE/SAS subprocess failure')
+        err = RuntimeError('PGE/SAS failure')
         err.add_note(e.output.decode())
         raise err from e
     except Exception as e:

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -14,6 +14,16 @@ from opera_commons.logger import logger
 ISO_DATETIME_PATTERN = "%Y-%m-%dT%H:%M:%S.%f"
 
 
+def get_short_error(e: Exception) -> str:
+    """Custom-elide error strings"""
+    err_string = str(e)
+
+    if len(err_string) > 35:  # https://github.com/hysds/hysds/blob/70f7ad93c99e986d90381b83313587e66409c189/hysds/utils.py#L347
+        err_string = f"{err_string[:33]}.."
+
+    return err_string
+
+
 def exec_wrapper(func):
     """Execution wrapper to dump alternate errors and tracebacks."""
 
@@ -24,7 +34,7 @@ def exec_wrapper(func):
                 status = await func(*args, **kwargs)
             except (Exception, SystemExit) as e:
                 with open("_alt_error.txt", "w") as f:
-                    f.write("%s\n" % str(e))
+                    f.write("%s\n" % get_short_error(e))
                 with open("_alt_traceback.txt", "w") as f:
                     f.write("%s\n" % traceback.format_exc())
                 raise
@@ -35,7 +45,7 @@ def exec_wrapper(func):
                 status = func(*args, **kwargs)
             except (Exception, SystemExit) as e:
                 with open("_alt_error.txt", "w") as f:
-                    f.write("%s\n" % str(e))
+                    f.write("%s\n" % get_short_error(e))
                 with open("_alt_traceback.txt", "w") as f:
                     f.write("%s\n" % traceback.format_exc())
                 raise

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -14,9 +14,30 @@ from opera_commons.logger import logger
 ISO_DATETIME_PATTERN = "%Y-%m-%dT%H:%M:%S.%f"
 
 
-def get_short_error(e: Exception) -> str:
+"""
+List of common substrings in PCM error messages we can strip out to reduce the short error message to be more readable.
+
+For str values, all occurrences of the substring are removed.
+Alternatively, a tuple can be provided with parameters for str.replace()
+"""
+SHORT_ERROR_REPLACEMENTS = [
+    'SciFlo step ',
+    'input_preprocessor_',
+    'postprocessor_',
+    ('_PGE', '', 1)
+]
+
+
+def get_short_error(e: Exception, strip=False) -> str:
     """Custom-elide error strings"""
     err_string = str(e)
+
+    if strip:
+        for replacement in SHORT_ERROR_REPLACEMENTS:
+            if isinstance(replacement, str):
+                err_string = err_string.replace(replacement, '')
+            else:
+                err_string = err_string.replace(*replacement)
 
     if len(err_string) > 35:  # https://github.com/hysds/hysds/blob/70f7ad93c99e986d90381b83313587e66409c189/hysds/utils.py#L347
         err_string = f"{err_string[:33]}.."


### PR DESCRIPTION
- Fully deduplicate tracebacks for PGE/SAS failures
- Improvements to short error messages for easier faceting

## Issues
- Contributes to [OPERA-2464](https://hysds-core.atlassian.net/browse/OPERA-2464)
## Testing
- [x] PGE/SAS error: reasonably sized traceback
- [x] PGE/SAS error: short error
- [x] PCM error: reasonably sized traceback
- [x] PCM error: short error

## Test results

### PGE/SAS Failure Traceback

<img width="1273" height="1126" alt="image" src="https://github.com/user-attachments/assets/062de74a-954d-491d-9a33-2bd929f31d01" />

### PCM Failure Traceback

<img width="1265" height="966" alt="image" src="https://github.com/user-attachments/assets/995d9009-174b-4cdc-8981-441d2ee608b0" />

### Short Errors

<img width="340" height="155" alt="image" src="https://github.com/user-attachments/assets/42b3b975-cd27-4b96-961e-c28061e4c639" />

