### PR TITLE
frame states via CMR audit

### DIFF
--- a/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
+++ b/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
@@ -758,9 +758,18 @@ async def fetch_opera_products(
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
-                    if resp.status == 429:
-                        await asyncio.sleep(0.5 * (2 ** attempt))
-                        continue
+                    if resp.status == 429 or resp.status >= 500:
+                        if attempt < 2:
+                            await asyncio.sleep(0.5 * (2 ** attempt))
+                            continue
+                        # All retries exhausted on 429/5xx - return WITHOUT caching
+                        # so we don't poison the cache with false-empty results
+                        logger = logging.getLogger(__name__)
+                        logger.warning(
+                            f"CMR returned status {resp.status} for burst "
+                            f"{burst.filename_pattern} after 3 attempts - NOT caching"
+                        )
+                        return set()
                     if resp.status != 200:
                         return set()
 
@@ -769,10 +778,16 @@ async def fetch_opera_products(
                     cache.set("cmr_opera", cache_params, product_ids)
                     return set(product_ids)
 
-            except (asyncio.TimeoutError, aiohttp.ClientError):
+            except (asyncio.TimeoutError, aiohttp.ClientError) as exc:
                 if attempt < 2:
                     await asyncio.sleep(0.5 * (2 ** attempt))
                     continue
+                # All retries exhausted - return WITHOUT caching
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    f"CMR network error for burst {burst.filename_pattern} "
+                    f"after 3 attempts: {exc} - NOT caching"
+                )
                 return set()
 
     return set()


### PR DESCRIPTION
fetch_opera_products() used to only retry HTTP 429. Any other non-200 response (504, 502, 503) was silently treated as "no products found" and the empty result was cached. When CMR/CloudFront returns 5xx under load, this poisons cmr_opera cache with false-negative entries, which later show up as spurious "missing" SLCs in reprocess batches.

Changes:
- Retry on 429 OR 5xx for 3 attempts
- After retries are exhausted on a transient failure, log a warning and return empty WITHOUT caching, so a re-run picks up the real data
- Same treatment for the network-error path (TimeoutError/ClientError)

Adds visible "NOT caching" warning lines that can be counted as a throttle indicator during long runs.

## Purpose
- Clear, easy-to-understand sentences outlining the purpose of the PR
## Proposed Changes
- [ADD] ...
- [CHANGE] ...
- [REMOVE] ...

## Issues
- Links to relevant issues
- Example: issue-XYZ
## Testing
- Provide some proof you've tested your changes 
- Example: test results available at ...
- Example: tested on operating system ...
