### PR TITLE
OPERA-2373: Fix DISP-S1 historical processing silently skipping state-0 frames

### DIFF
--- a/tools/run_disp_s1_historical_processing.py
+++ b/tools/run_disp_s1_historical_processing.py
@@ -73,7 +73,10 @@ def proc_once(eu, procs, args):
             logger.info(f"{frame_id=}, {last_frame_processed=}")
 
             # If the last_frame_processed is the same as the length of all sensing times, we'd already completed processing
-            if last_frame_processed == len(disp_burst_map[frame_id].sensing_datetimes):
+            # NOTE: frame_states keys are strings (from ES JSON) but disp_burst_map is keyed by int. Cast here so the
+            # lookup hits the real Frame instead of silently creating an empty defaultdict entry (len 0), which would
+            # make a state-0 frame compare 0 == 0 and be wrongly treated as already finished.
+            if last_frame_processed == len(disp_burst_map[int(frame_id)].sensing_datetimes):
                 finished = True
                 do_submit = False
             else:


### PR DESCRIPTION
## Summary

Fixes a bug in `tools/run_disp_s1_historical_processing.py` where DISP-S1 historical / catch-up frames seeded at **state 0** (never-before-processed frames) are silently treated as already finished and never submit any jobs. Frames with a non-zero starting state are unaffected, which masks the issue.

Unblocks [OPERA-2373](https://hysds-core.atlassian.net/browse/OPERA-2373).

## Root cause

In `proc_once()`, the per-frame completion check indexes `disp_burst_map` with the **string** `frame_id` taken from the ES `batch_proc` document's `frame_states`:

```python
for frame_id, last_frame_processed in p.frame_states.items():   # frame_id is a str, e.g. '834'
    if last_frame_processed == len(disp_burst_map[frame_id].sensing_datetimes):
```

`disp_burst_map` is a `defaultdict(_HistBursts)` keyed by **int** (`data_subscriber/cslc_utils.py`). The string key misses, and because it is a `defaultdict` it does not raise `KeyError` — it silently inserts a fresh empty `_HistBursts` whose `sensing_datetimes == []` (length 0). The comparison therefore becomes:

- **state 0:** `0 == 0` → `True` → `finished=True`, `do_submit=False` → frame is treated as complete and never processed.
- **state > 0:** e.g. `240 == 0` → `False` → the `else` branch calls `form_job_params(p, int(frame_id), ...)`, which uses the correct int key and works.

That asymmetry is why only zero-state frames break.

### Observed impact (OPS POP1, Region 3B catch-up)

4 of 21 frames in the "catchup with additional sensing time" batch proc were seeded at state 0 by the frame-state audit (no existing products): **834, 28221, 28222, 36009**. All have substantial input data in the active burst DB (263 / 264 / 200 / 203 sensing times) but submitted **zero** query jobs across 639 processing cycles, while the other 17 frames progressed normally. No bad data was produced — the frames simply never ran.

## Changes

- **Fix** `tools/run_disp_s1_historical_processing.py` — cast `frame_id` to `int` in the per-frame completion check in `proc_once()` so the lookup hits the real `disp_burst_map` entry instead of a defaulted empty `_HistBursts`. (The other `disp_burst_map[frame_id]` accesses live inside `form_job_params`, where `frame_id` is already the int argument, and are correct.)

## Test plan

- [ ] Re-run `run_disp_s1_historical_processing.py` against a batch proc containing a state-0 frame and confirm it now logs `Attempting to process frame <id> at sensing time position 0` and submits a query job (m=1 for the first k-set).
- [ ] Confirm frames with state > 0 are unchanged (resume from their persisted ES state).
- [ ] On POP1, confirm frames 834 / 28221 / 28222 / 36009 advance past 0 after a fixed restart.
