### PR TITLE
HC-633: deploy hysds user-rules trigger fix to v6.1.2 clusters via provisioning hot-patch

### DIFF
--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -112,7 +112,7 @@ variable "po_daac_endpoint_url" {
 
 ####### Release Branches #############
 variable "pge_snapshots_date" {
-  default = "20250514-3.1.6"
+  default = "20250514-3.1.7"
 }
 
 variable "pge_releases" {

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -112,7 +112,7 @@ variable "po_daac_endpoint_url" {
 
 ####### Release Branches #############
 variable "pge_snapshots_date" {
-  default = "20250514-3.1.7"
+  default = "20250514-3.1.8"
 }
 
 variable "pge_releases" {

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -686,7 +686,7 @@ resource "aws_instance" "mozart" {
       hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
       if [ "$hysds_cur" = "3.1.1" ]; then
         swap_ops_repo hysds_commons v2.1.2
-        swap_ops_repo hysds v3.1.5
+        swap_ops_repo hysds v3.1.6
       fi
 
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -654,6 +654,32 @@ resource "aws_instance" "mozart" {
       set -ex
       source ~/.bash_profile
 
+      # Hot-patch the v6.1.2 framework line: swap ~/mozart/ops/hysds and
+      # ~/mozart/ops/hysds_commons to the patched releases that remove the fixed
+      # sleeps from user rules evaluation and batch all rule queries into one
+      # msearch round trip (see the hysds v3.1.2 and hysds_commons v2.1.2 release
+      # notes). Mozart's ops trees are the cluster's source of truth -- sdscli's
+      # rsync_code() rm -rf's factotum's copies and re-rsyncs from here on every
+      # `sds -d update factotum` -- so patching here propagates the fix and every
+      # future update re-applies it instead of reverting it. All installs are
+      # editable, so the reinstall_hysds_compat below installs the swapped trees.
+      # Guarded on the exact unpatched version so this self-disables (instead of
+      # silently downgrading) once hysds_release moves past the v6.1.2 line;
+      # remove this block at that point.
+      swap_ops_repo() {
+        repo=$1; tag=$2
+        curl -fsSL --retry 5 -o /tmp/$repo-$tag.tar.gz "https://github.com/hysds/$repo/archive/refs/tags/$tag.tar.gz"
+        rm -rf ~/mozart/ops/$repo
+        mkdir -p ~/mozart/ops/$repo
+        tar xzf /tmp/$repo-$tag.tar.gz -C ~/mozart/ops/$repo --strip-components=1
+        rm -f /tmp/$repo-$tag.tar.gz
+      }
+      hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
+      if [ "$hysds_cur" = "3.1.1" ]; then
+        swap_ops_repo hysds_commons v2.1.2
+        swap_ops_repo hysds v3.1.2
+      fi
+
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth
       # that registers a finder for the package only). This hides bare .py siblings
       # of the package from sys.path -- including hysds-3.1.1/celeryconfig.py, which

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -681,7 +681,7 @@ resource "aws_instance" "mozart" {
       hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
       if [ "$hysds_cur" = "3.1.1" ]; then
         swap_ops_repo hysds_commons v2.1.2
-        swap_ops_repo hysds v3.1.3
+        swap_ops_repo hysds v3.1.4
       fi
 
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -694,7 +694,10 @@ resource "aws_instance" "mozart" {
       # so its internal install_base_es_template doesn't crash with
       # ModuleNotFoundError: No module named 'celeryconfig'.
       reinstall_hysds_compat() {
-        for pkg in hysds hysds_commons; do
+        # dependency order: hysds declares hysds_commons in install_requires and
+        # hysds_commons is not on PyPI, so it must already be installed when
+        # hysds installs -- mandatory now that swap_ops_repo uninstalls both
+        for pkg in hysds_commons hysds; do
           if [ -d ~/mozart/ops/$pkg ]; then
             (cd ~/mozart/ops/$pkg && pip install -e . --config-settings editable_mode=compat)
           fi

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -686,7 +686,7 @@ resource "aws_instance" "mozart" {
       hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
       if [ "$hysds_cur" = "3.1.1" ]; then
         swap_ops_repo hysds_commons v2.1.2
-        swap_ops_repo hysds v3.1.6
+        swap_ops_repo hysds v3.1.7
       fi
 
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -671,8 +671,13 @@ resource "aws_instance" "mozart" {
         curl -fsSL --retry 5 -o /tmp/$repo-$tag.tar.gz "https://github.com/hysds/$repo/archive/refs/tags/$tag.tar.gz"
         # uninstall while the old editable tree still exists so pip can remove
         # its dist-info; otherwise the uninstall is a no-op and a stale
-        # dist-info lingers, making pip report the old version forever
-        ~/mozart/bin/pip uninstall -y $repo 2>/dev/null || true
+        # dist-info lingers, making pip report the old version forever. The
+        # venv bundle can ship duplicate dist-info entries for one package and
+        # pip uninstall removes a single distribution per invocation, so loop
+        # (bounded) until none remain.
+        for _ in 1 2 3; do
+          ~/mozart/bin/pip uninstall -y $repo 2>/dev/null || break
+        done
         rm -rf ~/mozart/ops/$repo
         mkdir -p ~/mozart/ops/$repo
         tar xzf /tmp/$repo-$tag.tar.gz -C ~/mozart/ops/$repo --strip-components=1

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -669,6 +669,10 @@ resource "aws_instance" "mozart" {
       swap_ops_repo() {
         repo=$1; tag=$2
         curl -fsSL --retry 5 -o /tmp/$repo-$tag.tar.gz "https://github.com/hysds/$repo/archive/refs/tags/$tag.tar.gz"
+        # uninstall while the old editable tree still exists so pip can remove
+        # its dist-info; otherwise the uninstall is a no-op and a stale
+        # dist-info lingers, making pip report the old version forever
+        ~/mozart/bin/pip uninstall -y $repo 2>/dev/null || true
         rm -rf ~/mozart/ops/$repo
         mkdir -p ~/mozart/ops/$repo
         tar xzf /tmp/$repo-$tag.tar.gz -C ~/mozart/ops/$repo --strip-components=1
@@ -677,7 +681,7 @@ resource "aws_instance" "mozart" {
       hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
       if [ "$hysds_cur" = "3.1.1" ]; then
         swap_ops_repo hysds_commons v2.1.2
-        swap_ops_repo hysds v3.1.2
+        swap_ops_repo hysds v3.1.3
       fi
 
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -686,7 +686,7 @@ resource "aws_instance" "mozart" {
       hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
       if [ "$hysds_cur" = "3.1.1" ]; then
         swap_ops_repo hysds_commons v2.1.2
-        swap_ops_repo hysds v3.1.4
+        swap_ops_repo hysds v3.1.5
       fi
 
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -774,8 +774,15 @@ resource "aws_instance" "mozart" {
       if [ "$hysds_cur" = "3.1.1" ]; then
         KEY=$(awk '/^KEY_FILENAME/ {print $2}' ~/.sds/config)
         FACTOTUM_IP=$(awk '/^FACTOTUM_PVT_IP/ {print $2}' ~/.sds/config)
+        # exclude the rendered celeryconfig: it lives INSIDE the hysds ops tree
+        # and is rendered per node (mozart's points at 127.0.0.1 for its local
+        # rabbit/redis) -- copying mozart's over factotum's leaves every
+        # factotum celery worker dialing a broker that isn't there
         for repo in hysds_commons hysds; do
-          rsync -az --delete -e "ssh -i $KEY -o StrictHostKeyChecking=no" ~/mozart/ops/$repo/ hysdsops@$FACTOTUM_IP:verdi/ops/$repo/
+          rsync -az --delete \
+            --exclude=celeryconfig.py --exclude=celeryconfig.pyc --exclude=__pycache__ \
+            -e "ssh -i $KEY -o StrictHostKeyChecking=no" \
+            ~/mozart/ops/$repo/ hysdsops@$FACTOTUM_IP:verdi/ops/$repo/
         done
         ssh -i $KEY -o StrictHostKeyChecking=no hysdsops@$FACTOTUM_IP '
           ~/verdi/bin/pip uninstall -y hysds hysds_commons || true

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -686,7 +686,7 @@ resource "aws_instance" "mozart" {
       hysds_cur=$(~/mozart/bin/python -c 'import hysds; print(hysds.__version__)' 2>/dev/null || echo none)
       if [ "$hysds_cur" = "3.1.1" ]; then
         swap_ops_repo hysds_commons v2.1.2
-        swap_ops_repo hysds v3.1.7
+        swap_ops_repo hysds v3.1.8
       fi
 
       # pip 21.3+ defaults to strict editable mode (creates an __editable__.<pkg>.pth

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -756,6 +756,28 @@ resource "aws_instance" "mozart" {
         sds -d update factotum -f -c
       fi
 
+      # The config-only (-c) update path above never syncs code to factotum:
+      # sdscli update_factotum skips rsync_code + pip installs entirely with -c,
+      # so on artifactory venues factotum's verdi venv keeps running the bundled
+      # hysds. The user_rules evaluators run ONLY on factotum, so push the
+      # patched trees there and reinstall them into the verdi venv explicitly.
+      # Uses the same guard variable captured before the swap; remove together
+      # with the swap block above.
+      if [ "$hysds_cur" = "3.1.1" ]; then
+        KEY=$(awk '/^KEY_FILENAME/ {print $2}' ~/.sds/config)
+        FACTOTUM_IP=$(awk '/^FACTOTUM_PVT_IP/ {print $2}' ~/.sds/config)
+        for repo in hysds_commons hysds; do
+          rsync -az --delete -e "ssh -i $KEY -o StrictHostKeyChecking=no" ~/mozart/ops/$repo/ hysdsops@$FACTOTUM_IP:verdi/ops/$repo/
+        done
+        ssh -i $KEY -o StrictHostKeyChecking=no hysdsops@$FACTOTUM_IP '
+          ~/verdi/bin/pip uninstall -y hysds hysds_commons || true
+          cd ~/verdi/ops/hysds_commons && ~/verdi/bin/pip install --no-deps -e . --config-settings editable_mode=compat
+          cd ~/verdi/ops/hysds && ~/verdi/bin/pip install --no-deps -e . --config-settings editable_mode=compat
+          ~/verdi/bin/supervisorctl -c ~/verdi/etc/supervisord.conf restart user_rules_dataset: user_rules_job: || true
+          ~/verdi/bin/python -c "import hysds, hysds_commons; print(\"factotum patched:\", hysds.__version__, hysds_commons.__version__)"
+        '
+      fi
+
       # Install mozart ISM policy via direct REST PUT against OpenSearch instead of
       # the historical `fab -R mozart update_ilm_policy_mozart` task. NISAR pattern,
       # see nisar-pcm/cluster_provisioning/modules/common/main.tf:1888-1896.


### PR DESCRIPTION
## Summary

Provisioning hot-patch that deploys the HC-633 hysds user-rules trigger-evaluation fix to OPERA clusters running HySDS framework **v6.1.2** (hysds v3.1.1 / hysds_commons v2.1.1), ahead of the upstream framework release that will carry it. During mozart provisioning it swaps the mozart + factotum `hysds`/`hysds_commons` ops trees to the patched tagged releases (**hysds v3.1.8** + **hysds_commons v2.1.2**) and reinstalls them in compat mode, so sdscli `rsync_code` re-applies the patch on every `sds update` rather than reverting it.

## Upstream framework PRs

This change deploys two upstream HySDS PRs. **Their descriptions carry the design write-ups, before/after algorithm diagrams, and the full test artifacts + validation** — factotum verdict logs, the live msearch→per-rule fallback, the unit suites, and the DISP-S1 forward A/B:

- **hysds/hysds#219** — user-rules trigger-evaluation fix (single `msearch` round trip, refresh-visibility settled-probe, per-`doc_id` shard routing, malformed-rule fallback).
- **hysds/hysds_commons#71** — `SearchUtility.msearch()` (multi-search batching with closed-index params per header).

## Background

HC-633: the user-rules trigger evaluators raced OpenSearch refresh visibility and dropped forward DISP-S1 triggers — a complete `cycle-state-config` whose `is_complete` false→true update was not yet search-visible caused the k-cycle evaluator rule to return 0 hits ("didn't match"), so no `kcycle-state-config` and no downstream L3 was produced. The framework fix lands in hysds/hysds#219 + hysds/hysds_commons#71 (→ develop, riding into framework v6.3.3). OPERA runs v6.1.2 today and needs the fix now, so this terraform change applies the patched tagged releases to the factotum venv during provisioning.

## Changes

`cluster_provisioning/modules/common/mozart.tf`, `cluster_provisioning/dev-int/override.tf`:

- **`swap_ops_repo()`** — during mozart provisioning, swap the `hysds` and `hysds_commons` ops trees to the patched tagged releases (currently **hysds v3.1.8**, **hysds_commons v2.1.2**) before the compat reinstall. Because sdscli re-rsyncs factotum from mozart on every update, swapping at the mozart source makes the patch self-re-applying instead of being reverted.
- Swap-mechanism hardening:
  - clean stale `*.dist-info` on swap,
  - install `hysds_commons` before `hysds` (dependency order),
  - uninstall repeatedly to clear duplicate dist-infos,
  - push the patched `hysds` to the factotum verdi venv after config-only updates (a config-only `sds update` skips rsync/pip, so the swap would otherwise never reach factotum),
  - exclude the node-rendered `celeryconfig.py` from the factotum tree push (it is per-node despite living inside the code tree; pushing mozart's copy points factotum's brokers at 127.0.0.1).

## Validation

hysds v3.1.8 validated end-to-end on dev-e2e (DISP-S1 forward, frame 31241, k=15/m=3):

- **56 complete cycle-state-configs → 56 kcycle-state-configs (0 dropped)**, 55 forward L3_DISP_S1, 6 CCSLC.
- **0 evaluator crashes** (no TypeError/Traceback), 56/56 distinct complete-CSCs matched the k-cycle evaluator rule, 462 settled-probes.
- Supersedes the v3.1.6 replica-lag drops (56→53) and the v3.1.7 msearch `preference`-kwarg TypeError.

**Full test artifacts + validation evidence** — before/after diagrams, factotum verdict logs, the live msearch→per-rule fallback, the unit suites, and the forward A/B — are documented in the upstream PRs: hysds/hysds#219 and hysds/hysds_commons#71.

## Notes

- **Temporary provisioning stopgap.** Remove the `swap_ops_repo` block once OPERA moves to a framework release containing the fix (upstream HC-631).
- Depends on the published tagged releases `hysds v3.1.8` / `hysds_commons v2.1.2` (upstream PRs: hysds/hysds#219, hysds/hysds_commons#71).
- Carved from the bundled `hc633-hotpatch` branch (which the running validation clusters deploy from); this branch isolates only the hysds hot-patch concern. Base `35ec4678`; rebase onto develop at merge time.

Jira: https://hysds-core.atlassian.net/browse/HC-633
