### PR TITLE
Add optional burst filtering for L2 products

### DIFF
--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -71,9 +71,9 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
-            {%- if runconfig.input_file_group.burst_list %}
+            {%- if runconfig.processing.burst_list %}
             burst_id:
-              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              {%- for burst_id in runconfig.processing.burst_list %}
               - {{ burst_id }}
               {%- endfor %}
             {%- else %}

--- a/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1.jinja2.tmpl
@@ -71,7 +71,14 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
+            {%- if runconfig.input_file_group.burst_list %}
             burst_id:
+              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              - {{ burst_id }}
+              {%- endfor %}
+            {%- else %}
+            burst_id:
+            {%- endif %}
           dynamic_ancillary_file_group:
             {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
             {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}

--- a/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
@@ -72,7 +72,14 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
+            {%- if runconfig.input_file_group.burst_list %}
             burst_id:
+              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              - {{ burst_id }}
+              {%- endfor %}
+            {%- else %}
+            burst_id:
+            {%- endif %}
           dynamic_ancillary_file_group:
             {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}
             {%- if runconfig.dynamic_ancillary_file_group[ type ] is not none %}

--- a/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_CSLC_S1_STATIC.jinja2.tmpl
@@ -72,9 +72,9 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
-            {%- if runconfig.input_file_group.burst_list %}
+            {%- if runconfig.processing.burst_list %}
             burst_id:
-              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              {%- for burst_id in runconfig.processing.burst_list %}
               - {{ burst_id }}
               {%- endfor %}
             {%- else %}

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -72,7 +72,14 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
+            {%- if runconfig.input_file_group.burst_list %}
             burst_id:
+              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              - {{ burst_id }}
+              {%- endfor %}
+            {%- else %}
+            burst_id:
+            {%- endif %}
             source_data_access: "https://search.asf.alaska.edu/#/?dataset=SENTINEL-1&productTypes=SLC"
           dynamic_ancillary_file_group:
             {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}

--- a/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1.jinja2.tmpl
@@ -72,9 +72,9 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
-            {%- if runconfig.input_file_group.burst_list %}
+            {%- if runconfig.processing.burst_list %}
             burst_id:
-              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              {%- for burst_id in runconfig.processing.burst_list %}
               - {{ burst_id }}
               {%- endfor %}
             {%- else %}

--- a/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
@@ -73,7 +73,14 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
+            {%- if runconfig.input_file_group.burst_list %}
             burst_id:
+              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              - {{ burst_id }}
+              {%- endfor %}
+            {%- else %}
+            burst_id:
+            {%- endif %}
             source_data_access: "https://search.asf.alaska.edu/#/?dataset=SENTINEL-1&productTypes=SLC"
           dynamic_ancillary_file_group:
             {%- for type in runconfig.dynamic_ancillary_file_group.keys() %}

--- a/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L2_RTC_S1_STATIC.jinja2.tmpl
@@ -73,9 +73,9 @@ RunConfig:
             {%- endif %}{# if runconfig.input_file_group[ type ] is iterable and runconfig.input_file_group[ type ] is not string #}
             {%- endif %}{# if runconfig.input_file_group[ type ] is not none #}
             {%- endfor %}{# for type in runconfig.input_file_group.keys() #}
-            {%- if runconfig.input_file_group.burst_list %}
+            {%- if runconfig.processing.burst_list %}
             burst_id:
-              {%- for burst_id in runconfig.input_file_group.burst_list %}
+              {%- for burst_id in runconfig.processing.burst_list %}
               - {{ burst_id }}
               {%- endfor %}
             {%- else %}

--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -77,6 +77,9 @@ class AsfDaacSlcDownload(BaseDownload):
                 self.logger.info("Adding intersects_north_america to dataset metadata")
                 additional_metadata["intersects_north_america"] = True
 
+            if download.get('burst_ids'):
+                additional_metadata['burst_ids'] = download['burst_ids']
+
             dataset_dir = self.extract_one_to_one(product, self.cfg, working_dir=Path.cwd(),
                                                   extra_metadata=additional_metadata,
                                                   name_postscript='-r'+str(download['revision_id']))

--- a/data_subscriber/parser.py
+++ b/data_subscriber/parser.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import re
 from datetime import datetime
 
 from data_subscriber.cmr import (Collection, Endpoint, Provider, PGEProduct, CMR_TIME_FORMAT)
@@ -273,6 +274,12 @@ def create_parser():
                                  "action": "store_false",
                                  "help": "Disable granule dedupe checks (HLS + SLC)"}}
 
+    burst_ids = {"positionals": ["--burst-ids"],
+                 "kwargs": {"dest": "burst_ids",
+                            "nargs": '+',
+                            "default": None,
+                            "help": 'List of burst IDs to process. Only use with --native-id'}}
+
     _add_arguments(parser.add_mutually_exclusive_group(required=False), [verbose, quiet])
 
     survey_parser = subparsers.add_parser("survey",
@@ -293,7 +300,7 @@ def create_parser():
                             batch_ids, use_temporal, temporal_start_date, native_id,
                             transfer_protocol, frame_id, include_regions,
                             exclude_regions, proc_mode, k_offsets_counts, product_id_time, window_delta, query_replacement_file,
-                            tile_filter, granule_dedupe]
+                            tile_filter, granule_dedupe, burst_ids]
 
     _add_arguments(full_parser, full_parser_arg_list)
     _add_arguments(full_parser.add_mutually_exclusive_group(required=False), [verbose, quiet])
@@ -307,7 +314,7 @@ def create_parser():
                              release_version, job_queue, chunk_size, max_revision,
                              native_id, use_temporal, temporal_start_date, transfer_protocol, product_id_time, window_delta,
                              frame_id, include_regions, exclude_regions, proc_mode, k_offsets_counts, query_replacement_file,
-                             tile_filter, granule_dedupe]
+                             tile_filter, granule_dedupe, burst_ids]
 
     _add_arguments(query_parser, query_parser_arg_list)
     _add_arguments(query_parser.add_mutually_exclusive_group(required=False), [verbose, quiet])
