### PR TITLE
Terraform updates

### DIFF
--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -465,6 +465,18 @@ variable "queues" {
       "total_jobs_metric" = true
       "use_on_demand"     = false
     }
+    "opera-job_worker-large_job_retry" = {
+      "name"          = "opera-job_worker-large_job_retry"
+      "log_file_name" = "run_large_job_retry"
+      "instance_type" = ["m6a.8xlarge", "m7a.8xlarge", "m8a.8xlarge"]
+      "user_data"         = "launch_template_user_data.sh.tmpl"
+      "root_dev_size"     = 100
+      "data_dev_size"     = 900
+      "min_size"          = 0
+      "max_size"          = 20
+      "total_jobs_metric" = true
+      "use_on_demand"     = false
+    }
     # Split by DAAC (not by product) so ops can drain delivery to one DAAC
     # without affecting the other (e.g., scale _asf to 0 during an ASF DAAC
     # outage, keep _podaac running). Per-product granularity still

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -323,7 +323,7 @@ variable "queues" {
       "name"          = "opera-job_worker-sciflo-l3_dswx_s1"
       "log_file_name" = "run_sciflo_L3_DSWx_S1"
       "instance_type" = ["c6i.2xlarge", "c7i.2xlarge", "c8i.2xlarge", "c6i.4xlarge", "c7i.4xlarge", "c8i.4xlarge",
-      "m6i.2xlarge", "m7i.2xlarge", "m8i.2xlarge", "m6i.4xlarge", "m7i.4xlarge", "m8i.4xlarge"]
+      "m6i.2xlarge", "m7i.2xlarge", "m8i.2xlarge"]
       "user_data"         = "launch_template_user_data.sh.tmpl"
       "root_dev_size"     = 50
       "data_dev_size"     = 100


### PR DESCRIPTION
## Purpose
- Remove 64 GiB instance types from the DSWx-S1 ASG
- Add new queue for retrying jobs on very large instances

## Issues
- [OPERA-2502](https://hysds-core.atlassian.net/browse/OPERA-2502)
- [OPERA-2509](https://hysds-core.atlassian.net/browse/OPERA-2509)
## Testing
- N/A