@@ -317,7 +324,7 @@ def create_parser():
                                             formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     download_parser_arg_list = [endpoint, dry_run, smoke_run, provider, product,
                                 batch_ids, start_date, end_date, use_temporal, proc_mode,
-                                temporal_start_date, transfer_protocol, release_version]
+                                temporal_start_date, transfer_protocol, release_version, burst_ids]
     _add_arguments(download_parser, download_parser_arg_list)
     _add_arguments(download_parser.add_mutually_exclusive_group(required=False), [verbose, quiet])
     _add_arguments(download_parser.add_mutually_exclusive_group(required=False), [coverage_percent, coverage_num])
@@ -342,6 +349,9 @@ def validate_args(args):
 
     if hasattr(args, "minutes") and args.minutes:
         _validate_minutes(args.minutes)
+
+    if hasattr(args, "burst_ids") and args.burst_ids:
+        _validate_burst_list(args)
 
 
 def _validate_bounds(bbox):
@@ -389,3 +399,15 @@ def _validate_native_id(native_id: str):
     # TODO: Should --native-id='*' be allowed
 
     return native_id
+
+
+def _validate_burst_list(args):
+    burst_pattern = re.compile(r'T\d{3}[-_]\d{6}[-_]IW[123]', flags=re.I)
+
+    if not args.native_id:
+        raise argparse.ArgumentTypeError('Burst filtering must be used with --native-id')
+
+    for burst in args.burst_ids:
+        if not burst_pattern.fullmatch(burst):
+            raise argparse.ArgumentTypeError(f'Value given in --burst-ids list "{burst}" does not match expected '
+                                             f'pattern {burst_pattern.pattern} (case insensitive)')

--- a/data_subscriber/slc/slc_query.py
+++ b/data_subscriber/slc/slc_query.py
@@ -25,6 +25,9 @@ class SlcCmrQuery(BaseQuery):
         if does_bbox_intersect_north_america(granule["bounding_box"]):
             additional_fields["intersects_north_america"] = True
 
+        if args.burst_ids:
+            additional_fields["burst_ids"] = args.burst_ids
+
         return additional_fields
 
     def update_url_index(

--- a/data_subscriber/slc/slc_query.py
+++ b/data_subscriber/slc/slc_query.py
@@ -27,6 +27,8 @@ class SlcCmrQuery(BaseQuery):
 
         if args.burst_ids:
             additional_fields["burst_ids"] = args.burst_ids
+        else:
+            additional_fields["burst_ids"] = None
 
         return additional_fields
 

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -16,7 +16,6 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
-    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
     tec_file: __CHIMERA_VAL__
@@ -29,6 +28,7 @@ runconfig:
     product_specification_version: __CHIMERA_VAL__
   processing:
     polarization: co-pol
+    burst_list: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1.yaml
@@ -16,6 +16,7 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
+    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
     tec_file: __CHIMERA_VAL__
@@ -39,6 +40,7 @@ preconditions:
   - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
   - get_slc_s1_tec_file
   - get_slc_s1_burst_database
+  - get_burst_list
   - get_cnm_version
   - set_daac_product_type
 

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
@@ -16,6 +16,7 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
+    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
     tec_file: __CHIMERA_VAL__
@@ -41,6 +42,7 @@ preconditions:
   - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
   - get_slc_s1_tec_file
   - get_slc_s1_burst_database
+  - get_burst_list
   - get_cnm_version
   - set_daac_product_type
 

--- a/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_CSLC_S1_STATIC.yaml
@@ -16,7 +16,6 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
-    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
     tec_file: __CHIMERA_VAL__
@@ -30,6 +29,7 @@ runconfig:
     product_specification_version: __CHIMERA_VAL__
   processing:
     polarization: co-pol
+    burst_list: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
@@ -16,7 +16,6 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
-    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
   static_ancillary_file_group:
@@ -32,6 +31,7 @@ runconfig:
     estimated_geometric_accuracy_bias_y: __CHIMERA_VAL__
     estimated_geometric_accuracy_stddev_x: __CHIMERA_VAL__
     estimated_geometric_accuracy_stddev_y: __CHIMERA_VAL__
+    burst_list: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1.yaml
@@ -16,6 +16,7 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
+    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
   static_ancillary_file_group:
@@ -43,6 +44,7 @@ preconditions:
   - get_slc_s1_orbit_file
   - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
   - get_slc_s1_burst_database
+  - get_burst_list
   - get_cnm_version
   - set_daac_product_type
 

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
@@ -16,7 +16,6 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
-    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
   static_ancillary_file_group:
@@ -33,6 +32,7 @@ runconfig:
     estimated_geometric_accuracy_bias_y: __CHIMERA_VAL__
     estimated_geometric_accuracy_stddev_x: __CHIMERA_VAL__
     estimated_geometric_accuracy_stddev_y: __CHIMERA_VAL__
+    burst_list: __CHIMERA_VAL__
   cnm_version: "__CHIMERA_VAL__"
 
 # This lists all the precondition evaluation steps that this PGE needs to run prior to running the PGE.

--- a/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
+++ b/opera_chimera/configs/pge_configs/PGE_L2_RTC_S1_STATIC.yaml
@@ -16,6 +16,7 @@ runconfig:
   input_file_group:
     safe_file_path: __CHIMERA_VAL__
     orbit_file_path: __CHIMERA_VAL__
+    burst_list: __CHIMERA_VAL__
   dynamic_ancillary_file_group:
     dem_file: __CHIMERA_VAL__
   static_ancillary_file_group:
@@ -45,6 +46,7 @@ preconditions:
   - get_slc_s1_orbit_file
   - get_slc_s1_dem  # Note: this must be run after get_slc_s1_safe_file
   - get_slc_s1_burst_database
+  - get_burst_list
   - get_cnm_version
   - set_daac_product_type
 

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -2447,7 +2447,7 @@ class OperaPreConditionFunctions(PreConditionFunctions):
             normalized_burst_ids.append(burst_id.lower().replace('-', '_'))
 
         rc_params = {
-            'burst_list': normalized_burst_ids
+            'burst_list': list(set(normalized_burst_ids))
         }
 
         logger.info(f"rc_params : {rc_params}")

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -2426,6 +2426,34 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         return rc_params
 
+    def get_burst_list(self):
+        """Gets the list of bursts to process"""
+        logger.info(f"Evaluating precondition {inspect.currentframe().f_code.co_name}")
+
+        metadata = self._context["product_metadata"]["metadata"]
+        burst_pattern = re.compile(r'T\d{3}[-_]\d{6}[-_]IW[123]', flags=re.I)
+
+        burst_ids: list[str] = metadata.get('burst_ids')
+
+        if not burst_ids:
+            burst_ids = None
+
+        normalized_burst_ids = []
+
+        for burst_id in burst_ids:
+            if not burst_pattern.fullmatch(burst_id):
+                raise ValueError(f'Burst ID {burst_id} does not match pattern {burst_pattern.pattern}')
+
+            normalized_burst_ids.append(burst_id.lower().replace('-', '_'))
+
+        rc_params = {
+            'burst_list': normalized_burst_ids
+        }
+
+        logger.info(f"rc_params : {rc_params}")
+
+        return rc_params
+
     def instantiate_algorithm_parameters_template(self):
         """
         Downloads a template algorithm parameters yaml file from S3, then

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -2436,19 +2436,21 @@ class OperaPreConditionFunctions(PreConditionFunctions):
         burst_ids: list[str] = metadata.get('burst_ids')
 
         if not burst_ids:
-            burst_ids = None
+            rc_params = {
+                'burst_list': None
+            }
+        else:
+            normalized_burst_ids = []
 
-        normalized_burst_ids = []
+            for burst_id in burst_ids:
+                if not burst_pattern.fullmatch(burst_id):
+                    raise ValueError(f'Burst ID {burst_id} does not match pattern {burst_pattern.pattern}')
 
-        for burst_id in burst_ids:
-            if not burst_pattern.fullmatch(burst_id):
-                raise ValueError(f'Burst ID {burst_id} does not match pattern {burst_pattern.pattern}')
+                normalized_burst_ids.append(burst_id.lower().replace('-', '_'))
 
-            normalized_burst_ids.append(burst_id.lower().replace('-', '_'))
-
-        rc_params = {
-            'burst_list': list(set(normalized_burst_ids))
-        }
+            rc_params = {
+                'burst_list': list(set(normalized_burst_ids))
+            }
 
         logger.info(f"rc_params : {rc_params}")
 


### PR DESCRIPTION
## Purpose
This PR adds the option to only process specific bursts within a given S1 SLC input when generating RTC-S1, CSLC-S1 or the associated static layers products.

To use the filter, use the `--burst-ids` param with the DAAC data subscriber tool, giving one or more burst IDs to restrict to. Provided burst IDs are case insensitive and do not distinguish between `_` and `-` (in other words, both `t001_123456_iw1` and `T001-123456-IW1` are acceptable). No checks can be made to ensure the provided burst list is actually present within the SAFE file, and thus would proceed to the SAS to fail. This option is only available when triggering by native ID.

Example:
```bash
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -c SENTINEL-1A_SLC --job-queue=opera-job_worker-slc_data_download --chunk-size=1 --processing-mode=reprocessing -p ASF --native-id=S1A_IW_SLC__1SDV_20260420T171823_20260420T171850_064166_08137D_D6D2* --burst-ids T044-093062-IW3 T044-093061-IW3 T044-093061-IW2 T044-093063-IW1
```

## Issues
- [OPERA-2435](https://hysds-core.atlassian.net/browse/OPERA-2435)

## Testing
- [x] RTC-S1
- [x] CSLC-S1
- [x] RTC-S1-STATIC
- [x] CSLC-S1-STATIC

Results from running the above example command:

<img width="1271" height="811" alt="image" src="https://github.com/user-attachments/assets/18febcff-bead-4979-84da-55f3e0d6b432" />

