### PR TITLE
OPERA-2518: Improved memory handling in CMR audit scripts

### DIFF
--- a/cluster_provisioning/modules/common/grq_factotum_metrics.tf
+++ b/cluster_provisioning/modules/common/grq_factotum_metrics.tf
@@ -21,6 +21,7 @@ resource "aws_instance" "metrics" {
 
               PROJECT=${var.project}
               ENVIRONMENT=${var.environment}
+              SWAP=200
 
               echo "PASS" >> /tmp/user_data_test.txt
 
@@ -314,6 +315,7 @@ resource "aws_instance" "grq" {
               #!/bin/bash
               PROJECT=${var.project}
               ENVIRONMENT=${var.environment}
+              SWAP=200
 
               echo "PASS" >> /tmp/user_data_test.txt
 
@@ -473,6 +475,7 @@ resource "aws_instance" "factotum" {
 
               PROJECT=${var.project}
               ENVIRONMENT=${var.environment}
+              SWAP=200
 
               echo "PASS" >> /tmp/user_data_test.txt
 

--- a/cluster_provisioning/modules/common/mozart.tf
+++ b/cluster_provisioning/modules/common/mozart.tf
@@ -31,6 +31,7 @@ resource "aws_instance" "mozart" {
               METRICSIP=${aws_instance.metrics.private_ip}
               PROJECT=${var.project}
               ENVIRONMENT=${var.environment}
+              SWAP=200
 
               echo "PASS" >> /tmp/user_data_test.txt
 

--- a/data_subscriber/cmr.py
+++ b/data_subscriber/cmr.py
@@ -135,7 +135,8 @@ def get_cmr_token(endpoint, settings, get_token=True):
     return cmr, token, username, password, edl
 
 async def async_query_cmr_v2(timerange: Optional[DateTimeRange] = None, provider: str = None, collection: str = None, bbox: str = None, token: str = None,
-                             cmr_hostname: Literal["cmr.earthdata.nasa.gov", "cmr.uat.earthdata.nasa.gov"] = "cmr.earthdata.nasa.gov") -> list[dict]:
+                             cmr_hostname: Literal["cmr.earthdata.nasa.gov", "cmr.uat.earthdata.nasa.gov"] = "cmr.earthdata.nasa.gov",
+                             output_dir: Optional[str] = None):
     """
     :param timerange: The start/end timestamps for the CMR query. Clients SHOULD typically set this value. Defaults to 1900-01-01:00:00:00Z to NOW
     :param provider: query param required by CMR.
@@ -143,6 +144,7 @@ async def async_query_cmr_v2(timerange: Optional[DateTimeRange] = None, provider
     :param bbox: A bounding box CMR query param as a comma-separated string. e.g. "-180,-90,180,90"
     :param token: Specifies a user (bearer) token from EDL for use as authentication
     :param cmr_hostname: The hostname of the CMR API, whether OPS or UAT.
+    :param output_dir: When set, streams results to JSONL files on disk and returns list of file paths.
     """
     logger = get_logger()
     request_url = f"https://{cmr_hostname}/search/granules.umm_json"
@@ -171,12 +173,15 @@ async def async_query_cmr_v2(timerange: Optional[DateTimeRange] = None, provider
     logger.debug("request_url=%s", request_url)
     logger.debug("params=%s", params)
 
-    product_granules = await _async_request_search_cmr_granules(collection, request_url, [params], convert_results=False)
-    search_results_count = len(product_granules)
-
-    logger.info(f"CMR Query Complete. Found %d granule(s)", search_results_count)
-
-    return product_granules
+    if output_dir:
+        paths = await _async_request_search_cmr_granules(collection, request_url, [params], convert_results=False, output_dir=output_dir)
+        logger.info(f"CMR Query Complete. Results written to {len(paths)} file(s)")
+        return paths
+    else:
+        product_granules = await _async_request_search_cmr_granules(collection, request_url, [params], convert_results=False)
+        search_results_count = len(product_granules)
+        logger.info(f"CMR Query Complete. Found %d granule(s)", search_results_count)
+        return product_granules
 
 
 async def async_query_cmr(args, token, cmr_hostname, settings, timerange = None, now: datetime = None, verbose=True) -> list:
@@ -398,9 +403,14 @@ def _get_temporal_range(start: Optional[str] = None, end: Optional[str] =None) -
     return "{},{}".format(start, end)
 
 
-async def _async_request_search_cmr_granules(collection, request_url, paramss: Iterable[dict], convert_results=True, sem: Optional[asyncio.Semaphore] = None):
-    response_jsons = await async_cmr_posts(request_url, cmr_client.paramss_to_request_body(paramss), sem=sem)
-    return response_jsons_to_cmr_granules(collection, response_jsons, convert_results=convert_results)
+async def _async_request_search_cmr_granules(collection, request_url, paramss: Iterable[dict], convert_results=True, sem: Optional[asyncio.Semaphore] = None,
+                                              output_dir: Optional[str] = None):
+    if output_dir:
+        paths = await async_cmr_posts(request_url, cmr_client.paramss_to_request_body(paramss), sem=sem, output_dir=output_dir)
+        return paths
+    else:
+        response_jsons = await async_cmr_posts(request_url, cmr_client.paramss_to_request_body(paramss), sem=sem)
+        return response_jsons_to_cmr_granules(collection, response_jsons, convert_results=convert_results)
 
 
 def response_jsons_to_cmr_granules(collection, response_jsons, convert_results=True):

--- a/report/opera_validator/opv_disp_s1.py
+++ b/report/opera_validator/opv_disp_s1.py
@@ -2,8 +2,10 @@ from collections import defaultdict
 import gc
 import logging
 import copy
+import os
 import sys
 import datetime
+import tempfile
 import pandas as pd
 import pickle
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -11,6 +13,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from report.opera_validator.opv_util import retrieve_r3_products, BURST_AND_DATE_GRANULE_PATTERN, get_granules_from_query
 from data_subscriber import es_conn_util
 from data_subscriber.cslc_utils import parse_cslc_native_id, localize_disp_frame_burst_hist, build_cslc_native_ids, sensing_time_day_index
+from tools.ops.cmr_audit.cmr_audit_utils import extract_fields
 from tools.ops.cmr_audit.cmr_iso_xml_utils import (
     fetch_cslc_input_granules_from_iso_xml,
     get_iso_xml_url_from_umm
@@ -239,37 +242,58 @@ def retrieve_disp_s1_from_cmr(smallest_date, greatest_date, output_endpoint, fra
 
     # Query CMR for each frame separately to use CMR's attribute filtering
     # This is much more efficient than querying all products and filtering in Python
-    for frame_id in frames_to_validate:
-        # Use CMR's attribute filtering to get only products for this frame
-        extra_params = {"attribute[]": f"int,FRAME_NUMBER,{frame_id}"}
-        frame_products = retrieve_r3_products(smallest_date, greatest_date, output_endpoint,
-                                              _DISP_S1_PRODUCT_TYPE, extra_params=extra_params)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        for frame_id in frames_to_validate:
+            # Use CMR's attribute filtering to get only products for this frame
+            extra_params = {"attribute[]": f"int,FRAME_NUMBER,{frame_id}"}
+            frame_output_path = os.path.join(tmpdir, f"disp_frame_{frame_id}.jsonl")
+            retrieve_r3_products(smallest_date, greatest_date, output_endpoint,
+                                 _DISP_S1_PRODUCT_TYPE, extra_params=extra_params,
+                                 output_path=frame_output_path)
 
-        logging.debug(f"Frame {frame_id}: CMR returned {len(frame_products)} products before EndingDateTime filter")
+            if return_full_umm:
+                # Need full UMM objects — read back from JSONL with filtering
+                import json as _json
+                filtered_count = 0
+                excluded_count = 0
+                with open(frame_output_path) as f:
+                    for line in f:
+                        disp_s1 = _json.loads(line)
+                        try:
+                            actual_temporal_time = datetime.datetime.strptime(
+                                disp_s1.get("umm").get("TemporalExtent")['RangeDateTime']['EndingDateTime'], "%Y-%m-%dT%H:%M:%SZ")
+                            if actual_temporal_time >= smallest_date and actual_temporal_time <= greatest_date:
+                                filtered_disp_s1.append(disp_s1)
+                                filtered_count += 1
+                            else:
+                                excluded_count += 1
+                        except (KeyError, ValueError) as e:
+                            logging.warning(f"Could not parse EndingDateTime for product: {e}")
+                            continue
+            else:
+                # Only need GranuleUR — use extract_fields for efficiency
+                records = extract_fields([frame_output_path], [
+                    "umm.GranuleUR", "umm.TemporalExtent.RangeDateTime.EndingDateTime"
+                ])
+                filtered_count = 0
+                excluded_count = 0
+                for record in records:
+                    try:
+                        actual_temporal_time = datetime.datetime.strptime(
+                            record["umm.TemporalExtent.RangeDateTime.EndingDateTime"], "%Y-%m-%dT%H:%M:%SZ")
+                        if actual_temporal_time >= smallest_date and actual_temporal_time <= greatest_date:
+                            filtered_disp_s1.append(record["umm.GranuleUR"])
+                            filtered_count += 1
+                        else:
+                            excluded_count += 1
+                            logging.debug(f"Excluded product with EndingDateTime {actual_temporal_time} "
+                                         f"(outside range {smallest_date} to {greatest_date}): "
+                                         f"{record['umm.GranuleUR'][:70]}")
+                    except (KeyError, ValueError) as e:
+                        logging.warning(f"Could not parse EndingDateTime for product: {e}")
+                        continue
 
-        filtered_count = 0
-        excluded_count = 0
-        for disp_s1 in frame_products:
-            # Secondary filter by EndingDateTime to ensure it's within the requested range
-            try:
-                actual_temporal_time = datetime.datetime.strptime(
-                    disp_s1.get("umm").get("TemporalExtent")['RangeDateTime']['EndingDateTime'], "%Y-%m-%dT%H:%M:%SZ")
-                if actual_temporal_time >= smallest_date and actual_temporal_time <= greatest_date:
-                    if return_full_umm:
-                        filtered_disp_s1.append(disp_s1)
-                    else:
-                        filtered_disp_s1.append(disp_s1.get("umm").get("GranuleUR"))
-                    filtered_count += 1
-                else:
-                    excluded_count += 1
-                    logging.debug(f"Excluded product with EndingDateTime {actual_temporal_time} "
-                                 f"(outside range {smallest_date} to {greatest_date}): "
-                                 f"{disp_s1.get('umm').get('GranuleUR', 'Unknown')[:70]}")
-            except (KeyError, ValueError) as e:
-                logging.warning(f"Could not parse EndingDateTime for product: {e}")
-                continue
-
-        logging.debug(f"Frame {frame_id}: {filtered_count} products passed filter, {excluded_count} excluded")
+            logging.debug(f"Frame {frame_id}: {filtered_count} products passed filter, {excluded_count} excluded")
 
     return filtered_disp_s1
 
@@ -622,14 +646,17 @@ def validate_disp_s1(start_date, end_date, timestamp, input_endpoint, output_end
 
     def query_single_burst_ids_only(query_info):
         """Query CMR for a single burst ID and return only granule IDs (not full UMM objects)"""
-        result = get_granules_from_query(
-            start=start_date, end=end_date, timestamp=timestamp,
-            endpoint=input_endpoint, provider="ASF", shortname=shortname,
-            extra_params=query_info['extra_params']
-        )
-        # Extract only granule IDs to reduce memory usage
-        if result:
-            return [granule.get("umm").get("GranuleUR") for granule in result]
+        with tempfile.TemporaryDirectory() as burst_tmpdir:
+            paths = get_granules_from_query(
+                start=start_date, end=end_date, timestamp=timestamp,
+                endpoint=input_endpoint, provider="ASF", shortname=shortname,
+                extra_params=query_info['extra_params'],
+                output_dir=burst_tmpdir
+            )
+            # Extract only granule IDs to reduce memory usage
+            if paths:
+                records = extract_fields(paths, ["umm.GranuleUR"])
+                return [r["umm.GranuleUR"] for r in records]
         return []
 
     # Use a set to avoid duplicate granule IDs and reduce memory

--- a/report/opera_validator/opv_util.py
+++ b/report/opera_validator/opv_util.py
@@ -69,7 +69,7 @@ def fetch_with_backoff(url, params):
             time.sleep(delay + jitter)
             print(f"Retrying page {params.get('page_num')} after delay of {delay + jitter} seconds due to error: {e}")
 
-def parallel_fetch(url, params, page_num, page_size, downloaded_batches):
+def parallel_fetch(url, params, page_num, page_size, downloaded_batches, output_path=None):
     """
     Fetches granules in parallel using the provided API.
 
@@ -79,8 +79,9 @@ def parallel_fetch(url, params, page_num, page_size, downloaded_batches):
     :page_size (int): The number of granules to fetch per page.
     :downloaded_batches (multiprocessing.Value): A shared integer value representing
         the number of batches that have been successfully downloaded.
+    :output_path: When set, writes items to JSONL file instead of returning them.
 
-    :returns (list): A list of batch granules fetched from the API.
+    :returns (list): A list of batch granules fetched from the API (empty if output_path is set).
     """
 
     params['page_num'] = page_num
@@ -90,6 +91,11 @@ def parallel_fetch(url, params, page_num, page_size, downloaded_batches):
         logging.debug(f"Fetching {url} with {params}")
         batch_granules = fetch_with_backoff(url, params)
         logging.debug(f"Fetch success: {len(batch_granules)} batch granules downloaded.")
+        if output_path:
+            import json as _json
+            with open(output_path, 'a') as f:
+                for item in batch_granules:
+                    f.write(_json.dumps(item) + '\n')
     except Exception as e:
         logging.error(f"Failed to fetch granules for page {page_num}: {e}")
         batch_granules = []
@@ -151,7 +157,7 @@ def generate_url_params(start, end, endpoint = 'OPS', provider = 'ASF', short_na
     return base_url, params
 
 def retrieve_r3_products(smallest_date, greatest_date, endpoint, shortname, extra_params=None,
-                         max_retries=3, base_delay=1.0, max_delay=30.0):
+                         max_retries=3, base_delay=1.0, max_delay=30.0, output_path=None):
     """
     Retrieve R3 products from CMR with exponential backoff retry.
 
@@ -192,6 +198,7 @@ def retrieve_r3_products(smallest_date, greatest_date, endpoint, shortname, extr
 
     all_granules = []
     total_hits = None
+    total_fetched = 0
     pbar = None
 
     while True:
@@ -250,14 +257,21 @@ def retrieve_r3_products(smallest_date, greatest_date, endpoint, shortname, extr
 
         # Append the current page's granules to the all_granules list
         batch_size = len(granules['items'])
-        all_granules.extend(granules['items'])
+        if output_path:
+            import json as _json
+            with open(output_path, 'a') as f:
+                for item in granules['items']:
+                    f.write(_json.dumps(item) + '\n')
+        else:
+            all_granules.extend(granules['items'])
+        total_fetched += batch_size
 
         # Update progress bar
         if pbar:
             pbar.update(batch_size)
 
         # Check if we've retrieved all pages
-        if len(all_granules) >= total_hits:
+        if total_fetched >= total_hits:
             break
 
         # Increment the page number for the next iteration
@@ -267,7 +281,7 @@ def retrieve_r3_products(smallest_date, greatest_date, endpoint, shortname, extr
     if pbar:
         pbar.close()
 
-    return all_granules
+    return output_path if output_path else all_granules
 
 def get_burst_id(granule_id):
     """
@@ -356,7 +370,8 @@ def get_burst_ids_from_file(filename):
     return burst_ids, burst_dates
 
 
-def get_granules_from_query(start, end, timestamp, endpoint, provider='ASF', shortname='OPERA_L2_RTC-S1_V1', extra_params=None):
+def get_granules_from_query(start, end, timestamp, endpoint, provider='ASF', shortname='OPERA_L2_RTC-S1_V1', extra_params=None,
+                            output_dir=None):
     """
     Fetches granule metadata from the CMR API within a specified temporal range using parallel requests.
 
@@ -366,8 +381,10 @@ def get_granules_from_query(start, end, timestamp, endpoint, provider='ASF', sho
     :endpoint: CMR API endpoint ('OPS' or 'UAT').
     :provider: Data provider ID (default 'ASF').
     :shortname: Short name of the product (default 'OPERA_L2_RTC-S1_V1').
-    :return: List of granule metadata.
+    :output_dir: When set, writes results to JSONL files and returns list of file paths.
+    :return: List of granule metadata, or list of file paths when output_dir is set.
     """
+    import os
 
     granules = []
 
@@ -405,8 +422,14 @@ def get_granules_from_query(start, end, timestamp, endpoint, provider='ASF', sho
             # max_workers = min(5, (total_granules + page_size - 1) // page_size)
             # futures = [executor.submit(parallel_fetch, base_url, params, page_num, page_size, downloaded_batches, total_batches) for page_num in range(1, total_batches + 1)]
             futures = []
+            paths = []
             for page_num in range(1, total_batches + 1):
-                future = executor.submit(parallel_fetch, base_url, params, page_num, page_size, downloaded_batches)
+                if output_dir:
+                    page_path = os.path.join(output_dir, f"granules_page_{page_num}.jsonl")
+                    paths.append(page_path)
+                    future = executor.submit(parallel_fetch, base_url, params, page_num, page_size, downloaded_batches, output_path=page_path)
+                else:
+                    future = executor.submit(parallel_fetch, base_url, params, page_num, page_size, downloaded_batches)
                 futures.append(future)
                 random_delay = random.uniform(0, 0.1)
                 time.sleep(random_delay)  # Stagger the submission of function calls for CMR optimization
@@ -416,9 +439,13 @@ def get_granules_from_query(start, end, timestamp, endpoint, provider='ASF', sho
                 granules_result = future.result()
                 pbar_global.update(len(granules_result))
 
-                granules.extend(granules_result)
+                if not output_dir:
+                    granules.extend(granules_result)
 
     print("\nGranule fetching complete.")
+
+    if output_dir:
+        return paths
 
     # Integrity check for total granules
     total_downloaded = sum(len(future.result()) for future in futures)

--- a/tests/unit/data_subscriber/test_cmr_query.py
+++ b/tests/unit/data_subscriber/test_cmr_query.py
@@ -1,0 +1,250 @@
+"""Tests for data_subscriber/cmr.py query functions.
+
+Establishes behavioral baselines for async_query_cmr_v2 and
+_async_request_search_cmr_granules before Phase 3 modifications.
+"""
+import asyncio
+import json
+from collections import namedtuple
+from unittest.mock import patch, AsyncMock
+
+import pytest
+
+from data_subscriber.cmr import (
+    async_query_cmr_v2,
+    _async_request_search_cmr_granules,
+    response_jsons_to_cmr_granules,
+    DateTimeRange,
+)
+
+
+# Minimal CMR response page matching the umm_json format
+def make_cmr_response(items, hits=None):
+    """Create a CMR response JSON structure."""
+    if hits is None:
+        hits = len(items)
+    return {"hits": hits, "items": items}
+
+
+SAMPLE_ITEM_RTC = {
+    "meta": {
+        "native-id": "OPERA_L2_RTC-S1_T168-359595-IW3_20250516T053145Z_20250516T155714Z_S1A_30_v1.0",
+        "revision-id": "1",
+        "revision-date": "2025-05-16T15:57:14.123Z",
+        "provider-id": "ASF"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L2_RTC-S1_T168-359595-IW3_20250516T053145Z_20250516T155714Z_S1A_30_v1.0",
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2025-05-16T05:31:45.000Z",
+                "EndingDateTime": "2025-05-16T05:31:50.000Z"
+            }
+        },
+        "DataGranule": {"ProductionDateTime": "2025-05-16T10:00:00.000Z"},
+        "ProviderDates": [{"Type": "Insert", "Date": "2025-05-16T12:00:00.000Z"}],
+        "Platforms": [{"ShortName": "Sentinel-1A"}],
+        "SpatialExtent": {
+            "HorizontalSpatialDomain": {
+                "Geometry": {
+                    "GPolygons": [{
+                        "Boundary": {
+                            "Points": [
+                                {"Latitude": 37.0, "Longitude": -122.0},
+                                {"Latitude": 37.0, "Longitude": -121.0},
+                                {"Latitude": 38.0, "Longitude": -121.0},
+                                {"Latitude": 38.0, "Longitude": -122.0}
+                            ]
+                        }
+                    }]
+                }
+            }
+        },
+        "RelatedUrls": [
+            {"URL": "https://example.com/data.tif", "Type": "GET DATA"}
+        ],
+        "AdditionalAttributes": [
+            {"Name": "POLARIZATION", "Values": ["VV", "VH"]}
+        ],
+        "InputGranules": [
+            "S1A_IW_SLC__1SDV_20250516T053145_20250516T053212_064123_07E456_ABCD.zip"
+        ]
+    }
+}
+
+SAMPLE_ITEM_SIMPLE = {
+    "meta": {
+        "native-id": "OPERA_L3_DSWx-S1_T55GCQ_20250512T193408Z_20250513T064736Z_S1A_30_v1.0",
+        "revision-id": "2",
+        "revision-date": "2025-05-13T06:47:36.456Z",
+        "provider-id": "POCLOUD"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L3_DSWx-S1_T55GCQ_20250512T193408Z_20250513T064736Z_S1A_30_v1.0",
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2025-05-12T19:34:08.000Z",
+                "EndingDateTime": "2025-05-13T06:47:36.000Z"
+            }
+        },
+        "InputGranules": [
+            "OPERA_L2_RTC-S1_T118-252625-IW2_20250512T193412Z_20250512T193437Z_S1A_30_v1.0"
+        ],
+        "RelatedUrls": [
+            {"URL": "https://example.com/dswx.tif", "Type": "GET DATA"}
+        ]
+    }
+}
+
+
+class TestAsyncQueryCmrV2:
+    """Tests for async_query_cmr_v2 baseline behavior."""
+
+    @pytest.fixture
+    def mock_async_cmr_posts(self):
+        """Mock the async_cmr_posts call to avoid network."""
+        with patch("data_subscriber.cmr.async_cmr_posts", new_callable=AsyncMock) as mock:
+            yield mock
+
+    def test_returns_raw_items_list(self, mock_async_cmr_posts):
+        """async_query_cmr_v2 returns a flat list of raw CMR items (convert_results=False)."""
+        mock_async_cmr_posts.return_value = [
+            make_cmr_response([SAMPLE_ITEM_SIMPLE, SAMPLE_ITEM_SIMPLE])
+        ]
+
+        timerange = DateTimeRange("2025-05-12T00:00:00Z", "2025-05-13T00:00:00Z")
+        result = asyncio.run(async_query_cmr_v2(
+            timerange=timerange,
+            provider="POCLOUD",
+            collection="OPERA_L3_DSWX-S1_V1"
+        ))
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        # Items should be raw CMR items (not converted)
+        assert result[0]["meta"]["native-id"] == SAMPLE_ITEM_SIMPLE["meta"]["native-id"]
+
+    def test_passes_correct_params_to_cmr_posts(self, mock_async_cmr_posts):
+        """Verify the request parameters are correctly constructed."""
+        mock_async_cmr_posts.return_value = [make_cmr_response([])]
+
+        timerange = DateTimeRange("2025-05-12T00:00:00Z", "2025-05-13T00:00:00Z")
+        asyncio.run(async_query_cmr_v2(
+            timerange=timerange,
+            provider="ASF",
+            collection="OPERA_L2_RTC-S1_V1",
+            bbox="-180,-60,180,90"
+        ))
+
+        # Verify async_cmr_posts was called
+        mock_async_cmr_posts.assert_called_once()
+        call_args = mock_async_cmr_posts.call_args
+        # First positional arg is the URL
+        assert "cmr.earthdata.nasa.gov/search/granules.umm_json" in call_args[0][0]
+
+    def test_returns_empty_list_when_no_results(self, mock_async_cmr_posts):
+        """Empty CMR response should return empty list."""
+        mock_async_cmr_posts.return_value = [make_cmr_response([])]
+
+        timerange = DateTimeRange("2025-05-12T00:00:00Z", "2025-05-13T00:00:00Z")
+        result = asyncio.run(async_query_cmr_v2(
+            timerange=timerange,
+            provider="ASF",
+            collection="OPERA_L2_RTC-S1_V1"
+        ))
+
+        assert result == []
+
+    def test_no_timerange_omits_temporal_param(self, mock_async_cmr_posts):
+        """When timerange is None, temporal param should not be included."""
+        mock_async_cmr_posts.return_value = [make_cmr_response([])]
+
+        asyncio.run(async_query_cmr_v2(
+            timerange=None,
+            provider="ASF",
+            collection="OPERA_L2_RTC-S1_V1"
+        ))
+
+        mock_async_cmr_posts.assert_called_once()
+        # The request body should not contain "temporal"
+        request_body = mock_async_cmr_posts.call_args[0][1][0]  # second positional arg, first item
+        assert "temporal" not in request_body
+
+
+class TestAsyncRequestSearchCmrGranules:
+    """Tests for _async_request_search_cmr_granules baseline behavior."""
+
+    @pytest.fixture
+    def mock_async_cmr_posts(self):
+        with patch("data_subscriber.cmr.async_cmr_posts", new_callable=AsyncMock) as mock:
+            yield mock
+
+    def test_returns_raw_items_when_convert_false(self, mock_async_cmr_posts):
+        """With convert_results=False, returns flat list of raw items."""
+        mock_async_cmr_posts.return_value = [
+            make_cmr_response([SAMPLE_ITEM_SIMPLE])
+        ]
+
+        result = asyncio.run(_async_request_search_cmr_granules(
+            "OPERA_L3_DSWX-S1_V1",
+            "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+            [{"provider": "POCLOUD", "ShortName[]": ["OPERA_L3_DSWX-S1_V1"]}],
+            convert_results=False
+        ))
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["meta"]["native-id"] == SAMPLE_ITEM_SIMPLE["meta"]["native-id"]
+
+    def test_passes_params_as_request_bodies(self, mock_async_cmr_posts):
+        """Params should be converted to request bodies via cmr_client.paramss_to_request_body."""
+        mock_async_cmr_posts.return_value = [make_cmr_response([])]
+
+        params = {"provider": "ASF", "ShortName[]": ["OPERA_L2_RTC-S1_V1"]}
+        asyncio.run(_async_request_search_cmr_granules(
+            "OPERA_L2_RTC-S1_V1",
+            "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+            [params],
+            convert_results=False
+        ))
+
+        mock_async_cmr_posts.assert_called_once()
+        call_args = mock_async_cmr_posts.call_args
+        # Second positional arg should be the request bodies list
+        request_bodies = call_args[0][1]
+        assert isinstance(request_bodies, list)
+        assert len(request_bodies) == 1
+        assert "provider" in request_bodies[0]
+
+
+class TestResponseJsonsToCmrGranules:
+    """Tests for response_jsons_to_cmr_granules conversion function."""
+
+    def test_convert_false_returns_flat_items(self):
+        """With convert_results=False, returns flat list of items from all pages."""
+        response_jsons = [
+            make_cmr_response([SAMPLE_ITEM_SIMPLE]),
+            make_cmr_response([SAMPLE_ITEM_SIMPLE])
+        ]
+
+        result = response_jsons_to_cmr_granules("OPERA_L3_DSWX-S1_V1", response_jsons, convert_results=False)
+
+        assert len(result) == 2
+        assert all(item["meta"]["native-id"] == SAMPLE_ITEM_SIMPLE["meta"]["native-id"] for item in result)
+
+    def test_empty_response_returns_empty_list(self):
+        """Empty response pages should return empty list."""
+        response_jsons = [make_cmr_response([])]
+
+        result = response_jsons_to_cmr_granules("OPERA_L3_DSWX-S1_V1", response_jsons, convert_results=False)
+
+        assert result == []
+
+    def test_multiple_pages_flattened(self):
+        """Items from multiple response pages should be flattened into single list."""
+        page1 = make_cmr_response([SAMPLE_ITEM_SIMPLE])
+        page2 = make_cmr_response([SAMPLE_ITEM_SIMPLE])
+
+        result = response_jsons_to_cmr_granules("OPERA_L3_DSWX-S1_V1", [page1, page2], convert_results=False)
+
+        assert len(result) == 2

--- a/tests/unit/data_subscriber/test_cmr_query.py
+++ b/tests/unit/data_subscriber/test_cmr_query.py
@@ -1,11 +1,10 @@
 """Tests for data_subscriber/cmr.py query functions.
 
 Establishes behavioral baselines for async_query_cmr_v2 and
-_async_request_search_cmr_granules before Phase 3 modifications.
+_async_request_search_cmr_granules, and validates the output_dir streaming path.
 """
 import asyncio
-import json
-from collections import namedtuple
+import tempfile
 from unittest.mock import patch, AsyncMock
 
 import pytest
@@ -248,3 +247,117 @@ class TestResponseJsonsToCmrGranules:
         result = response_jsons_to_cmr_granules("OPERA_L3_DSWX-S1_V1", [page1, page2], convert_results=False)
 
         assert len(result) == 2
+
+
+class TestAsyncQueryCmrV2OutputDir:
+    """Tests for async_query_cmr_v2 with output_dir."""
+
+    @pytest.fixture
+    def mock_async_cmr_posts(self):
+        with patch("data_subscriber.cmr.async_cmr_posts", new_callable=AsyncMock) as mock:
+            yield mock
+
+    def test_output_dir_passes_to_async_cmr_posts(self, mock_async_cmr_posts):
+        """When output_dir is set, it should be passed through to async_cmr_posts."""
+        mock_async_cmr_posts.return_value = ["/tmp/fake/cmr_batch_0.jsonl"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            timerange = DateTimeRange("2025-05-12T00:00:00Z", "2025-05-13T00:00:00Z")
+            result = asyncio.run(async_query_cmr_v2(
+                timerange=timerange,
+                provider="POCLOUD",
+                collection="OPERA_L3_DSWX-S1_V1",
+                output_dir=tmpdir
+            ))
+
+            # Should pass output_dir as kwarg
+            call_kwargs = mock_async_cmr_posts.call_args[1]
+            assert call_kwargs["output_dir"] == tmpdir
+
+    def test_output_dir_returns_paths(self, mock_async_cmr_posts):
+        """When output_dir is set, should return list of file paths."""
+        expected_paths = ["/tmp/fake/cmr_batch_0.jsonl", "/tmp/fake/cmr_batch_1.jsonl"]
+        mock_async_cmr_posts.return_value = expected_paths
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            timerange = DateTimeRange("2025-05-12T00:00:00Z", "2025-05-13T00:00:00Z")
+            result = asyncio.run(async_query_cmr_v2(
+                timerange=timerange,
+                provider="ASF",
+                collection="OPERA_L2_RTC-S1_V1",
+                output_dir=tmpdir
+            ))
+
+            assert result == expected_paths
+
+    def test_without_output_dir_still_returns_items(self, mock_async_cmr_posts):
+        """Without output_dir, behavior should be unchanged (returns items list)."""
+        mock_async_cmr_posts.return_value = [
+            make_cmr_response([SAMPLE_ITEM_SIMPLE])
+        ]
+
+        timerange = DateTimeRange("2025-05-12T00:00:00Z", "2025-05-13T00:00:00Z")
+        result = asyncio.run(async_query_cmr_v2(
+            timerange=timerange,
+            provider="POCLOUD",
+            collection="OPERA_L3_DSWX-S1_V1"
+        ))
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["meta"]["native-id"] == SAMPLE_ITEM_SIMPLE["meta"]["native-id"]
+
+
+class TestAsyncRequestSearchCmrGranulesOutputDir:
+    """Tests for _async_request_search_cmr_granules with output_dir."""
+
+    @pytest.fixture
+    def mock_async_cmr_posts(self):
+        with patch("data_subscriber.cmr.async_cmr_posts", new_callable=AsyncMock) as mock:
+            yield mock
+
+    def test_output_dir_passes_to_async_cmr_posts(self, mock_async_cmr_posts):
+        """When output_dir is set, it should be forwarded to async_cmr_posts."""
+        mock_async_cmr_posts.return_value = ["/tmp/fake/cmr_batch_0.jsonl"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = asyncio.run(_async_request_search_cmr_granules(
+                "OPERA_L3_DSWX-S1_V1",
+                "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+                [{"provider": "POCLOUD", "ShortName[]": ["OPERA_L3_DSWX-S1_V1"]}],
+                convert_results=False,
+                output_dir=tmpdir
+            ))
+
+            call_kwargs = mock_async_cmr_posts.call_args[1]
+            assert call_kwargs["output_dir"] == tmpdir
+
+    def test_output_dir_returns_paths_directly(self, mock_async_cmr_posts):
+        """When output_dir is set, returns paths from async_cmr_posts without conversion."""
+        expected_paths = ["/tmp/fake/cmr_batch_0.jsonl"]
+        mock_async_cmr_posts.return_value = expected_paths
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = asyncio.run(_async_request_search_cmr_granules(
+                "OPERA_L3_DSWX-S1_V1",
+                "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+                [{"provider": "POCLOUD", "ShortName[]": ["OPERA_L3_DSWX-S1_V1"]}],
+                output_dir=tmpdir
+            ))
+
+            assert result == expected_paths
+
+    def test_output_dir_skips_response_conversion(self, mock_async_cmr_posts):
+        """When output_dir is set, response_jsons_to_cmr_granules should NOT be called."""
+        mock_async_cmr_posts.return_value = ["/tmp/fake/cmr_batch_0.jsonl"]
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("data_subscriber.cmr.response_jsons_to_cmr_granules") as mock_convert:
+                result = asyncio.run(_async_request_search_cmr_granules(
+                    "OPERA_L3_DSWX-S1_V1",
+                    "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+                    [{"provider": "POCLOUD", "ShortName[]": ["OPERA_L3_DSWX-S1_V1"]}],
+                    output_dir=tmpdir
+                ))
+
+                mock_convert.assert_not_called()

--- a/tests/unit/report/opera_validator/test_opv_util.py
+++ b/tests/unit/report/opera_validator/test_opv_util.py
@@ -1,0 +1,270 @@
+"""Tests for report/opera_validator/opv_util.py query functions.
+
+Baseline + output_path/output_dir tests for retrieve_r3_products and get_granules_from_query.
+"""
+import json
+import tempfile
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from report.opera_validator.opv_util import retrieve_r3_products, parallel_fetch
+
+
+# Sample CMR response matching the umm_json format returned by these functions
+SAMPLE_ITEM = {
+    "meta": {
+        "native-id": "OPERA_L3_DISP-S1_IW_F01234_VV_20250101_20250113_v1.0_20250114T000000Z",
+        "revision-id": "1",
+        "revision-date": "2025-01-14T00:00:00.000Z"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L3_DISP-S1_IW_F01234_VV_20250101_20250113_v1.0_20250114T000000Z",
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2025-01-01T00:00:00.000Z",
+                "EndingDateTime": "2025-01-13T23:59:59.000Z"
+            }
+        },
+        "AdditionalAttributes": [
+            {"Name": "FRAME_NUMBER", "Values": ["1234"]}
+        ],
+        "RelatedUrls": [
+            {"URL": "https://example.com/disp.nc", "Type": "GET DATA"}
+        ]
+    }
+}
+
+
+def make_cmr_page_response(items, hits=None):
+    """Create a CMR response matching the JSON structure from requests.get().json()."""
+    if hits is None:
+        hits = len(items)
+    return {"hits": hits, "items": items}
+
+
+class TestRetrieveR3Products:
+    """Baseline tests for retrieve_r3_products."""
+
+    @pytest.fixture
+    def mock_requests_get(self):
+        with patch("report.opera_validator.opv_util.requests.get") as mock:
+            yield mock
+
+    def test_returns_all_items_single_page(self, mock_requests_get):
+        """Single page response returns all items."""
+        response_mock = MagicMock()
+        response_mock.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM, SAMPLE_ITEM], hits=2
+        )
+        response_mock.raise_for_status = MagicMock()
+        mock_requests_get.return_value = response_mock
+
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 14, tzinfo=timezone.utc)
+
+        result = retrieve_r3_products(start, end, "OPS", "OPERA_L3_DISP-S1_V1")
+
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["meta"]["native-id"] == SAMPLE_ITEM["meta"]["native-id"]
+
+    def test_returns_empty_list_when_no_hits(self, mock_requests_get):
+        """Empty response returns empty list."""
+        response_mock = MagicMock()
+        response_mock.json.return_value = make_cmr_page_response([], hits=0)
+        response_mock.raise_for_status = MagicMock()
+        mock_requests_get.return_value = response_mock
+
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 2, tzinfo=timezone.utc)
+
+        result = retrieve_r3_products(start, end, "OPS", "OPERA_L3_DISP-S1_V1")
+
+        assert result == []
+
+    def test_paginates_across_multiple_pages(self, mock_requests_get):
+        """Should paginate when hits > page_size items."""
+        page1_response = MagicMock()
+        page1_response.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM] * 1000, hits=1500
+        )
+        page1_response.raise_for_status = MagicMock()
+
+        page2_response = MagicMock()
+        page2_response.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM] * 500, hits=1500
+        )
+        page2_response.raise_for_status = MagicMock()
+
+        mock_requests_get.side_effect = [page1_response, page2_response]
+
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 14, tzinfo=timezone.utc)
+
+        result = retrieve_r3_products(start, end, "OPS", "OPERA_L3_DISP-S1_V1")
+
+        assert len(result) == 1500
+        assert mock_requests_get.call_count == 2
+
+
+class TestParallelFetch:
+    """Baseline tests for the parallel_fetch helper used by get_granules_from_query."""
+
+    @pytest.fixture
+    def mock_fetch_with_backoff(self):
+        with patch("report.opera_validator.opv_util.fetch_with_backoff") as mock:
+            yield mock
+
+    def test_returns_batch_granules(self, mock_fetch_with_backoff):
+        """Should return the list of granules from fetch_with_backoff."""
+        import multiprocessing
+        mock_fetch_with_backoff.return_value = [SAMPLE_ITEM, SAMPLE_ITEM]
+        downloaded_batches = multiprocessing.Value('i', 0)
+
+        result = parallel_fetch(
+            "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+            {"provider": "ASF", "ShortName[]": "OPERA_L2_RTC-S1_V1"},
+            page_num=1,
+            page_size=1000,
+            downloaded_batches=downloaded_batches
+        )
+
+        assert len(result) == 2
+        assert downloaded_batches.value == 1
+
+    def test_returns_empty_on_failure(self, mock_fetch_with_backoff):
+        """Should return empty list on fetch failure."""
+        import multiprocessing
+        mock_fetch_with_backoff.side_effect = Exception("Network error")
+        downloaded_batches = multiprocessing.Value('i', 0)
+
+        result = parallel_fetch(
+            "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+            {"provider": "ASF", "ShortName[]": "OPERA_L2_RTC-S1_V1"},
+            page_num=1,
+            page_size=1000,
+            downloaded_batches=downloaded_batches
+        )
+
+        assert result == []
+        assert downloaded_batches.value == 1
+
+
+class TestRetrieveR3ProductsOutputPath:
+    """Tests for retrieve_r3_products with output_path (Phase 4 streaming)."""
+
+    @pytest.fixture
+    def mock_requests_get(self):
+        with patch("report.opera_validator.opv_util.requests.get") as mock:
+            yield mock
+
+    def test_output_path_writes_jsonl(self, mock_requests_get):
+        """When output_path is set, items should be written to JSONL file."""
+        response_mock = MagicMock()
+        response_mock.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM, SAMPLE_ITEM], hits=2
+        )
+        response_mock.raise_for_status = MagicMock()
+        mock_requests_get.return_value = response_mock
+
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 14, tzinfo=timezone.utc)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/results.jsonl"
+            result = retrieve_r3_products(start, end, "OPS", "OPERA_L3_DISP-S1_V1",
+                                          output_path=output_path)
+
+            # Should return the output_path
+            assert result == output_path
+
+            # File should contain JSONL records
+            with open(output_path) as f:
+                lines = f.readlines()
+            assert len(lines) == 2
+            record = json.loads(lines[0])
+            assert record["meta"]["native-id"] == SAMPLE_ITEM["meta"]["native-id"]
+
+    def test_output_path_paginates_to_file(self, mock_requests_get):
+        """Multi-page responses should all be appended to the same JSONL file."""
+        page1_response = MagicMock()
+        page1_response.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM] * 1000, hits=1500
+        )
+        page1_response.raise_for_status = MagicMock()
+
+        page2_response = MagicMock()
+        page2_response.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM] * 500, hits=1500
+        )
+        page2_response.raise_for_status = MagicMock()
+
+        mock_requests_get.side_effect = [page1_response, page2_response]
+
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 14, tzinfo=timezone.utc)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/results.jsonl"
+            result = retrieve_r3_products(start, end, "OPS", "OPERA_L3_DISP-S1_V1",
+                                          output_path=output_path)
+
+            assert result == output_path
+            with open(output_path) as f:
+                lines = f.readlines()
+            assert len(lines) == 1500
+
+    def test_without_output_path_returns_list(self, mock_requests_get):
+        """Without output_path, should return list as before."""
+        response_mock = MagicMock()
+        response_mock.json.return_value = make_cmr_page_response(
+            [SAMPLE_ITEM], hits=1
+        )
+        response_mock.raise_for_status = MagicMock()
+        mock_requests_get.return_value = response_mock
+
+        start = datetime(2025, 1, 1, tzinfo=timezone.utc)
+        end = datetime(2025, 1, 14, tzinfo=timezone.utc)
+
+        result = retrieve_r3_products(start, end, "OPS", "OPERA_L3_DISP-S1_V1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+
+
+class TestParallelFetchOutputPath:
+    """Tests for parallel_fetch with output_path (Phase 4 streaming)."""
+
+    @pytest.fixture
+    def mock_fetch_with_backoff(self):
+        with patch("report.opera_validator.opv_util.fetch_with_backoff") as mock:
+            yield mock
+
+    def test_output_path_writes_jsonl(self, mock_fetch_with_backoff):
+        """When output_path is set, items should be written to JSONL file."""
+        import multiprocessing
+        mock_fetch_with_backoff.return_value = [SAMPLE_ITEM, SAMPLE_ITEM]
+        downloaded_batches = multiprocessing.Value('i', 0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = f"{tmpdir}/page_1.jsonl"
+            result = parallel_fetch(
+                "https://cmr.earthdata.nasa.gov/search/granules.umm_json",
+                {"provider": "ASF", "ShortName[]": "OPERA_L2_RTC-S1_V1"},
+                page_num=1,
+                page_size=1000,
+                downloaded_batches=downloaded_batches,
+                output_path=output_path
+            )
+
+            # Still returns the batch granules (for progress bar counting)
+            assert len(result) == 2
+
+            # File should contain JSONL records
+            with open(output_path) as f:
+                lines = f.readlines()
+            assert len(lines) == 2
+            record = json.loads(lines[0])
+            assert record["meta"]["native-id"] == SAMPLE_ITEM["meta"]["native-id"]

--- a/tests/unit/test_dist_s1_input_tool.py
+++ b/tests/unit/test_dist_s1_input_tool.py
@@ -18,12 +18,8 @@ Test markers:
 - @pytest.mark.cmr: CMR integration tests - test lookback logic with real CMR data (requires network)
   To run only unit tests: pytest tests/unit/test_dist_s1.py -m "not cmr"
   To run only CMR integration tests: pytest tests/unit/test_dist_s1.py -m cmr
-
-Note: These tests do not exercise the full DIST-S1 pipeline, only the standalone lookback window
-selection logic defined within the test along with CMR querying.
 """
 
-from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import List, Optional, Tuple
 
@@ -31,71 +27,19 @@ import dateutil.parser
 import pytest
 
 from data_subscriber.cmr import DateTimeRange, async_query_cmr_v2
-
-
-@dataclass
-class RtcGranule:
-    """Represents an RTC granule file with its acquisition time and polarization."""
-
-    granule_id: str
-    acquisition_time: datetime
-    polarization: Optional[list] = None  # e.g., ["VV", "VH"] or ["HH", "HV"]
-
-    def __repr__(self) -> str:
-        pol_str = f", {self.polarization}" if self.polarization else ""
-        return f"RtcGranule({self.granule_id}, {self.acquisition_time.isoformat()}{pol_str})"
-
-    def is_dual_pol(self) -> bool:
-        """Check if this granule has dual polarization."""
-        if not self.polarization or len(self.polarization) != 2:
-            return False
-        pol_set = set(self.polarization)
-        return pol_set == {"HH", "HV"} or pol_set == {"VV", "VH"}
-
-
-@dataclass
-class LookbackWindow:
-    window_start: datetime
-    window_center: datetime
-    window_end: datetime
-
-
-# Type alias for granule lists
-GranuleList = List[RtcGranule]
+from tools.dist_s1_input_tool import (
+    GranuleList,
+    RtcGranule,
+    calculate_lookback_window,
+    extract_burst_and_subswath_from_granule_id,
+    select_dist_s1_input_files,
+    select_files_in_window,
+)
 
 
 # ============================================================================
 # Test Helper Functions
 # ============================================================================
-
-
-def extract_burst_and_subswath_from_granule_id(granule_id: str) -> Tuple[Optional[str], Optional[str]]:
-    """
-    Extract burst ID and subswath from an RTC granule ID.
-
-    Args:
-        granule_id: RTC granule ID (e.g., "OPERA_L2_RTC-S1_T168-359429-IW2_...")
-
-    Returns:
-        Tuple of (burst_id, subswath) or (None, None) if parsing fails
-
-    Example:
-        >>> extract_burst_and_subswath_from_granule_id("OPERA_L2_RTC-S1_T168-359429-IW2_20240925T120000Z_...")
-        ('359429', 'IW2')
-    """
-    import re
-
-    # Pattern: OPERA_L2_RTC-S1_{tile}-{burst}-{subswath}_{rest}
-    # Example: OPERA_L2_RTC-S1_T168-359429-IW2_20240925T120000Z_...
-    pattern = r"OPERA_L2_RTC-S1_T?\w+-(\d+)-(IW[123])_"
-
-    match = re.search(pattern, granule_id)
-    if match:
-        burst_id = match.group(1)
-        subswath = match.group(2)
-        return burst_id, subswath
-
-    return None, None
 
 
 def generate_rtc_granule_id(
@@ -121,149 +65,6 @@ def generate_rtc_granule_id(
 
     return f"OPERA_L2_RTC-S1_{tile_id}-{burst_id}-{subswath}_" f"{acq_str}_{prod_str}_{satellite}_30_v1.0"
 
-
-# ============================================================================
-# Helper Functions for Lookback Window Logic
-# ============================================================================
-
-
-def deduplicate_by_acquisition_time(granules: GranuleList) -> GranuleList:
-    """
-    Keep only the latest processing version for each acquisition time.
-
-    When multiple products exist at the same acquisition time, this function
-    keeps only the one with the latest granule_id (proxy for processing time).
-
-    Args:
-        granules: List of RtcGranule objects
-
-    Returns:
-        Deduplicated list with one granule per unique acquisition time
-    """
-    from collections import defaultdict
-
-    by_acq_time = defaultdict(list)
-    for granule in granules:
-        by_acq_time[granule.acquisition_time].append(granule)
-
-    # For each acquisition time, keep the one with latest granule_id (proxy for processing time)
-    deduplicated = []
-    for acq_time, grp in by_acq_time.items():
-        # Sort by granule_id (later processing times have later IDs typically)
-        latest = sorted(grp, key=lambda g: g.granule_id)[-1]
-        deduplicated.append(latest)
-
-        # Log if we deduplicated anything
-        if len(grp) > 1:
-            print(
-                f"Deduplicated {len(grp)} granules at acquisition time {acq_time.isoformat()}, kept: {latest.granule_id}"
-            )
-
-    # Return sorted by acquisition time for consistent ordering
-    return sorted(deduplicated, key=lambda g: g.acquisition_time)
-
-
-def calculate_lookback_window(t0: datetime, years_back: int, window_size_days: int) -> LookbackWindow:
-    """
-    Calculate a backward-looking lookback window ending at t0 - years_back years.
-
-    Args:
-        t0: Reference time
-        years_back: Number of years to look back (1, 2, or 3)
-        window_size_days: Size of the lookback window in days (e.g., 60 means the previous 60 days)
-
-    Returns:
-        LookbackWindow with window_start, window_center, window_end where:
-        - window_end: t0 - years_back years (the target date)
-        - window_start: window_end - window_size_days (looking backward)
-        - window_center: midpoint of the window (for reference)
-
-    Example:
-        For t0=2025-09-25, years_back=1, window_size_days=60:
-        - window_end = 2024-09-25 (target date)
-        - window_start = 2024-07-27 (60 days before target)
-        - Files closest to 2024-09-25 are selected
-    """
-    # Calculate the target date (end of the window)
-    days_back = years_back * 365
-    window_end = t0 - timedelta(days=days_back)
-
-    # Look backward from the target date
-    window_start = window_end - timedelta(days=window_size_days)
-
-    # Calculate midpoint for reference
-    window_center = window_start + timedelta(days=window_size_days // 2)
-
-    return LookbackWindow(window_start, window_center, window_end)
-
-
-def select_files_in_window(
-    available_files: GranuleList, lookback_window: LookbackWindow, max_files: int
-) -> GranuleList:
-    """
-    Select files within a window, choosing those closest to the window end.
-
-    Args:
-        available_files: GranuleList of available files
-        lookback_window: LookbackWindow object
-        max_files: Maximum number of files to select
-
-    Returns:
-        GranuleList of selected files, sorted by proximity to window end (closest first)
-    """
-    # Filter files within the window
-    files_in_window = [
-        file
-        for file in available_files
-        if lookback_window.window_start <= file.acquisition_time <= lookback_window.window_end
-    ]
-
-    # Deduplicate by acquisition time (keep latest processing version)
-    files_in_window = deduplicate_by_acquisition_time(files_in_window)
-
-    # Sort by distance from window end (target date), closest first
-    files_in_window.sort(key=lambda f: abs((f.acquisition_time - lookback_window.window_end).total_seconds()))
-
-    # Return up to max_files
-    return files_in_window[:max_files]
-
-
-def select_dist_s1_input_files(
-    t0: datetime, available_files: GranuleList, window_configs: List[Tuple[int, int, int]]
-) -> Tuple[GranuleList, GranuleList, GranuleList]:
-    """
-    Select input files for DIST-S1 algorithm across three lookback windows.
-
-    Args:
-        t0: Reference time
-        available_files: GranuleList of available files
-        window_configs: List of (years_back, window_size_days, max_files) tuples
-                       for w1, w2, w3 respectively
-
-    Returns:
-        Tuple of (w1_files, w2_files, w3_files) as GranuleLists
-
-    Raises:
-        ValueError: If no files are found in any window
-    """
-    results = []
-
-    for years_back, window_size_days, max_files in window_configs:
-        lookback_window = calculate_lookback_window(t0, years_back, window_size_days)
-
-        selected_files = select_files_in_window(available_files, lookback_window, max_files)
-
-        if len(selected_files) == 0:
-            # Alert: no files found in this window
-            print(
-                f"WARNING: No files found in window w{years_back} "
-                f"(target date: {lookback_window.window_end.isoformat()}, "
-                f"range: {lookback_window.window_start.isoformat()} to {lookback_window.window_end.isoformat()})"
-            )
-
-        results.append(selected_files)
-
-    return tuple(results)
 
 
 def select_dist_s1_baseline_products(
@@ -1387,20 +1188,15 @@ class TestDistS1WithCMRData:
         """
         from tools.dist_s1_input_tool import query_and_select_baseline_products_for_dist_s1
 
-        tile_id = "T102"
+        tile_id = "05VLJ"  # Real MGRS tile in Alaska (lat~62, lon~-156)
         # Use a time during the lookback window where we know there's data
-        # From previous tests, we know there's data around July-September 2024
         t0 = datetime(2024, 8, 15, 12, 0, 0)
 
         # Standard configuration
         window_configs = [(1, 60, 8), (2, 60, 6), (3, 60, 6)]
 
-        # Use bounding box for small region in Alaska
-        bbox = "-156,62,-155,62.5"
-
         print(f"\n" + "=" * 80)
         print(f"Testing COMPLETE DIST-S1 workflow for tile {tile_id} at t0={t0.isoformat()}")
-        print(f"Using bounding box: {bbox}")
         print(f"Note: Test may skip if no RTC coverage at this specific time")
         print("=" * 80)
 
@@ -1409,9 +1205,7 @@ class TestDistS1WithCMRData:
             tile_id=tile_id,
             t0=t0,
             window_configs=window_configs,
-            time_tolerance_minutes=60,  # Use larger tolerance for test
-            bbox=bbox,
-            auto_bbox=False,
+            time_tolerance_minutes=10,  # Use larger tolerance for test
         )
 
         if not baseline_products:

--- a/tests/unit/tools/ops/cmr_audit/test_extract_utilities.py
+++ b/tests/unit/tools/ops/cmr_audit/test_extract_utilities.py
@@ -1,0 +1,596 @@
+"""Unit tests for extract_native_ids and extract_fields utilities.
+
+Tests Phase 1.5 of MEMORY_OPTIMIZATION_IMPLEMENTATION.md.
+"""
+import json
+import tempfile
+from pathlib import Path
+import pytest
+
+from tools.ops.cmr_audit.cmr_audit_utils import extract_native_ids, extract_fields
+
+
+# Sample CMR granule data structures based on actual audit script usage
+SAMPLE_RTC_GRANULE = {
+    "meta": {
+        "native-id": "OPERA_L2_RTC-S1_T168-359595-IW3_20250516T053145Z_20250516T155714Z_S1A_30_v1.0",
+        "revision-id": "1",
+        "revision-date": "2025-05-16T15:57:14.123Z"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L2_RTC-S1_T168-359595-IW3_20250516T053145Z_20250516T155714Z_S1A_30_v1.0",
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2025-05-16T05:31:45.000Z",
+                "EndingDateTime": "2025-05-16T05:31:50.000Z"
+            }
+        }
+    }
+}
+
+SAMPLE_DSWX_GRANULE = {
+    "meta": {
+        "native-id": "OPERA_L3_DSWx-S1_T55GCQ_20250512T193408Z_20250513T064736Z_S1A_30_v1.0",
+        "revision-id": "2",
+        "revision-date": "2025-05-13T06:47:36.456Z"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L3_DSWx-S1_T55GCQ_20250512T193408Z_20250513T064736Z_S1A_30_v1.0",
+        "InputGranules": [
+            "OPERA_L2_RTC-S1_T118-252625-IW2_20250512T193412Z_20250512T193437Z_S1A_30_v1.0",
+            "OPERA_L2_RTC-S1_T118-252626-IW2_20250512T193409Z_20250512T193434Z_S1A_30_v1.0"
+        ],
+        "RelatedUrls": [
+            {"URL": "https://example.com/data.tif", "Type": "GET DATA"}
+        ]
+    }
+}
+
+SAMPLE_HLS_GRANULE = {
+    "meta": {
+        "native-id": "HLS.L30.T10TEM.2024001T185931.v2.0",
+        "revision-id": "1",
+        "revision-date": "2024-01-01T18:59:31.000Z"
+    },
+    "umm": {
+        "GranuleUR": "HLS.L30.T10TEM.2024001T185931.v2.0"
+    }
+}
+
+SAMPLE_TROPO_GRANULE = {
+    "meta": {
+        "native-id": "NISAR_L2_PR_RRSD_001_005_A_219_4020_SHNA_A_20240101T000000_20240101T235959_v0.1",
+        "revision-id": "1",
+        "revision-date": "2024-01-01T12:00:00.000Z"
+    },
+    "umm": {
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2024-01-01T00:00:00.000Z",
+                "EndingDateTime": "2024-01-01T23:59:59.000Z"
+            }
+        }
+    }
+}
+
+SAMPLE_SLC_GRANULE = {
+    "meta": {
+        "native-id": "S1A_IW_SLC__1SDV_20250101T120000_20250101T120030_051234_063456_ABCD",
+        "revision-id": "1",
+        "revision-date": "2025-01-01T12:00:30.000Z"
+    },
+    "umm": {
+        "GranuleUR": "S1A_IW_SLC__1SDV_20250101T120000_20250101T120030_051234_063456_ABCD",
+        "SpatialExtent": {
+            "HorizontalSpatialDomain": {
+                "Geometry": {
+                    "GPolygons": [
+                        {
+                            "Boundary": {
+                                "Points": [
+                                    {"Longitude": -122.0, "Latitude": 37.0},
+                                    {"Longitude": -121.0, "Latitude": 37.0},
+                                    {"Longitude": -121.0, "Latitude": 38.0},
+                                    {"Longitude": -122.0, "Latitude": 38.0}
+                                ]
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+
+SAMPLE_DISP_S1_GRANULE = {
+    "meta": {
+        "native-id": "OPERA_L3_DISP-S1_IW_F01234_VV_20250101_20250113_v1.0_20250114T000000Z",
+        "revision-id": "1",
+        "revision-date": "2025-01-14T00:00:00.000Z"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L3_DISP-S1_IW_F01234_VV_20250101_20250113_v1.0_20250114T000000Z",
+        "AdditionalAttributes": [
+            {"Name": "FRAME_NUMBER", "Values": ["1234"]},
+            {"Name": "PRODUCT_VERSION", "Values": ["1.0"]}
+        ],
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2025-01-01T00:00:00.000Z",
+                "EndingDateTime": "2025-01-13T23:59:59.000Z"
+            }
+        },
+        "RelatedUrls": [
+            {"URL": "https://example.com/disp.nc", "Type": "GET DATA"}
+        ]
+    }
+}
+
+SAMPLE_GRANULE_WITH_NONE = {
+    "meta": {
+        "native-id": "OPERA_L2_RTC-S1_TEST_20250101T000000Z_v1.0",
+        "revision-id": "1",
+        "revision-date": "2025-01-01T00:00:00.000Z"
+    },
+    "umm": {
+        "GranuleUR": "OPERA_L2_RTC-S1_TEST_20250101T000000Z_v1.0",
+        "TemporalExtent": {
+            "RangeDateTime": {
+                "BeginningDateTime": "2025-01-01T00:00:00.000Z",
+                "EndingDateTime": None
+            }
+        }
+    }
+}
+
+
+class TestExtractNativeIds:
+    """Test extract_native_ids function."""
+
+    def test_single_file_multiple_records(self):
+        """Test extracting native IDs from a single file with multiple records."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_HLS_GRANULE) + '\n')
+
+            native_ids = extract_native_ids([jsonl_path])
+
+            assert len(native_ids) == 3
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_DSWX_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_HLS_GRANULE["meta"]["native-id"] in native_ids
+
+    def test_multiple_files(self):
+        """Test extracting native IDs from multiple files."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file1 = Path(tmpdir) / "file1.jsonl"
+            file2 = Path(tmpdir) / "file2.jsonl"
+
+            with open(file1, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            with open(file2, 'w') as f:
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            native_ids = extract_native_ids([file1, file2])
+
+            assert len(native_ids) == 2
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_DSWX_GRANULE["meta"]["native-id"] in native_ids
+
+    def test_empty_file(self):
+        """Test that empty files return empty set."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_file = Path(tmpdir) / "empty.jsonl"
+            empty_file.touch()
+
+            native_ids = extract_native_ids([empty_file])
+
+            assert native_ids == set()
+
+    def test_mixed_collections(self):
+        """Test extracting native IDs from mixed collection types in same directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rtc_file = Path(tmpdir) / "rtc.jsonl"
+            dswx_file = Path(tmpdir) / "dswx.jsonl"
+            hls_file = Path(tmpdir) / "hls.jsonl"
+
+            with open(rtc_file, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            with open(dswx_file, 'w') as f:
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            with open(hls_file, 'w') as f:
+                f.write(json.dumps(SAMPLE_HLS_GRANULE) + '\n')
+
+            # Test reading all files together
+            all_ids = extract_native_ids([rtc_file, dswx_file, hls_file])
+            assert len(all_ids) == 3
+
+            # Test reading subsets
+            rtc_ids = extract_native_ids([rtc_file])
+            assert len(rtc_ids) == 1
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in rtc_ids
+
+    def test_duplicate_native_ids(self):
+        """Test that duplicate native IDs are deduplicated (set behavior)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                # Write same record twice
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            native_ids = extract_native_ids([jsonl_path])
+
+            # Should only have one unique ID
+            assert len(native_ids) == 1
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in native_ids
+
+
+class TestExtractFields:
+    """Test extract_fields function."""
+
+    def test_simple_field_extraction(self):
+        """Test extracting simple top-level nested fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            records = extract_fields([jsonl_path], ["meta.native-id"])
+
+            assert len(records) == 1
+            assert records[0]["meta.native-id"] == SAMPLE_RTC_GRANULE["meta"]["native-id"]
+
+    def test_multiple_simple_fields(self):
+        """Test extracting multiple simple fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "meta.revision-id",
+                "meta.revision-date"
+            ])
+
+            assert len(records) == 1
+            assert records[0]["meta.native-id"] == SAMPLE_RTC_GRANULE["meta"]["native-id"]
+            assert records[0]["meta.revision-id"] == SAMPLE_RTC_GRANULE["meta"]["revision-id"]
+            assert records[0]["meta.revision-date"] == SAMPLE_RTC_GRANULE["meta"]["revision-date"]
+
+    def test_deeply_nested_field(self):
+        """Test extracting deeply nested fields."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            records = extract_fields([jsonl_path], [
+                "umm.TemporalExtent.RangeDateTime.BeginningDateTime"
+            ])
+
+            assert len(records) == 1
+            expected = SAMPLE_RTC_GRANULE["umm"]["TemporalExtent"]["RangeDateTime"]["BeginningDateTime"]
+            assert records[0]["umm.TemporalExtent.RangeDateTime.BeginningDateTime"] == expected
+
+    def test_array_field_extraction(self):
+        """Test extracting array fields - should return full array."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            records = extract_fields([jsonl_path], ["umm.InputGranules"])
+
+            assert len(records) == 1
+            assert isinstance(records[0]["umm.InputGranules"], list)
+            assert len(records[0]["umm.InputGranules"]) == 2
+            assert records[0]["umm.InputGranules"] == SAMPLE_DSWX_GRANULE["umm"]["InputGranules"]
+
+    def test_missing_required_field_raises_keyerror(self):
+        """Test that missing required fields raise KeyError."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            # Try to extract a field that doesn't exist
+            with pytest.raises(KeyError, match="Key 'NonExistentField' not found"):
+                extract_fields([jsonl_path], ["meta.NonExistentField"])
+
+    def test_missing_nested_field_raises_keyerror(self):
+        """Test that missing nested fields raise KeyError with informative message."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_HLS_GRANULE) + '\n')
+
+            # HLS granule doesn't have InputGranules
+            with pytest.raises(KeyError, match="Key 'InputGranules' not found in path 'umm.InputGranules'"):
+                extract_fields([jsonl_path], ["umm.InputGranules"])
+
+    def test_multiple_records_from_single_file(self):
+        """Test extracting fields from multiple records in one file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            records = extract_fields([jsonl_path], ["meta.native-id"])
+
+            assert len(records) == 2
+            native_ids = [r["meta.native-id"] for r in records]
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_DSWX_GRANULE["meta"]["native-id"] in native_ids
+
+    def test_multiple_files_multiple_records(self):
+        """Test extracting fields from multiple files with multiple records each."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            file1 = Path(tmpdir) / "file1.jsonl"
+            file2 = Path(tmpdir) / "file2.jsonl"
+
+            with open(file1, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            with open(file2, 'w') as f:
+                f.write(json.dumps(SAMPLE_HLS_GRANULE) + '\n')
+
+            records = extract_fields([file1, file2], ["meta.native-id", "meta.revision-id"])
+
+            assert len(records) == 3
+            native_ids = [r["meta.native-id"] for r in records]
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_DSWX_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_HLS_GRANULE["meta"]["native-id"] in native_ids
+
+    def test_empty_file_returns_empty_list(self):
+        """Test that empty files return empty list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            empty_file = Path(tmpdir) / "empty.jsonl"
+            empty_file.touch()
+
+            records = extract_fields([empty_file], ["meta.native-id"])
+
+            assert records == []
+
+    def test_optional_field_with_none_value(self):
+        """Test that fields with explicit None values are returned as None."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_GRANULE_WITH_NONE) + '\n')
+
+            records = extract_fields([jsonl_path], [
+                "umm.TemporalExtent.RangeDateTime.EndingDateTime"
+            ])
+
+            assert len(records) == 1
+            assert records[0]["umm.TemporalExtent.RangeDateTime.EndingDateTime"] is None
+
+    def test_traversal_through_none_returns_none(self):
+        """Test that traversing past a None value returns None rather than raising."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # A record where an intermediate value is None
+            granule = {
+                "meta": {"native-id": "test-id"},
+                "umm": {"TemporalExtent": None}
+            }
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(granule) + '\n')
+
+            records = extract_fields([jsonl_path], [
+                "umm.TemporalExtent.RangeDateTime.BeginningDateTime"
+            ])
+
+            assert len(records) == 1
+            assert records[0]["umm.TemporalExtent.RangeDateTime.BeginningDateTime"] is None
+
+
+class TestFieldAccessPatterns:
+    """Test field access patterns needed by audit scripts."""
+
+    def test_rtc_audit_pattern(self):
+        """Test field access pattern used by cmr_audit_dswx_s1.py for RTC granules."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "rtc.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+
+            # Pattern from implementation plan line 366
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "meta.revision-id",
+                "meta.revision-date"
+            ])
+
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify we can access fields with dot notation as keys
+            native_id = record["meta.native-id"]
+            revision_id = record["meta.revision-id"]
+            revision_date = record["meta.revision-date"]
+
+            # Verify transformations still work
+            burst_id = native_id[16:31]
+            assert burst_id == "T168-359595-IW3"
+
+    def test_dswx_audit_pattern(self):
+        """Test field access pattern used by cmr_audit_dswx_s1.py for DSWx granules."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "dswx.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            # Pattern from implementation plan line 367
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "umm.InputGranules"
+            ])
+
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify we can iterate over InputGranules array
+            input_granules = record["umm.InputGranules"]
+            assert isinstance(input_granules, list)
+            assert len(input_granules) == 2
+
+            # Verify we can process the array as in the actual script
+            for granule in input_granules:
+                assert granule.startswith("OPERA_L2_RTC-S1_")
+
+    def test_tropo_audit_pattern(self):
+        """Test field access pattern used by cmr_audit_tropo.py."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "tropo.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_TROPO_GRANULE) + '\n')
+
+            # Pattern from implementation plan line 482
+            records = extract_fields([jsonl_path], [
+                "umm.TemporalExtent.RangeDateTime.BeginningDateTime"
+            ])
+
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify we can process the datetime as in the actual script
+            begin_dt = record["umm.TemporalExtent.RangeDateTime.BeginningDateTime"]
+            date_str = begin_dt.split('T')[0]
+            assert date_str == "2024-01-01"
+
+    def test_dist_s1_audit_pattern(self):
+        """Test field access pattern used by cmr_audit_dist_s1.py."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "dist.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            # Pattern from implementation plan line 425
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "umm.RelatedUrls"
+            ])
+
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify we can access nested array of dicts
+            related_urls = record["umm.RelatedUrls"]
+            assert isinstance(related_urls, list)
+            assert len(related_urls) == 1
+            assert related_urls[0]["URL"] == "https://example.com/data.tif"
+
+    def test_slc_audit_pattern(self):
+        """Test field access pattern used by cmr_audit_slc.py for spatial geometry."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "slc.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_SLC_GRANULE) + '\n')
+
+            # Pattern from implementation plan line 408
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "umm.SpatialExtent.HorizontalSpatialDomain.Geometry.GPolygons"
+            ])
+
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify deeply nested spatial geometry is returned as-is
+            gpolygons = record["umm.SpatialExtent.HorizontalSpatialDomain.Geometry.GPolygons"]
+            assert isinstance(gpolygons, list)
+            assert len(gpolygons) == 1
+            points = gpolygons[0]["Boundary"]["Points"]
+            assert len(points) == 4
+            assert points[0]["Latitude"] == 37.0
+
+    def test_disp_s1_audit_pattern(self):
+        """Test field access pattern used by opv_disp_s1.py for DISP-S1 granules."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "disp.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_DISP_S1_GRANULE) + '\n')
+
+            # Pattern from implementation plan line 508-516
+            records = extract_fields([jsonl_path], [
+                "umm.AdditionalAttributes",
+                "umm.TemporalExtent.RangeDateTime.EndingDateTime",
+                "umm.GranuleUR",
+                "umm.RelatedUrls"
+            ])
+
+            assert len(records) == 1
+            record = records[0]
+
+            # Verify AdditionalAttributes array
+            attrs = record["umm.AdditionalAttributes"]
+            assert isinstance(attrs, list)
+            assert len(attrs) == 2
+            frame_attr = next(a for a in attrs if a["Name"] == "FRAME_NUMBER")
+            assert frame_attr["Values"] == ["1234"]
+
+            # Verify EndingDateTime
+            assert record["umm.TemporalExtent.RangeDateTime.EndingDateTime"] == "2025-01-13T23:59:59.000Z"
+
+            # Verify GranuleUR
+            assert "DISP-S1" in record["umm.GranuleUR"]
+
+    def test_combining_extract_functions(self):
+        """Test that scripts can use both extract functions together."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "combined.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            # Extract native IDs
+            native_ids = extract_native_ids([jsonl_path])
+            assert len(native_ids) == 2
+
+            # Extract detailed fields
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "meta.revision-id"
+            ])
+            assert len(records) == 2
+
+            # Verify consistency
+            extracted_ids = {r["meta.native-id"] for r in records}
+            assert native_ids == extracted_ids
+
+    def test_avoid_redundant_reads(self):
+        """Test pattern where extract_fields includes native-id to avoid redundant reads."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            jsonl_path = Path(tmpdir) / "test.jsonl"
+            with open(jsonl_path, 'w') as f:
+                f.write(json.dumps(SAMPLE_RTC_GRANULE) + '\n')
+                f.write(json.dumps(SAMPLE_DSWX_GRANULE) + '\n')
+
+            # Extract fields including native-id
+            records = extract_fields([jsonl_path], [
+                "meta.native-id",
+                "meta.revision-id"
+            ])
+
+            # Derive native ID set from extracted records (avoid calling extract_native_ids)
+            native_ids = {r["meta.native-id"] for r in records}
+
+            assert len(native_ids) == 2
+            assert SAMPLE_RTC_GRANULE["meta"]["native-id"] in native_ids
+            assert SAMPLE_DSWX_GRANULE["meta"]["native-id"] in native_ids
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/tools/ops/cmr_audit/test_extract_utilities.py
+++ b/tests/unit/tools/ops/cmr_audit/test_extract_utilities.py
@@ -1,6 +1,4 @@
 """Unit tests for extract_native_ids and extract_fields utilities.
-
-Tests Phase 1.5 of MEMORY_OPTIMIZATION_IMPLEMENTATION.md.
 """
 import json
 import tempfile

--- a/tools/dist_s1_input_formatters.py
+++ b/tools/dist_s1_input_formatters.py
@@ -1,0 +1,425 @@
+"""
+Output formatting for the DIST-S1 input tool.
+
+Handles JSON, text, and IDs output formats for single query, batch, and
+temporal window modes.
+"""
+
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _calculate_lookback_window(time, years_back, window_size):
+    """Deferred import to avoid circular dependency with dist_s1_input_tool."""
+    from tools.dist_s1_input_tool import calculate_lookback_window
+    return calculate_lookback_window(time, years_back, window_size)
+
+
+def format_baseline_product_json(product: dict, time, window_size: int) -> dict:
+    """Format a single baseline product for JSON output."""
+    windows = {}
+    for years_back, window_name in [(1, "w1"), (2, "w2"), (3, "w3")]:
+        windows[window_name] = {
+            "years_back": years_back,
+            "window": _calculate_lookback_window(time, years_back, window_size).to_dict(),
+            "granules": [g.to_dict() for g in product[window_name]],
+            "count": len(product[window_name]),
+        }
+
+    total_files = len(product["t0"]) + len(product["w1"]) + len(product["w2"]) + len(product["w3"])
+    return {
+        "burst_id": product["burst_id"],
+        "subswath": product["subswath"],
+        "t0": {
+            "description": "RTC granules at acquisition time",
+            "granules": [g.to_dict() for g in product["t0"]],
+            "count": len(product["t0"]),
+        },
+        "windows": windows,
+        "total_granules": total_files,
+    }
+
+
+def format_json_output(results: list[dict], args) -> dict:
+    """Format results as JSON output."""
+    if len(results) == 1:
+        # Single query mode
+        result = results[0]
+        tile_id = result["tile_id"]
+        time = result["reference_time"]
+        baseline_products = result["baseline_products"]
+
+        output = {
+            "query": {
+                "tile_id": tile_id,
+                "reference_time": time.isoformat(),
+                "window_size_days": args.window_size,
+                "max_files": list(args.max_files),
+            },
+            "baseline_products": {},
+            "summary": {
+                "total_baselines": len(baseline_products),
+                "total_granules": 0,
+            },
+        }
+
+        for baseline_id, product in baseline_products.items():
+            formatted = format_baseline_product_json(product, time, args.window_size)
+            output["baseline_products"][baseline_id] = formatted
+            output["summary"]["total_granules"] += formatted["total_granules"]
+    else:
+        # Batch mode
+        output = {
+            "query": {"window_size_days": args.window_size, "max_files": list(args.max_files)},
+            "results": [],
+        }
+        total_baselines = total_granules = 0
+        for result in results:
+            baseline_products = result["baseline_products"]
+            result_entry = {
+                "native_id": result.get("native_id"),
+                "tile_id": result["tile_id"],
+                "reference_time": result["reference_time"].isoformat(),
+                "baseline_products": {},
+            }
+            result_total_granules = 0
+            for baseline_id, product in baseline_products.items():
+                formatted = format_baseline_product_json(product, result["reference_time"], args.window_size)
+                result_entry["baseline_products"][baseline_id] = formatted
+                result_total_granules += formatted["total_granules"]
+            result_entry["total_granules"] = result_total_granules
+            result_entry["total_baselines"] = len(baseline_products)
+            output["results"].append(result_entry)
+            total_baselines += len(baseline_products)
+            total_granules += result_total_granules
+        output["summary"] = {
+            "total_queries": len(results),
+            "total_baselines": total_baselines,
+            "total_granules": total_granules,
+        }
+
+        # Add list of products needing retriggering (successful queries with sufficient inputs)
+        output["products_to_retrigger"] = []
+        for result in results:
+            tile_id = result["tile_id"]
+            # Add acquisition group if present
+            if "acq_group" in result and result["acq_group"]:
+                formatted_tile_id = f"{tile_id}_{result['acq_group']}"
+            else:
+                formatted_tile_id = tile_id
+
+            output["products_to_retrigger"].append(
+                {
+                    "tile_id": tile_id,
+                    "acq_group": result.get("acq_group"),
+                    "acquisition_time": result["reference_time"].isoformat(),
+                    "formatted": f"{formatted_tile_id},{result['reference_time'].strftime('%Y%m%dT%H%M%SZ')}",
+                }
+            )
+
+    return output
+
+
+def format_ids_output(results: list[dict]) -> str:
+    """Format results as granule IDs only (one per line)."""
+    ids = []
+    for result in results:
+        for product in result["baseline_products"].values():
+            for window_name in ["t0", "w1", "w2", "w3"]:
+                ids.extend(g.granule_id for g in product[window_name])
+    return "\n".join(ids)
+
+
+def format_temporal_window_json(results: dict, args) -> dict:
+    """Format temporal window results for JSON serialization."""
+    formatted_details = []
+    for detail in results["details"]:
+        formatted_detail = {
+            "tile_id": detail["tile_id"],
+            "acquisition_time": detail["acquisition_time"].isoformat(),
+            "is_sufficient": detail["is_sufficient"],
+            "baseline_count": detail["baseline_count"],
+            "reason": detail.get("reason", ""),
+        }
+
+        # Include diagnostics if present
+        if "diagnostics" in detail and detail["diagnostics"]:
+            formatted_detail["diagnostics"] = detail["diagnostics"]
+
+        # Format baseline_products if present
+        if "baseline_products" in detail and detail["baseline_products"]:
+            formatted_baselines = {}
+            for baseline_id, product in detail["baseline_products"].items():
+                formatted_baselines[baseline_id] = format_baseline_product_json(
+                    product, detail["acquisition_time"], args.window_size
+                )
+            formatted_detail["baseline_products"] = formatted_baselines
+        else:
+            formatted_detail["baseline_products"] = {}
+
+        formatted_details.append(formatted_detail)
+
+    return {
+        "query": results["query"],
+        "summary": results["summary"],
+        "jobs_by_tile": results["jobs_by_tile"],
+        "jobs_by_date": results["jobs_by_date"],
+        "details": formatted_details,
+    }
+
+
+def format_temporal_window_output(results: dict, args) -> str:
+    """Format temporal window analysis results."""
+    if args.output == "json":
+        # Determine output filename
+        if args.output_file:
+            output_file = args.output_file
+        else:
+            # Auto-generate filename based on query parameters
+            start = results["query"]["start_date"].replace(":", "").replace("-", "")[:8]
+            end = results["query"]["end_date"].replace(":", "").replace("-", "")[:8]
+            output_file = f"temporal_window_analysis_{start}_{end}.json"
+
+        # Auto-generate log filename if not specified
+        if not args.log_file and args.output == "json":
+            log_file = output_file.replace(".json", ".log")
+            file_handler = logging.FileHandler(log_file, mode="w")
+            file_handler.setLevel(logging.DEBUG)
+            file_handler.setFormatter(
+                logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
+            )
+            logging.getLogger().addHandler(file_handler)
+            logger.info(f"Auto-generated log file: {log_file}")
+
+        # Format results for JSON serialization
+        formatted_results = format_temporal_window_json(results, args)
+
+        # Save full results to file
+        with open(output_file, "w") as f:
+            json.dump(formatted_results, f, indent=2)
+
+        # Return summary message
+        summary = results["summary"]
+        log_msg = (
+            f" (logs: {output_file.replace('.json', '.log')})" if not args.log_file else f" (logs: {args.log_file})"
+        )
+        return (
+            f"\nSaved detailed results to: {output_file}{log_msg}\n"
+            f"Summary: {summary['jobs_with_sufficient_inputs']}/{summary['total_acquisition_times']} "
+            f"jobs have sufficient inputs across {summary['total_tiles']} tiles\n"
+        )
+
+    # Text output format
+    lines = []
+    query = results["query"]
+    summary = results["summary"]
+    jobs_by_tile = results["jobs_by_tile"]
+    jobs_by_date = results["jobs_by_date"]
+
+    lines.extend(
+        [
+            "",
+            "=" * 80,
+            "DIST-S1 Temporal Window Job Forecast",
+            "=" * 80,
+            f"Query Period: {query['start_date']} to {query['end_date']}",
+        ]
+    )
+
+    # Add window config info
+    wc = query["window_configs"]
+    lines.append(f"Window Configuration: w1={wc[0][2]}, w2={wc[1][2]}, w3={wc[2][2]} ({wc[0][1]}-day windows)")
+
+    lines.extend(
+        [
+            "",
+            "Summary:",
+            f"  Unique tiles with RTC data: {summary['total_tiles']}",
+            f"  Total acquisition times analyzed: {summary['total_acquisition_times']}",
+            f"  Jobs with sufficient inputs: {summary['jobs_with_sufficient_inputs']}",
+            f"  Jobs with insufficient inputs: {summary['jobs_with_insufficient_inputs']}",
+        ]
+    )
+
+    # Breakdown by tile (top 15)
+    if jobs_by_tile:
+        lines.extend(
+            [
+                "",
+                "Breakdown by Tile (top 15):",
+            ]
+        )
+
+        # Sort by total jobs (sufficient + insufficient)
+        sorted_tiles = sorted(
+            jobs_by_tile.items(), key=lambda x: x[1]["sufficient"] + x[1]["insufficient"], reverse=True
+        )
+
+        for tile, counts in sorted_tiles[:15]:
+            total = counts["sufficient"] + counts["insufficient"]
+            lines.append(
+                f"  {tile:10s}: {total:3d} jobs ({counts['sufficient']:3d} sufficient, {counts['insufficient']:3d} insufficient)"
+            )
+
+    # Breakdown by date (show all dates with data)
+    if jobs_by_date:
+        lines.extend(
+            [
+                "",
+                "Breakdown by Date:",
+            ]
+        )
+
+        for date_str in sorted(jobs_by_date.keys()):
+            counts = jobs_by_date[date_str]
+            total = counts["sufficient"] + counts["insufficient"]
+            lines.append(
+                f"  {date_str}: {total:3d} jobs ({counts['sufficient']:3d} sufficient, {counts['insufficient']:3d} insufficient)"
+            )
+
+    # Show insufficient jobs if there are any (and not too many)
+    insufficient_jobs = [d for d in results["details"] if not d["is_sufficient"]]
+    if insufficient_jobs and len(insufficient_jobs) <= 20:
+        lines.extend(
+            [
+                "",
+                "Insufficient Jobs (missing data):",
+            ]
+        )
+        for job in insufficient_jobs:
+            lines.append(f"  {job['tile_id']:10s} @ {job['acquisition_time'].isoformat()}: {job['reason']}")
+    elif len(insufficient_jobs) > 20:
+        lines.extend(
+            [
+                "",
+                f"Insufficient Jobs: {len(insufficient_jobs)} jobs have insufficient data",
+                "  (Use --output json --full-output for complete list)",
+            ]
+        )
+
+    lines.extend(["=" * 80, ""])
+
+    return "\n".join(lines)
+
+
+def format_text_output(results: list[dict], args) -> str:
+    """Format results as human-readable text output."""
+    lines = []
+    if len(results) == 1:
+        # Single query mode
+        result = results[0]
+        tile_id, time, baseline_products = result["tile_id"], result["reference_time"], result["baseline_products"]
+        lines.extend(
+            [
+                "\n" + "=" * 80,
+                "DIST-S1 Baseline Product Selection Results",
+                "=" * 80 + "\n",
+                f"Tile: {tile_id}",
+                f"Acquisition time: {time.isoformat()}",
+                f"Found {len(baseline_products)} baseline products (unique burst+subswath combinations)\n",
+            ]
+        )
+
+        total_files = 0
+        for baseline_id, product in sorted(baseline_products.items()):
+            t0, w1, w2, w3 = product["t0"], product["w1"], product["w2"], product["w3"]
+            baseline_total = len(t0) + len(w1) + len(w2) + len(w3)
+            total_files += baseline_total
+            lines.extend(
+                [
+                    "-" * 80,
+                    f"Baseline: {baseline_id} (burst={product['burst_id']}, subswath={product['subswath']})",
+                    f"Total files: {baseline_total} (t0={len(t0)}, w1={len(w1)}, w2={len(w2)}, w3={len(w3)})",
+                    "",
+                    "  Acquisition Time (t0):",
+                    f"    Files found: {len(t0)}",
+                ]
+            )
+            lines.extend(f"      {g.acquisition_time.isoformat()}: {g.granule_id}" for g in t0) if t0 else lines.append(
+                "      (No granules found)"
+            )
+            lines.append("")
+
+            for window_name, granules, years_back in [("Window 1", w1, 1), ("Window 2", w2, 2), ("Window 3", w3, 3)]:
+                window = _calculate_lookback_window(time, years_back, args.window_size)
+                lines.extend(
+                    [
+                        f"  {window_name} (t0 - {years_back} year{'s' if years_back > 1 else ''}):",
+                        f"    Target date: {window.window_end.isoformat()}",
+                        f"    Range: {window.window_start.isoformat()} to {window.window_end.isoformat()}",
+                        f"    Files found: {len(granules)}/{args.max_files[years_back - 1]}",
+                    ]
+                )
+                if granules:
+                    for g in granules:
+                        days = (g.acquisition_time - window.window_end).days
+                        lines.append(
+                            f"      {g.acquisition_time.isoformat()} ({'+' if days >= 0 else ''}{days}d): {g.granule_id}"
+                        )
+                else:
+                    lines.append("      (No granules found)")
+                lines.append("")
+
+        lines.extend(
+            [
+                "=" * 80,
+                f"Total baselines: {len(baseline_products)}",
+                f"Total files selected: {total_files}",
+                "=" * 80 + "\n",
+            ]
+        )
+
+    else:
+        # Batch mode
+        lines.extend(["\n" + "=" * 80, "DIST-S1 Baseline Product Selection Results (Batch)", "=" * 80 + "\n"])
+        grand_total_files = grand_total_baselines = 0
+        for i, result in enumerate(results, 1):
+            baseline_products = result["baseline_products"]
+            result_total_files = sum(
+                len(p["t0"]) + len(p["w1"]) + len(p["w2"]) + len(p["w3"]) for p in baseline_products.values()
+            )
+            lines.extend(
+                [
+                    f"[{i}/{len(results)}] {result['tile_id']},{result['reference_time'].isoformat()} {len(baseline_products)} baselines"
+                ]
+            )
+            grand_total_files += result_total_files
+            grand_total_baselines += len(baseline_products)
+
+        # Add section for products needing retriggering (successful queries with sufficient inputs)
+        lines.extend(
+            [
+                "",
+                "Products Needing Retriggering:",
+                "=" * 80,
+            ]
+        )
+
+        if results:
+            lines.append("Format: tile_id,acquisition_time")
+            lines.append("")
+            for result in results:
+                tile_id = result["tile_id"]
+                acq_time = result["reference_time"]
+                # Add acquisition group if present
+                if "acq_group" in result and result["acq_group"]:
+                    formatted_tile_id = f"{tile_id}_{result['acq_group']}"
+                else:
+                    formatted_tile_id = tile_id
+                # Format as tile_id,timestamp (same format as input for easy copy-paste)
+                lines.append(f"{formatted_tile_id},{acq_time.strftime('%Y%m%dT%H%M%SZ')}")
+
+            lines.append("")
+            lines.append(f"Total products to retrigger: {len(results)}")
+        else:
+            lines.append("(None - all queried products have insufficient inputs)")
+
+        lines.extend(
+            [
+                "=" * 80 + "\n",
+            ]
+        )
+
+    return "\n".join(lines)

--- a/tools/dist_s1_input_tool.py
+++ b/tools/dist_s1_input_tool.py
@@ -25,6 +25,7 @@ import math
 import os
 import re
 import sys
+import tempfile
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -34,17 +35,16 @@ from dateutil.parser import isoparse
 
 from data_subscriber.cmr import DateTimeRange, async_query_cmr_v2
 from data_subscriber.dist_s1_utils import localize_dist_burst_db
+from tools.dist_s1_input_formatters import (
+    format_ids_output,
+    format_json_output,
+    format_temporal_window_output,
+    format_text_output,
+)
+from tools.ops.cmr_audit.cmr_audit_utils import extract_fields
 
-# RTC cache support (optional, support to come)
-try:
-    from opera_commons.es_connection import get_grq_es
-
-    RTC_CACHE_AVAILABLE = True
-except ImportError:
-    RTC_CACHE_AVAILABLE = False
-    get_grq_es = None
-
-CMR_RTC_CACHE_INDEX = "cmr_rtc_cache"
+logging.getLogger("elasticsearch").setLevel(level=logging.WARNING)
+logger = logging.getLogger(__name__)
 
 DIST_S1_NATIVE_ID_REGEX = (
     r"OPERA_L3_DIST(?:-ALERT)?-S1_"
@@ -54,8 +54,68 @@ DIST_S1_NATIVE_ID_REGEX = (
     r"S1[A-D]?_30_v[\d.]+.*"
 )
 
-logging.getLogger("elasticsearch").setLevel(level=logging.WARNING)
-logger = logging.getLogger(__name__)
+class DistBurstDb:
+    """Provides a clean interface over the DIST-S1 MGRS burst lookup table.
+
+    Wraps the raw 4-tuple (dist_products, bursts_to_products, product_to_bursts, all_tile_ids)
+    returned by localize_dist_burst_db() and exposes domain-level queries.
+    """
+
+    def __init__(self, dist_products: dict, bursts_to_products: dict, product_to_bursts: dict):
+        self._dist_products = dist_products  # tile_id -> set of product_ids
+        self._bursts_to_products = bursts_to_products  # burst_id -> set of product_ids
+        self._product_to_bursts = product_to_bursts  # product_id -> set of burst_ids
+
+    @classmethod
+    def load(cls) -> "DistBurstDb":
+        """Load the burst database from localize_dist_burst_db()."""
+        dist_products, bursts_to_products, product_to_bursts, _ = localize_dist_burst_db()
+        return cls(dist_products, bursts_to_products, product_to_bursts)
+
+    def bursts_by_track(self, tile_id: str) -> Optional[dict]:
+        """Get burst IDs organized by track (product) for a tile. Returns None if not found."""
+        normalized_tile = tile_id if not tile_id.startswith("T") else tile_id[1:]
+        tile_variants = [normalized_tile, f"T{normalized_tile}"]
+
+        for tile_variant in tile_variants:
+            if tile_variant in self._dist_products:
+                product_ids = self._dist_products[tile_variant]
+                bursts_by_track = {}
+                for product_id in product_ids:
+                    if product_id in self._product_to_bursts:
+                        bursts_by_track[product_id] = set(self._product_to_bursts[product_id])
+                logger.info("Found %d tracks for tile %s from lookup table", len(bursts_by_track), tile_variant)
+                return bursts_by_track
+
+        logger.warning("Tile %s not found in lookup table", tile_id)
+        return None
+
+    def bursts_for_tile(self, tile_id: str) -> Optional[set]:
+        """Get all burst IDs that overlap a given MGRS tile."""
+        bursts_by_track = self.bursts_by_track(tile_id)
+        if bursts_by_track is None:
+            logger.warning("Falling back to bbox-based search")
+            return None
+        all_bursts = set()
+        for bursts in bursts_by_track.values():
+            all_bursts.update(bursts)
+        logger.info("Found %d bursts for tile %s from lookup table", len(all_bursts), tile_id)
+        return all_bursts
+
+    def products_for_burst(self, burst_id: str) -> set:
+        """Get product IDs that contain a given burst."""
+        return self._bursts_to_products.get(burst_id, set())
+
+    def sample_burst_ids(self, n: int = 5) -> list:
+        """Return a sample of burst IDs from the database (for debugging)."""
+        return list(self._bursts_to_products.keys())[:n]
+
+
+try:
+    _burst_db = DistBurstDb.load()
+except Exception as e:
+    logger.error("Could not load MGRS burst lookup table: %s", e)
+    _burst_db = None
 
 
 @dataclass
@@ -87,154 +147,23 @@ class RtcGranule:
         return pol_set == {"HH", "HV"} or pol_set == {"VV", "VH"}
 
 
-# Type alias for granule lists
-GranuleList = list[RtcGranule]
+@dataclass
+class LookbackWindow:
+    window_start: datetime
+    window_center: datetime
+    window_end: datetime
 
-
-def get_rtc_cache_connection():
-    """
-    Get RTC cache ElasticSearch connection if available.
-
-    Returns None if cache is not available (e.g., running locally).
-    The cache is only available when deployed in OPERA SDS environment.
-    """
-    logger.info("Attempting to connect to RTC cache")
-    if not RTC_CACHE_AVAILABLE:
-        logger.debug("RTC cache not available: opera_commons.es_connection module not found")
-        return None
-
-    try:
-        grq_es = get_grq_es(logger)
-        # Test connection with a minimal query
-        grq_es.search(index=CMR_RTC_CACHE_INDEX, body={"size": 0})
-        logger.info("Successfully connected to RTC cache")
-        return grq_es
-    except Exception as e:
-        logger.info(f"RTC cache not available (likely running locally): {e}")
-        return None
-
-
-def query_rtc_cache_by_bursts_and_time(
-    grq_es,
-    burst_ids: list[str],
-    start_time: datetime,
-    end_time: datetime,
-) -> list[dict]:
-    """
-    Query RTC cache for granules matching burst IDs within a time range.
-
-    Args:
-        grq_es: ElasticSearch connection
-        burst_ids: List of burst IDs to query (e.g., ["T168-359429-IW2"])
-        start_time: Start of time range
-        end_time: End of time range
-
-    Returns:
-        List of granule metadata dictionaries from cache
-    """
-    if not burst_ids:
-        return []
-
-    # Build query for burst IDs and time range
-    should_clauses = [{"term": {"burst_id.keyword": bid}} for bid in burst_ids]
-
-    query = {
-        "query": {
-            "bool": {
-                "must": [
-                    {"bool": {"should": should_clauses, "minimum_should_match": 1}},
-                    {
-                        "range": {
-                            "acquisition_timestamp": {
-                                "gte": start_time.isoformat(),
-                                "lte": end_time.isoformat(),
-                            }
-                        }
-                    },
-                ]
-            }
-        },
-        "size": 10000,  # Large enough for typical queries
-    }
-
-    result = grq_es.search(index=CMR_RTC_CACHE_INDEX, body=query)
-    hits = result["hits"]["hits"]
-
-    logger.debug(f"RTC cache query returned {len(hits)} granules for {len(burst_ids)} burst(s)")
-
-    return [hit["_source"] for hit in hits]
-
-
-def cache_results_to_rtc_granules(cache_results: list[dict]) -> GranuleList:
-    """
-    Convert RTC cache results to RtcGranule objects.
-
-    Args:
-        cache_results: List of cache document sources
-
-    Returns:
-        List of RtcGranule objects
-    """
-    granules = []
-    for result in cache_results:
-        granule_id = result.get("granule_id")
-        if not granule_id:
-            continue
-
-        # Parse acquisition time
-        acq_time_str = result.get("acquisition_timestamp")
-        if isinstance(acq_time_str, str):
-            acq_time = isoparse(acq_time_str)
-            # Remove timezone info to match CMR behavior
-            acq_time = acq_time.replace(tzinfo=None)
-        elif isinstance(acq_time_str, datetime):
-            acq_time = acq_time_str.replace(tzinfo=None)
-        else:
-            continue
-
-        # Extract polarization from granule_id if not in cache
-        # RTC granules are typically dual-pol (VV+VH or HH+HV)
-        polarization = None
-        if "VV" in granule_id or "VH" in granule_id:
-            polarization = ["VV", "VH"]
-        elif "HH" in granule_id or "HV" in granule_id:
-            polarization = ["HH", "HV"]
-
-        granules.append(RtcGranule(granule_id, acq_time, polarization))
-
-    return granules
-
-
-def _convert_cache_granules_to_cmr_format(granules: GranuleList) -> list[dict]:
-    """
-    Convert RtcGranule objects to CMR-like format for consistent processing.
-
-    Args:
-        granules: List of RtcGranule objects
-
-    Returns:
-        List of dictionaries in CMR UMM-JSON format
-    """
-    cmr_format = []
-    for granule in granules:
-        # Create a minimal UMM-JSON structure that matches what CMR returns
-        umm_doc = {
-            "umm": {
-                "GranuleUR": granule.granule_id,
-                "TemporalExtent": {
-                    "RangeDateTime": {"BeginningDateTime": granule.acquisition_time.strftime("%Y-%m-%dT%H:%M:%S.%fZ")}
-                },
-                "AdditionalAttributes": [],
-            }
+    def to_dict(self) -> dict:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "window_start": self.window_start.isoformat(),
+            "window_center": self.window_center.isoformat(),
+            "window_end": self.window_end.isoformat(),
         }
 
-        # Add polarization if available
-        if granule.polarization:
-            umm_doc["umm"]["AdditionalAttributes"].append({"Name": "POLARIZATION", "Values": granule.polarization})
 
-        cmr_format.append(umm_doc)
-
-    return cmr_format
+# Type alias for granule lists
+GranuleList = list[RtcGranule]
 
 
 def parse_dist_s1_native_id(native_id: str) -> tuple:
@@ -310,7 +239,8 @@ def _mgrs_tile_to_bbox(tile_id: str, margin_km: float = 15.0) -> tuple:
         if crosses_antimeridian:
             logger.warning(
                 "MGRS tile '%s' bbox crosses antimeridian — CMR bbox query may be unreliable. "
-                "Consider using a polygon query instead.", tile_id
+                "Consider using a polygon query instead.",
+                tile_id,
             )
             lon_min = max(lon_min, -180.0)
             lon_max = min(lon_max, 180.0)
@@ -325,64 +255,20 @@ def _mgrs_tile_to_bbox(tile_id: str, margin_km: float = 15.0) -> tuple:
         return None
 
 
-@dataclass
-class LookbackWindow:
-    window_start: datetime
-    window_center: datetime
-    window_end: datetime
-
-    def to_dict(self) -> dict:
-        """Convert to dictionary for JSON serialization."""
-        return {
-            "window_start": self.window_start.isoformat(),
-            "window_center": self.window_center.isoformat(),
-            "window_end": self.window_end.isoformat(),
-        }
-
-
-def get_bursts_by_track_from_db(tile_id: str) -> dict:
+def get_bursts_by_track_from_db(tile_id: str) -> Optional[dict]:
     """Get burst IDs organized by track (product) for a tile. Returns None if not found."""
-    try:
-        dist_products, _, product_to_bursts, _ = localize_dist_burst_db()
-    except Exception as e:
-        logger.warning("Could not load MGRS burst lookup table: %s", e)
+    if _burst_db is None:
+        logger.warning("Burst DB not loaded, cannot look up tile %s", tile_id)
         return None
-
-    # Normalize tile ID
-    normalized_tile = tile_id if not tile_id.startswith("T") else tile_id[1:]
-    tile_variants = [normalized_tile, f"T{normalized_tile}"]
-
-    for tile_variant in tile_variants:
-        if tile_variant in dist_products:
-            # Get all product IDs (tracks) for this tile
-            product_ids = dist_products[tile_variant]
-
-            # Build dict mapping product to its bursts
-            bursts_by_track = {}
-            for product_id in product_ids:
-                if product_id in product_to_bursts:
-                    bursts = product_to_bursts[product_id]
-                    bursts_by_track[product_id] = set(bursts)
-
-            logger.info("Found %d tracks for tile %s from lookup table", len(bursts_by_track), tile_variant)
-            return bursts_by_track
-
-    logger.warning("Tile %s not found in lookup table", tile_id)
-    return None
+    return _burst_db.bursts_by_track(tile_id)
 
 
-def get_bursts_for_tile_from_db(tile_id: str) -> set:
+def get_bursts_for_tile_from_db(tile_id: str) -> Optional[set]:
     """Get all burst IDs that overlap a given MGRS tile from the lookup table."""
-    bursts_by_track = get_bursts_by_track_from_db(tile_id)
-    if bursts_by_track is None:
-        logger.warning("Falling back to bbox-based search")
+    if _burst_db is None:
+        logger.warning("Burst DB not loaded, cannot look up tile %s", tile_id)
         return None
-    # Flatten all bursts from all tracks into a single set
-    all_bursts = set()
-    for bursts in bursts_by_track.values():
-        all_bursts.update(bursts)
-    logger.info("Found %d bursts for tile %s from lookup table", len(all_bursts), tile_id)
-    return all_bursts
+    return _burst_db.bursts_for_tile(tile_id)
 
 
 def identify_track_from_active_bursts(active_burst_ids: set, bursts_by_track: dict) -> tuple:
@@ -592,7 +478,6 @@ async def query_and_select_baseline_products_for_dist_s1(
     time_tolerance_minutes: int = 10,
     provider: str = "ASF",
     collection: str = "OPERA_L2_RTC-S1_V1",
-    grq_es=None,
 ) -> dict:
     """
     Complete DIST-S1 baseline product selection workflow using consolidated queries.
@@ -614,7 +499,6 @@ async def query_and_select_baseline_products_for_dist_s1(
         time_tolerance_minutes: Tolerance for t0 acquisition time matching
         provider: CMR provider (default "ASF")
         collection: Collection shortname (default "OPERA_L2_RTC-S1_V1")
-        grq_es: Optional ElasticSearch connection for RTC cache
     """
     # Step 1: Find active bursts at acquisition time (unchanged from original)
     logger.info("Step 1: Finding RTC bursts at acquisition time %s for tile %s", t0.isoformat(), tile_id)
@@ -634,7 +518,6 @@ async def query_and_select_baseline_products_for_dist_s1(
         provider=provider,
         collection=collection,
         bbox=bbox,
-        grq_es=grq_es,
     )
 
     if not active_bursts:
@@ -718,7 +601,6 @@ async def query_and_select_baseline_products_for_dist_s1(
         provider=provider,
         collection=collection,
         bbox=bbox,
-        grq_es=grq_es,
     )
 
     # Log statistics about historical data retrieved
@@ -748,8 +630,9 @@ async def query_and_select_baseline_products_for_dist_s1(
 
                 historical_granules_by_burst[burst_key].append(granule)
 
-    async def process_burst(burst_id: str, subswath: str):
-        """Process a single burst using pre-queried historical data."""
+    # Process all bursts — this is pure in-memory filtering, no I/O needed
+    baseline_products = {}
+    for burst_id, subswath in active_bursts:
         baseline_id = f"{burst_id}-{subswath}"
         logger.info("Processing burst %s...", baseline_id)
 
@@ -771,10 +654,11 @@ async def query_and_select_baseline_products_for_dist_s1(
                 logger.debug("  Reference polarization from t0: %s", reference_pol)
 
                 # Filter historical granules to match this polarization
-                filtered_granules = []
-                for granule in burst_granules:
-                    if granule.polarization and set(granule.polarization) == reference_pol_set:
-                        filtered_granules.append(granule)
+                filtered_granules = [
+                    granule
+                    for granule in burst_granules
+                    if granule.polarization and set(granule.polarization) == reference_pol_set
+                ]
 
                 if len(filtered_granules) < len(burst_granules):
                     logger.info(
@@ -798,7 +682,7 @@ async def query_and_select_baseline_products_for_dist_s1(
             len(t0_burst_granules) + len(w1) + len(w2) + len(w3),
         )
 
-        return baseline_id, {
+        baseline_products[baseline_id] = {
             "burst_id": burst_id,
             "subswath": subswath,
             "t0": t0_burst_granules,
@@ -806,15 +690,6 @@ async def query_and_select_baseline_products_for_dist_s1(
             "w2": w2,
             "w3": w3,
         }
-
-    # Process all bursts concurrently
-    tasks = [process_burst(burst_id, subswath) for burst_id, subswath in active_bursts]
-    burst_results = await asyncio.gather(*tasks)
-
-    # Collect results into baseline_products dict
-    baseline_products = {}
-    for baseline_id, product in burst_results:
-        baseline_products[baseline_id] = product
 
     logger.info("Generated %d baseline products", len(baseline_products))
 
@@ -856,77 +731,6 @@ async def query_and_select_baseline_products_for_dist_s1(
     }
 
 
-def select_dist_s1_baseline_products(
-    t0: datetime, available_files: GranuleList, window_configs: list[tuple[int, int, int]]
-) -> dict:
-    """
-    Select input files for DIST-S1 algorithm, grouped by burst+subswath baseline products.
-
-    For each unique burst+subswath combination, this function performs independent lookback
-    window selection. Each burst+subswath gets its own set of (w1, w2, w3) files,
-    which constitutes one "baseline product".
-
-    Args:
-        t0: Reference time
-        available_files: GranuleList of available RTC files
-        window_configs: List of (years_back, window_size_days, max_files) tuples
-                       for w1, w2, w3 respectively
-
-    Returns:
-        Dictionary mapping baseline_id (burst-subswath) to baseline product data:
-        {
-            "359429-IW1": {
-                "burst_id": "359429",
-                "subswath": "IW1",
-                "w1": [RtcGranule, ...],
-                "w2": [RtcGranule, ...],
-                "w3": [RtcGranule, ...]
-            },
-            ...
-        }
-
-    Example:
-        If 16 bursts with 3 subswaths each overlap a tile, this returns 48 baseline products
-        (one for each burst+subswath combination).
-    """
-    from collections import defaultdict
-
-    # Group granules by burst+subswath
-    grouped_granules = defaultdict(list)
-
-    for granule in available_files:
-        burst_id, subswath = extract_burst_and_subswath_from_granule_id(granule.granule_id)
-
-        if burst_id is None or subswath is None:
-            logger.warning("Could not extract burst/subswath from granule ID: %s", granule.granule_id)
-            continue
-
-        # Use "burst-subswath" as the baseline identifier
-        baseline_id = f"{burst_id}-{subswath}"
-        grouped_granules[baseline_id].append(granule)
-
-    # For each baseline (burst+subswath), perform lookback selection
-    baseline_products = {}
-
-    for baseline_id, granules in sorted(grouped_granules.items()):
-        burst_id, subswath = baseline_id.split("-", 1)
-
-        # Apply lookback window selection for this baseline
-        w1, w2, w3 = select_dist_s1_input_files(t0, granules, window_configs)
-
-        baseline_products[baseline_id] = {
-            "burst_id": burst_id,
-            "subswath": subswath,
-            "w1": w1,
-            "w2": w2,
-            "w3": w3,
-        }
-
-    logger.info("Generated %d baseline products from %d RTC granules", len(baseline_products), len(available_files))
-
-    return baseline_products
-
-
 def get_bbox_from_tile_id(tile_id: str, margin_km: float = 75.0) -> str:
     """Get bounding box string from MGRS tile ID in format 'west,south,east,north'."""
     result = _mgrs_tile_to_bbox(tile_id, margin_km)
@@ -946,7 +750,6 @@ async def query_historical_data_for_tile(
     provider: str = "ASF",
     collection: str = "OPERA_L2_RTC-S1_V1",
     bbox: Optional[str] = None,
-    grq_es=None,
 ) -> dict[int, GranuleList]:
     """
     Query all historical RTC granules for a tile across all lookback windows.
@@ -958,7 +761,6 @@ async def query_historical_data_for_tile(
     Features:
     - One query per lookback window instead of per-burst queries
     - Pagination support for large result sets (tiles with many bursts)
-    - RTC cache integration when available
     - Concurrent querying of different windows
 
     Args:
@@ -968,7 +770,6 @@ async def query_historical_data_for_tile(
         provider: CMR provider (default "ASF")
         collection: Collection shortname (default "OPERA_L2_RTC-S1_V1")
         bbox: Optional bounding box (if None, will be auto-derived from tile_id)
-        grq_es: Optional ElasticSearch connection for RTC cache
 
     Returns:
         Dictionary mapping years_back -> list of RtcGranules
@@ -981,11 +782,8 @@ async def query_historical_data_for_tile(
 
     results = {}  # years_back -> granules
 
-    # Get all bursts for this tile from the lookup table (for RTC cache queries)
-    valid_bursts_from_db = get_bursts_for_tile_from_db(tile_id)
-
     # Query each window in parallel
-    async def query_window(years_back: int, window_size_days: int, max_files: int):
+    async def query_window(years_back: int, window_size_days: int):
         lookback_window = calculate_lookback_window(t0, years_back, window_size_days)
 
         # Create time range for this window
@@ -996,82 +794,37 @@ async def query_historical_data_for_tile(
 
         logger.info("Querying historical window w%d: %s to %s", years_back, timerange.start_date, timerange.end_date)
 
-        # Try RTC cache first if available
+        logger.info("Querying CMR for tile %s in w%d", tile_id, years_back)
         window_granules = []
-        if grq_es and valid_bursts_from_db:
-            try:
-                logger.info("Attempting RTC cache query for all bursts in tile %s, window w%d", tile_id, years_back)
-                cache_results = query_rtc_cache_by_bursts_and_time(
-                    grq_es, list(valid_bursts_from_db), lookback_window.window_start, lookback_window.window_end
-                )
-                if cache_results:
-                    window_granules = cache_results_to_rtc_granules(cache_results)
-                    logger.info(
-                        "Found %d granules from RTC cache for tile %s in w%d", len(window_granules), tile_id, years_back
-                    )
-            except Exception as e:
-                logger.warning("RTC cache query failed for w%d: %s, falling back to CMR", years_back, e)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rtc_paths = await async_query_cmr_v2(
+                timerange=timerange, provider=provider, collection=collection, token=None, bbox=bbox, output_dir=tmpdir
+            )
+            rtc_records = extract_fields(rtc_paths, ["umm.GranuleUR", "umm.TemporalExtent", "umm.AdditionalAttributes"])
 
-        # Fall back to CMR if cache didn't return results or returned too few results
-        if not window_granules:
-            # Use pagination to handle large result sets
-            page = 1
-            page_size = 2000  # CMR typically limits to 2000 results per page
-            all_cmr_results = []
+            logger.info("Found %d CMR results for tile %s in w%d", len(rtc_records), tile_id, years_back)
 
-            while True:
-                logger.info("Querying CMR for tile %s in w%d (page %d)", tile_id, years_back, page)
+        # Convert CMR results to RtcGranule objects
+        for rtc_record in rtc_records:
+            granule_id = rtc_record.get("GranuleUR")
+            if not granule_id:
+                continue
 
-                # We handle pagination manually by making multiple calls
-                # Passing page_num and page_size in kwargs allows future extensions
-                cmr_results = await async_query_cmr_v2(
-                    timerange=timerange, provider=provider, collection=collection, token=None, bbox=bbox
-                )
+            # Extract acquisition time
+            acquisition_time = _extract_acquisition_time_from_umm(rtc_record.get("umm.TemporalExtent", {}))
+            if not acquisition_time:
+                continue
 
-                page_count = len(cmr_results)
-                logger.info("Retrieved %d results on page %d", page_count, page)
-                all_cmr_results.extend(cmr_results)
+            # Extract polarization
+            polarization = _extract_polarization_from_umm(rtc_record.get("umm.AdditionalAttributes", {}))
 
-                # Check if we need to fetch more pages - we stop if we got fewer results
-                # than the typical page size (assuming we got all results)
-                # Note: Since async_query_cmr_v2 doesn't support pagination directly,
-                # this is an approximate approach
-                if page_count < page_size:
-                    break
-
-                page += 1
-                # Stopping after a reasonable number of pages to prevent infinite loops
-                if page > 10:  # Arbitrary limit - adjust as needed
-                    logger.warning("Reached maximum page limit (10) for CMR query, some results may be missing")
-                    break
-
-            logger.info("Found %d total CMR results for tile %s in w%d", len(all_cmr_results), tile_id, years_back)
-
-            # Convert CMR results to RtcGranule objects
-            for result in all_cmr_results:
-                umm = result.get("umm", {})
-                granule_id = umm.get("GranuleUR")
-                if not granule_id:
-                    continue
-
-                # Extract acquisition time
-                acquisition_time = _extract_acquisition_time_from_umm(umm)
-                if not acquisition_time:
-                    continue
-
-                # Extract polarization
-                polarization = _extract_polarization_from_umm(umm)
-
-                window_granules.append(RtcGranule(granule_id, acquisition_time, polarization))
+            window_granules.append(RtcGranule(granule_id, acquisition_time, polarization))
 
         logger.info("Total granules retrieved for window w%d: %d", years_back, len(window_granules))
         results[years_back] = window_granules
 
     # Query all windows concurrently
-    tasks = [
-        query_window(years_back, window_size_days, max_files)
-        for years_back, window_size_days, max_files in window_configs
-    ]
+    tasks = [query_window(years_back, window_size_days) for years_back, window_size_days, _max_files in window_configs]
     await asyncio.gather(*tasks)
 
     return results
@@ -1084,12 +837,10 @@ async def query_rtc_bursts_at_acquisition_time(
     provider: str = "ASF",
     collection: str = "OPERA_L2_RTC-S1_V1",
     bbox: Optional[str] = None,
-    grq_es=None,
 ) -> tuple[list[tuple[str, str]], dict[str, list]]:
     """
     Query for RTC bursts at acquisition time.
 
-    Tries RTC cache first if available, falls back to CMR.
     Returns (active_bursts, t0_granules_by_burst).
     """
     # Try to get valid bursts from the lookup table first
@@ -1108,35 +859,31 @@ async def query_rtc_bursts_at_acquisition_time(
     logger.info("Querying RTC bursts at acquisition time %s (±%d min)", t0.isoformat(), time_tolerance_minutes)
     logger.info("  Time range: %s to %s", time_start.isoformat(), time_end.isoformat())
 
-    # Try RTC cache first if available
-    cmr_results = []
-    if grq_es and valid_bursts_from_db:
-        try:
-            logger.debug("Attempting RTC cache query for t0 granules")
-            # Query cache for all bursts associated with this tile
-            cache_results = query_rtc_cache_by_bursts_and_time(grq_es, list(valid_bursts_from_db), time_start, time_end)
-            if cache_results:
-                logger.info("  Found %d results from RTC cache at acquisition time", len(cache_results))
-                # Convert cache results to granule format for processing
-                cache_granules = cache_results_to_rtc_granules(cache_results)
-                # Convert to CMR-like format for consistent processing below
-                cmr_results = _convert_cache_granules_to_cmr_format(cache_granules)
-        except Exception as e:
-            logger.warning("RTC cache query failed: %s, falling back to CMR", e)
-            cmr_results = []
+    t0_rtc_granules = []
+    timerange = DateTimeRange(
+        start_date=time_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        end_date=time_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
 
-    # Fall back to CMR if cache didn't return results
-    if not cmr_results:
-        timerange = DateTimeRange(
-            start_date=time_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            end_date=time_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    logger.debug("Querying CMR for t0 granules")
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rtc_paths = await async_query_cmr_v2(
+            timerange=timerange, provider=provider, collection=collection, token=None, bbox=bbox, output_dir=tmpdir
         )
+        rtc_records = extract_fields(rtc_paths, ["umm.GranuleUR", "umm.TemporalExtent", "umm.AdditionalAttributes"])
 
-        logger.debug("Querying CMR for t0 granules")
-        cmr_results = await async_query_cmr_v2(
-            timerange=timerange, provider=provider, collection=collection, token=None, bbox=bbox
-        )
-        logger.info("  Found %d CMR results at acquisition time", len(cmr_results))
+        logger.info("  Found %d CMR results at acquisition time", len(rtc_records))
+
+    # Convert CMR UMM-JSON results to RtcGranule objects
+    for rtc_record in rtc_records:
+        granule_id = rtc_record.get("umm.GranuleUR")
+        if not granule_id:
+            continue
+        acquisition_time = _extract_acquisition_time_from_umm(rtc_record.get("umm.TemporalExtent", {}))
+        if not acquisition_time:
+            continue
+        polarization = _extract_polarization_from_umm(rtc_record.get("umm.AdditionalAttributes", {}))
+        t0_rtc_granules.append(RtcGranule(granule_id, acquisition_time, polarization))
 
     # Extract unique burst+subswath combinations (dual-pol only) and collect granules
     active_bursts = set()
@@ -1144,23 +891,10 @@ async def query_rtc_bursts_at_acquisition_time(
     filtered_single_pol = 0
     filtered_not_in_db = 0
 
-    for result in cmr_results:
-        umm = result.get("umm", {})
-        granule_id = umm.get("GranuleUR")
-        if not granule_id:
-            continue
-
-        # Extract acquisition time
-        temporal = umm.get("TemporalExtent", {})
-        range_dt = temporal.get("RangeDateTime", {})
-        acq_time_str = range_dt.get("BeginningDateTime")
-        if not acq_time_str:
-            continue
-
-        acq_time = isoparse(acq_time_str.replace("Z", "+00:00"))
-
-        # Extract polarization
-        polarization = _extract_polarization_from_umm(umm)
+    for granule in t0_rtc_granules:
+        granule_id = granule.granule_id
+        acq_time = granule.acquisition_time
+        polarization = granule.polarization
 
         # Check if dual-polarization (HH+HV or VV+VH)
         if not polarization or len(polarization) != 2:
@@ -1220,216 +954,8 @@ async def query_rtc_bursts_at_acquisition_time(
     return sorted(list(active_bursts)), t0_granules_by_burst
 
 
-async def query_rtc_granules_for_burst(
-    tile_id: str,
-    burst_id: str,
-    subswath: str,
-    t0: datetime,
-    window_configs: list[tuple[int, int, int]],
-    provider: str = "ASF",
-    collection: str = "OPERA_L2_RTC-S1_V1",
-    bbox: Optional[str] = None,
-    grq_es=None,
-) -> GranuleList:
-    """
-    Query for RTC granules for a specific burst within lookback windows.
-
-    Tries RTC cache first if available, falls back to CMR.
-    """
-    # Try to construct the full burst ID for cache queries
-    # We need format like "T168-359429-IW2" instead of just "359429"
-    valid_bursts_from_db = get_bursts_for_tile_from_db(tile_id)
-    full_burst_id = None
-    if valid_bursts_from_db:
-        # Search for a burst that matches our burst_id and subswath
-        for db_burst_id in valid_bursts_from_db:
-            # db_burst_id format: "T168-359429-IW2"
-            parts = db_burst_id.split("-")
-            if len(parts) == 3 and parts[1] == burst_id and parts[2] == subswath:
-                full_burst_id = db_burst_id
-                break
-
-    async def query_window(years_back: int, window_size_days: int):
-        """Query a single window and return filtered granules."""
-        lookback_window = calculate_lookback_window(t0, years_back, window_size_days)
-
-        logger.debug(
-            "  Querying window w%d for burst %s-%s: %s to %s",
-            years_back,
-            burst_id,
-            subswath,
-            lookback_window.window_start.isoformat(),
-            lookback_window.window_end.isoformat(),
-        )
-
-        # Try RTC cache first if available and we have the full burst ID
-        window_granules = []
-        if grq_es and full_burst_id:
-            try:
-                logger.debug("    Attempting RTC cache query for burst %s in w%d", full_burst_id, years_back)
-                cache_results = query_rtc_cache_by_bursts_and_time(
-                    grq_es, [full_burst_id], lookback_window.window_start, lookback_window.window_end
-                )
-                if cache_results:
-                    window_granules = cache_results_to_rtc_granules(cache_results)
-                    logger.debug(
-                        "    Found %d granules from RTC cache for burst %s-%s in w%d",
-                        len(window_granules),
-                        burst_id,
-                        subswath,
-                        years_back,
-                    )
-            except Exception as e:
-                logger.warning("    RTC cache query failed for w%d: %s, falling back to CMR", years_back, e)
-
-        # Fall back to CMR if cache didn't return results
-        if not window_granules:
-            timerange = DateTimeRange(
-                start_date=lookback_window.window_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
-                end_date=lookback_window.window_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            )
-
-            logger.debug("    Querying CMR for burst %s-%s in w%d", burst_id, subswath, years_back)
-            cmr_results = await async_query_cmr_v2(
-                timerange=timerange, provider=provider, collection=collection, token=None, bbox=bbox
-            )
-
-            # Filter for this specific burst+subswath
-            matched_count = 0
-            for result in cmr_results:
-                umm = result.get("umm", {})
-                granule_id = umm.get("GranuleUR")
-                if not granule_id:
-                    continue
-
-                # Check if this granule matches our burst+subswath
-                g_burst_id, g_subswath = extract_burst_and_subswath_from_granule_id(granule_id)
-                if g_burst_id != burst_id or g_subswath != subswath:
-                    continue
-
-                # Extract acquisition time
-                acquisition_time = _extract_acquisition_time_from_umm(umm)
-                if not acquisition_time:
-                    continue
-
-                # Extract polarization
-                polarization = _extract_polarization_from_umm(umm)
-
-                window_granules.append(RtcGranule(granule_id, acquisition_time, polarization))
-                matched_count += 1
-
-            logger.debug(
-                "    Found %d granules from CMR for burst %s-%s in w%d", matched_count, burst_id, subswath, years_back
-            )
-
-        return window_granules
-
-    # Query all windows concurrently
-    tasks = [query_window(years_back, window_size_days) for years_back, window_size_days, _ in window_configs]
-    window_results = await asyncio.gather(*tasks)
-
-    # Combine results from all windows
-    all_granules = []
-    for window_granules in window_results:
-        all_granules.extend(window_granules)
-
-    return all_granules
-
-
-async def query_rtc_granules_for_windows(
-    tile_id: str,
-    t0: datetime,
-    window_configs: list[tuple[int, int, int]],
-    provider: str = "ASF",
-    collection: str = "OPERA_L2_RTC-S1_V1",
-) -> GranuleList:
-    """
-    Query CMR for RTC granules within specific lookback windows.
-
-    This function queries only the time ranges needed for the lookback windows,
-    making it much more efficient than querying years of data.
-
-    Args:
-        tile_id: MGRS tile ID (e.g., "T031SGR" or "T168")
-        t0: Reference time for lookback calculation
-        window_configs: List of (years_back, window_size_days, max_files) tuples
-        provider: CMR provider (default "ASF")
-        collection: Collection shortname (default "OPERA_L2_RTC-S1_V1")
-
-    Returns:
-        Combined list of RtcGranule objects from all windows
-    """
-    # Auto-derive bbox from tile_id
-    bbox = get_bbox_from_tile_id(tile_id)
-    if bbox:
-        logger.info("Auto-derived bounding box from tile %s: %s", tile_id, bbox)
-
-    async def query_window(years_back: int, window_size_days: int):
-        """Query a single window and return granules."""
-        lookback_window = calculate_lookback_window(t0, years_back, window_size_days)
-
-        # Create time range for this specific window
-        timerange = DateTimeRange(
-            start_date=lookback_window.window_start.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            end_date=lookback_window.window_end.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        )
-
-        logger.info("Querying window w%d: %s to %s", years_back, timerange.start_date, timerange.end_date)
-
-        # Query CMR without token (RTC-S1 is public data)
-        cmr_results = await async_query_cmr_v2(
-            timerange=timerange, provider=provider, collection=collection, token=None, bbox=bbox
-        )
-
-        logger.info("  Found %d CMR results", len(cmr_results))
-
-        # Convert CMR results to RtcGranule objects
-        # Note: We rely on the bbox filtering from CMR, so we accept all RTC granules
-        # returned by CMR within the DIST tile's bounding box
-        window_granules = []
-        matched_count = 0
-        for i, result in enumerate(cmr_results):
-            # Extract granule ID from UMM-JSON
-            umm = result.get("umm", {})
-            granule_id = umm.get("GranuleUR")
-            if not granule_id:
-                continue
-
-            # Log first few granule IDs for debugging
-            if i < 3:
-                logger.debug("  Sample granule: %s", granule_id[:80])
-
-            # Extract acquisition time from UMM-JSON
-            acquisition_time = _extract_acquisition_time_from_umm(umm)
-            if not acquisition_time:
-                continue
-
-            # Extract polarization
-            polarization = _extract_polarization_from_umm(umm)
-
-            window_granules.append(RtcGranule(granule_id, acquisition_time, polarization))
-            matched_count += 1
-
-        logger.info("  Accepted %d RTC granules within bbox", matched_count)
-        return window_granules
-
-    # Query all windows concurrently
-    tasks = [query_window(years_back, window_size_days) for years_back, window_size_days, _ in window_configs]
-    window_results = await asyncio.gather(*tasks)
-
-    # Combine results from all windows
-    all_granules = []
-    for window_granules in window_results:
-        all_granules.extend(window_granules)
-
-    logger.info("Total granules after filtering: %d", len(all_granules))
-    return all_granules
-
-
-def _extract_polarization_from_umm(umm: dict) -> Optional[list]:
+def _extract_polarization_from_umm(additional_attributes: dict) -> Optional[list]:
     """Extract polarization from UMM-JSON metadata."""
-    additional_attributes = umm.get("AdditionalAttributes", [])
-
     for attr in additional_attributes:
         if attr.get("Name") == "POLARIZATION":
             return attr.get("Values")  # e.g., ["VV", "VH"]
@@ -1437,11 +963,8 @@ def _extract_polarization_from_umm(umm: dict) -> Optional[list]:
     return None
 
 
-def _extract_acquisition_time_from_umm(umm: dict) -> Optional[datetime]:
+def _extract_acquisition_time_from_umm(temporal_extent: dict) -> Optional[datetime]:
     """Extract acquisition time from UMM-JSON metadata."""
-    # Try TemporalExtent for acquisition time
-    temporal_extent = umm.get("TemporalExtent", {})
-
     # Check RangeDateTime first
     range_datetime = temporal_extent.get("RangeDateTime")
     if range_datetime:
@@ -1587,7 +1110,6 @@ async def process_single_query(
     time: datetime,
     window_configs: list[tuple[int, int, int]],
     semaphore: Optional[asyncio.Semaphore] = None,
-    grq_es=None,
 ) -> dict:
     """
     Process a single DIST-S1 lookback query.
@@ -1597,7 +1119,6 @@ async def process_single_query(
         time: Reference time
         window_configs: Window configurations (years_back, window_size_days, max_files)
         semaphore: Optional semaphore for rate limiting concurrent requests
-        grq_es: Optional ElasticSearch connection for RTC cache
 
     Returns:
         Dictionary with query results
@@ -1605,16 +1126,15 @@ async def process_single_query(
     # Use semaphore for rate limiting if provided
     if semaphore:
         async with semaphore:
-            return await _process_single_query_impl(tile_id, time, window_configs, grq_es)
+            return await _process_single_query_impl(tile_id, time, window_configs)
     else:
-        return await _process_single_query_impl(tile_id, time, window_configs, grq_es)
+        return await _process_single_query_impl(tile_id, time, window_configs)
 
 
 async def _process_single_query_impl(
     tile_id: str,
     time: datetime,
     window_configs: list[tuple[int, int, int]],
-    grq_es=None,
 ) -> dict:
     """
     Internal implementation of process_single_query.
@@ -1629,7 +1149,6 @@ async def _process_single_query_impl(
         t0=time,
         window_configs=window_configs,
         time_tolerance_minutes=10,
-        grq_es=grq_es,
     )
 
     baseline_products = result["baseline_products"]
@@ -1653,7 +1172,6 @@ async def query_temporal_window_jobs(
     end_date: datetime,
     window_configs: list[tuple[int, int, int]],
     max_concurrent: int = 3,
-    grq_es=None,
 ) -> dict:
     """
     Query CMR for RTC granules across a temporal window and forecast DIST-S1 jobs.
@@ -1691,13 +1209,20 @@ async def query_temporal_window_jobs(
         end_date=end_date.strftime("%Y-%m-%dT%H:%M:%SZ"),
     )
 
-    cmr_results = await async_query_cmr_v2(
-        timerange=timerange, provider="ASF", collection="OPERA_L2_RTC-S1_V1", token=None, bbox=None
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rtc_paths = await async_query_cmr_v2(
+            timerange=timerange,
+            provider="ASF",
+            collection="OPERA_L2_RTC-S1_V1",
+            token=None,
+            bbox=None,
+            output_dir=tmpdir,
+        )
+        rtc_records = extract_fields(rtc_paths, ["umm.GranuleUR", "umm.TemporalExtent"])
 
-    logger.info("Found %d RTC granules in temporal window", len(cmr_results))
+        logger.info("Found %d RTC granules in temporal window", len(rtc_records))
 
-    if not cmr_results:
+    if not rtc_records:
         logger.warning("No RTC granules found in temporal window")
         return {
             "query": {
@@ -1718,39 +1243,18 @@ async def query_temporal_window_jobs(
 
     # Load the burst database to map bursts to MGRS tiles
     logger.info("Step 2: Loading DIST-S1 burst database...")
-    try:
-        dist_products, bursts_to_products, product_to_bursts, all_tile_ids = localize_dist_burst_db()
-    except Exception as e:
-        logger.error("Failed to load burst database: %s", e)
-        return {
-            "query": {
-                "start_date": start_date.isoformat(),
-                "end_date": end_date.isoformat(),
-                "window_configs": window_configs,
-            },
-            "summary": {
-                "total_tiles": 0,
-                "total_acquisition_times": 0,
-                "jobs_with_sufficient_inputs": 0,
-                "jobs_with_insufficient_inputs": 0,
-            },
-            "jobs_by_tile": {},
-            "jobs_by_date": {},
-            "details": [],
-        }
 
     # Step 3: Parse granules and extract acquisition times and burst IDs
     logger.info("Step 3: Parsing granules and extracting metadata...")
     granules_with_metadata = []
 
-    for result in cmr_results:
-        umm = result.get("umm", {})
-        granule_id = umm.get("GranuleUR")
+    for rtc_record in rtc_records:
+        granule_id = rtc_record.get("GranuleUR")
         if not granule_id:
             continue
 
         # Extract acquisition time
-        acquisition_time = _extract_acquisition_time_from_umm(umm)
+        acquisition_time = _extract_acquisition_time_from_umm(rtc_record.get("umm.TemporalExtent", {}))
         if not acquisition_time:
             continue
 
@@ -1781,7 +1285,7 @@ async def query_temporal_window_jobs(
     for acq_time, cluster_granules in list(acquisition_clusters.items())[:1]:
         sample_burst_ids = set(g["full_burst_id"] for g in cluster_granules[:5])
         logger.debug("Sample burst IDs from granules: %s", sample_burst_ids)
-        logger.debug("Sample burst IDs from database: %s", list(bursts_to_products.keys())[:5])
+        logger.debug("Sample burst IDs from database: %s", _burst_db.sample_burst_ids() if _burst_db else [])
 
     for acq_time, cluster_granules in acquisition_clusters.items():
         # Get unique burst IDs for this acquisition time
@@ -1791,9 +1295,9 @@ async def query_temporal_window_jobs(
         mgrs_tiles_in_cluster = set()
         matched_bursts = 0
         for burst_id in burst_ids_in_cluster:
-            if burst_id in bursts_to_products:
+            product_ids = _burst_db.products_for_burst(burst_id) if _burst_db else set()
+            if product_ids:
                 matched_bursts += 1
-                product_ids = bursts_to_products[burst_id]
                 for product_id in product_ids:
                     # Extract MGRS tile ID from product_id (format: "TILE_ID_acq_group")
                     mgrs_tile_id = product_id.rsplit("_", 1)[0]
@@ -1827,7 +1331,6 @@ async def query_temporal_window_jobs(
                     t0=time,
                     window_configs=window_configs,
                     time_tolerance_minutes=10,
-                    grq_es=grq_es,
                 )
 
                 baseline_products = result["baseline_products"]
@@ -1932,7 +1435,6 @@ async def _process_batch_queries(
     parsed_items: list[tuple[Optional[str], str, datetime]],
     window_configs: list[tuple[int, int, int]],
     max_concurrent: int,
-    grq_es=None,
 ) -> list[dict]:
     """Process multiple queries concurrently, return list of result dicts."""
     logger.info("Querying CMR with max %d concurrent requests...", max_concurrent)
@@ -1947,7 +1449,6 @@ async def _process_batch_queries(
             time=time,
             window_configs=window_configs,
             semaphore=semaphore,
-            grq_es=grq_es,
         )
         if result:
             if native_id:
@@ -1972,414 +1473,6 @@ async def _process_batch_queries(
 
     logger.info("Successfully determined %d/%d missing products", len(results), len(parsed_items))
     return results
-
-
-def _format_baseline_product_json(product: dict, time: datetime, window_size: int) -> dict:
-    """Format a single baseline product for JSON output."""
-    windows = {}
-    for years_back, window_name in [(1, "w1"), (2, "w2"), (3, "w3")]:
-        windows[window_name] = {
-            "years_back": years_back,
-            "window": calculate_lookback_window(time, years_back, window_size).to_dict(),
-            "granules": [g.to_dict() for g in product[window_name]],
-            "count": len(product[window_name]),
-        }
-
-    total_files = len(product["t0"]) + len(product["w1"]) + len(product["w2"]) + len(product["w3"])
-    return {
-        "burst_id": product["burst_id"],
-        "subswath": product["subswath"],
-        "t0": {
-            "description": "RTC granules at acquisition time",
-            "granules": [g.to_dict() for g in product["t0"]],
-            "count": len(product["t0"]),
-        },
-        "windows": windows,
-        "total_granules": total_files,
-    }
-
-
-def _format_json_output(results: list[dict], args) -> dict:
-    """Format results as JSON output."""
-    if len(results) == 1:
-        # Single query mode
-        result = results[0]
-        tile_id = result["tile_id"]
-        time = result["reference_time"]
-        baseline_products = result["baseline_products"]
-
-        output = {
-            "query": {
-                "tile_id": tile_id,
-                "reference_time": time.isoformat(),
-                "window_size_days": args.window_size,
-                "max_files": list(args.max_files),
-            },
-            "baseline_products": {},
-            "summary": {
-                "total_baselines": len(baseline_products),
-                "total_granules": 0,
-            },
-        }
-
-        for baseline_id, product in baseline_products.items():
-            formatted = _format_baseline_product_json(product, time, args.window_size)
-            output["baseline_products"][baseline_id] = formatted
-            output["summary"]["total_granules"] += formatted["total_granules"]
-    else:
-        # Batch mode
-        output = {
-            "query": {"window_size_days": args.window_size, "max_files": list(args.max_files)},
-            "results": [],
-        }
-        total_baselines = total_granules = 0
-        for result in results:
-            baseline_products = result["baseline_products"]
-            result_entry = {
-                "native_id": result.get("native_id"),
-                "tile_id": result["tile_id"],
-                "reference_time": result["reference_time"].isoformat(),
-                "baseline_products": {},
-            }
-            result_total_granules = 0
-            for baseline_id, product in baseline_products.items():
-                formatted = _format_baseline_product_json(product, result["reference_time"], args.window_size)
-                result_entry["baseline_products"][baseline_id] = formatted
-                result_total_granules += formatted["total_granules"]
-            result_entry["total_granules"] = result_total_granules
-            result_entry["total_baselines"] = len(baseline_products)
-            output["results"].append(result_entry)
-            total_baselines += len(baseline_products)
-            total_granules += result_total_granules
-        output["summary"] = {
-            "total_queries": len(results),
-            "total_baselines": total_baselines,
-            "total_granules": total_granules,
-        }
-
-        # Add list of products needing retriggering (successful queries with sufficient inputs)
-        output["products_to_retrigger"] = []
-        for result in results:
-            tile_id = result["tile_id"]
-            # Add acquisition group if present
-            if "acq_group" in result and result["acq_group"]:
-                formatted_tile_id = f"{tile_id}_{result['acq_group']}"
-            else:
-                formatted_tile_id = tile_id
-
-            output["products_to_retrigger"].append(
-                {
-                    "tile_id": tile_id,
-                    "acq_group": result.get("acq_group"),
-                    "acquisition_time": result["reference_time"].isoformat(),
-                    "formatted": f"{formatted_tile_id},{result['reference_time'].strftime('%Y%m%dT%H%M%SZ')}",
-                }
-            )
-
-    return output
-
-
-def _format_ids_output(results: list[dict]) -> str:
-    """Format results as granule IDs only (one per line)."""
-    ids = []
-    for result in results:
-        for product in result["baseline_products"].values():
-            for window_name in ["t0", "w1", "w2", "w3"]:
-                ids.extend(g.granule_id for g in product[window_name])
-    return "\n".join(ids)
-
-
-def _format_temporal_window_json(results: dict, args) -> dict:
-    """Format temporal window results for JSON serialization."""
-    formatted_details = []
-    for detail in results["details"]:
-        formatted_detail = {
-            "tile_id": detail["tile_id"],
-            "acquisition_time": detail["acquisition_time"].isoformat(),
-            "is_sufficient": detail["is_sufficient"],
-            "baseline_count": detail["baseline_count"],
-            "reason": detail.get("reason", ""),
-        }
-
-        # Include diagnostics if present
-        if "diagnostics" in detail and detail["diagnostics"]:
-            formatted_detail["diagnostics"] = detail["diagnostics"]
-
-        # Format baseline_products if present
-        if "baseline_products" in detail and detail["baseline_products"]:
-            formatted_baselines = {}
-            for baseline_id, product in detail["baseline_products"].items():
-                formatted_baselines[baseline_id] = _format_baseline_product_json(
-                    product, detail["acquisition_time"], args.window_size
-                )
-            formatted_detail["baseline_products"] = formatted_baselines
-        else:
-            formatted_detail["baseline_products"] = {}
-
-        formatted_details.append(formatted_detail)
-
-    return {
-        "query": results["query"],
-        "summary": results["summary"],
-        "jobs_by_tile": results["jobs_by_tile"],
-        "jobs_by_date": results["jobs_by_date"],
-        "details": formatted_details,
-    }
-
-
-def _format_temporal_window_output(results: dict, args) -> str:
-    """Format temporal window analysis results."""
-    if args.output == "json":
-        # Determine output filename
-        if args.output_file:
-            output_file = args.output_file
-        else:
-            # Auto-generate filename based on query parameters
-            start = results["query"]["start_date"].replace(":", "").replace("-", "")[:8]
-            end = results["query"]["end_date"].replace(":", "").replace("-", "")[:8]
-            output_file = f"temporal_window_analysis_{start}_{end}.json"
-
-        # Auto-generate log filename if not specified
-        if not args.log_file and args.output == "json":
-            log_file = output_file.replace(".json", ".log")
-            file_handler = logging.FileHandler(log_file, mode="w")
-            file_handler.setLevel(logging.DEBUG)
-            file_handler.setFormatter(
-                logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-            )
-            logging.getLogger().addHandler(file_handler)
-            logger.info(f"Auto-generated log file: {log_file}")
-
-        # Format results for JSON serialization
-        formatted_results = _format_temporal_window_json(results, args)
-
-        # Save full results to file
-        with open(output_file, "w") as f:
-            json.dump(formatted_results, f, indent=2)
-
-        # Return summary message
-        summary = results["summary"]
-        log_msg = (
-            f" (logs: {output_file.replace('.json', '.log')})" if not args.log_file else f" (logs: {args.log_file})"
-        )
-        return (
-            f"\nSaved detailed results to: {output_file}{log_msg}\n"
-            f"Summary: {summary['jobs_with_sufficient_inputs']}/{summary['total_acquisition_times']} "
-            f"jobs have sufficient inputs across {summary['total_tiles']} tiles\n"
-        )
-
-    # Text output format
-    lines = []
-    query = results["query"]
-    summary = results["summary"]
-    jobs_by_tile = results["jobs_by_tile"]
-    jobs_by_date = results["jobs_by_date"]
-
-    lines.extend(
-        [
-            "",
-            "=" * 80,
-            "DIST-S1 Temporal Window Job Forecast",
-            "=" * 80,
-            f"Query Period: {query['start_date']} to {query['end_date']}",
-        ]
-    )
-
-    # Add window config info
-    wc = query["window_configs"]
-    lines.append(f"Window Configuration: w1={wc[0][2]}, w2={wc[1][2]}, w3={wc[2][2]} ({wc[0][1]}-day windows)")
-
-    lines.extend(
-        [
-            "",
-            "Summary:",
-            f"  Unique tiles with RTC data: {summary['total_tiles']}",
-            f"  Total acquisition times analyzed: {summary['total_acquisition_times']}",
-            f"  Jobs with sufficient inputs: {summary['jobs_with_sufficient_inputs']}",
-            f"  Jobs with insufficient inputs: {summary['jobs_with_insufficient_inputs']}",
-        ]
-    )
-
-    # Breakdown by tile (top 10 or all if fewer)
-    if jobs_by_tile:
-        lines.extend(
-            [
-                "",
-                "Breakdown by Tile (top 15):",
-            ]
-        )
-
-        # Sort by total jobs (sufficient + insufficient)
-        sorted_tiles = sorted(
-            jobs_by_tile.items(), key=lambda x: x[1]["sufficient"] + x[1]["insufficient"], reverse=True
-        )
-
-        for tile, counts in sorted_tiles[:15]:
-            total = counts["sufficient"] + counts["insufficient"]
-            lines.append(
-                f"  {tile:10s}: {total:3d} jobs ({counts['sufficient']:3d} sufficient, {counts['insufficient']:3d} insufficient)"
-            )
-
-    # Breakdown by date (show all dates with data)
-    if jobs_by_date:
-        lines.extend(
-            [
-                "",
-                "Breakdown by Date:",
-            ]
-        )
-
-        for date_str in sorted(jobs_by_date.keys()):
-            counts = jobs_by_date[date_str]
-            total = counts["sufficient"] + counts["insufficient"]
-            lines.append(
-                f"  {date_str}: {total:3d} jobs ({counts['sufficient']:3d} sufficient, {counts['insufficient']:3d} insufficient)"
-            )
-
-    # Show insufficient jobs if there are any (and not too many)
-    insufficient_jobs = [d for d in results["details"] if not d["is_sufficient"]]
-    if insufficient_jobs and len(insufficient_jobs) <= 20:
-        lines.extend(
-            [
-                "",
-                "Insufficient Jobs (missing data):",
-            ]
-        )
-        for job in insufficient_jobs:
-            lines.append(f"  {job['tile_id']:10s} @ {job['acquisition_time'].isoformat()}: {job['reason']}")
-    elif len(insufficient_jobs) > 20:
-        lines.extend(
-            [
-                "",
-                f"Insufficient Jobs: {len(insufficient_jobs)} jobs have insufficient data",
-                "  (Use --output json --full-output for complete list)",
-            ]
-        )
-
-    lines.extend(["=" * 80, ""])
-
-    return "\n".join(lines)
-
-
-def _format_text_output(results: list[dict], args) -> str:
-    """Format results as human-readable text output."""
-    lines = []
-    if len(results) == 1:
-        # Single query mode
-        result = results[0]
-        tile_id, time, baseline_products = result["tile_id"], result["reference_time"], result["baseline_products"]
-        lines.extend(
-            [
-                "\n" + "=" * 80,
-                "DIST-S1 Baseline Product Selection Results",
-                "=" * 80 + "\n",
-                f"Tile: {tile_id}",
-                f"Acquisition time: {time.isoformat()}",
-                f"Found {len(baseline_products)} baseline products (unique burst+subswath combinations)\n",
-            ]
-        )
-
-        total_files = 0
-        for baseline_id, product in sorted(baseline_products.items()):
-            t0, w1, w2, w3 = product["t0"], product["w1"], product["w2"], product["w3"]
-            baseline_total = len(t0) + len(w1) + len(w2) + len(w3)
-            total_files += baseline_total
-            lines.extend(
-                [
-                    "-" * 80,
-                    f"Baseline: {baseline_id} (burst={product['burst_id']}, subswath={product['subswath']})",
-                    f"Total files: {baseline_total} (t0={len(t0)}, w1={len(w1)}, w2={len(w2)}, w3={len(w3)})",
-                    "",
-                    "  Acquisition Time (t0):",
-                    f"    Files found: {len(t0)}",
-                ]
-            )
-            lines.extend(f"      {g.acquisition_time.isoformat()}: {g.granule_id}" for g in t0) if t0 else lines.append(
-                "      (No granules found)"
-            )
-            lines.append("")
-
-            for window_name, granules, years_back in [("Window 1", w1, 1), ("Window 2", w2, 2), ("Window 3", w3, 3)]:
-                window = calculate_lookback_window(time, years_back, args.window_size)
-                lines.extend(
-                    [
-                        f"  {window_name} (t0 - {years_back} year{'s' if years_back > 1 else ''}):",
-                        f"    Target date: {window.window_end.isoformat()}",
-                        f"    Range: {window.window_start.isoformat()} to {window.window_end.isoformat()}",
-                        f"    Files found: {len(granules)}/{args.max_files[years_back - 1]}",
-                    ]
-                )
-                if granules:
-                    for g in granules:
-                        days = (g.acquisition_time - window.window_end).days
-                        lines.append(
-                            f"      {g.acquisition_time.isoformat()} ({'+' if days >= 0 else ''}{days}d): {g.granule_id}"
-                        )
-                else:
-                    lines.append("      (No granules found)")
-                lines.append("")
-
-        lines.extend(
-            [
-                "=" * 80,
-                f"Total baselines: {len(baseline_products)}",
-                f"Total files selected: {total_files}",
-                "=" * 80 + "\n",
-            ]
-        )
-
-    else:
-        # Batch mode
-        lines.extend(["\n" + "=" * 80, "DIST-S1 Baseline Product Selection Results (Batch)", "=" * 80 + "\n"])
-        grand_total_files = grand_total_baselines = 0
-        for i, result in enumerate(results, 1):
-            baseline_products = result["baseline_products"]
-            result_total_files = sum(
-                len(p["t0"]) + len(p["w1"]) + len(p["w2"]) + len(p["w3"]) for p in baseline_products.values()
-            )
-            lines.extend(
-                [
-                    f"[{i}/{len(results)}] {result['tile_id']},{result['reference_time'].isoformat()} {len(baseline_products)} baselines"
-                ]
-            )
-            grand_total_files += result_total_files
-            grand_total_baselines += len(baseline_products)
-
-        # Add section for products needing retriggering (successful queries with sufficient inputs)
-        lines.extend(
-            [
-                "",
-                "Products Needing Retriggering:",
-                "=" * 80,
-            ]
-        )
-
-        if results:
-            lines.append("Format: tile_id,acquisition_time")
-            lines.append("")
-            for result in results:
-                tile_id = result["tile_id"]
-                acq_time = result["reference_time"]
-                # Add acquisition group if present
-                if "acq_group" in result and result["acq_group"]:
-                    formatted_tile_id = f"{tile_id}_{result['acq_group']}"
-                else:
-                    formatted_tile_id = tile_id
-                # Format as tile_id,timestamp (same format as input for easy copy-paste)
-                lines.append(f"{formatted_tile_id},{acq_time.strftime('%Y%m%dT%H%M%SZ')}")
-
-            lines.append("")
-            lines.append(f"Total products to retrigger: {len(results)}")
-        else:
-            lines.append("(None - all queried products have insufficient inputs)")
-
-        lines.extend(
-            [
-                "=" * 80 + "\n",
-            ]
-        )
-
-    return "\n".join(lines)
 
 
 async def main():
@@ -2503,13 +1596,6 @@ Examples:
         help="Maximum number of concurrent queries in batch mode (default: 3). Note: each query makes 3 CMR requests (one per window).",
     )
 
-    parser.add_argument(
-        "--use-rtc-cache",
-        action="store_true",
-        dest="use_rtc_cache",
-        help="Use GRQ RTC Cache. Only available when running in cluster",
-    )
-
     args = parser.parse_args()
 
     # Set up file logging if requested
@@ -2548,16 +1634,6 @@ Examples:
         (3, args.window_size, args.max_files[2]),  # w3: 3 years back
     ]
 
-    # Try to establish RTC cache connection (only available when deployed)
-    if args.use_rtc_cache:
-        grq_es = get_rtc_cache_connection()
-    else:
-        grq_es = None
-    if grq_es:
-        logger.info("RTC cache connection established - queries will use cache with CMR fallback")
-    else:
-        logger.info("RTC cache not available - queries will use CMR directly")
-
     # Handle temporal window mode
     if args.temporal_window:
         results = await query_temporal_window_jobs(
@@ -2565,10 +1641,9 @@ Examples:
             end_date=args.end_date,
             window_configs=window_configs,
             max_concurrent=args.max_concurrent,
-            grq_es=grq_es,
         )
 
-        output = _format_temporal_window_output(results, args)
+        output = format_temporal_window_output(results, args)
         print(output)
         return
 
@@ -2614,7 +1689,6 @@ Examples:
             tile_id=tile_id,
             time=time,
             window_configs=window_configs,
-            grq_es=grq_es,
         )
 
         if not result:
@@ -2628,7 +1702,6 @@ Examples:
             parsed_items=parsed_items,
             window_configs=window_configs,
             max_concurrent=args.max_concurrent,
-            grq_es=grq_es,
         )
 
         # Save list of known missing products
@@ -2651,7 +1724,7 @@ Examples:
 
     # Format and output results
     if args.output == "json":
-        output = _format_json_output(results, args)
+        output = format_json_output(results, args)
         json_str = json.dumps(output, indent=2)
 
         if args.output_file:
@@ -2664,14 +1737,14 @@ Examples:
         else:
             print(json_str)
     elif args.output == "ids":
-        formatted_ids = _format_ids_output(results)
+        formatted_ids = format_ids_output(results)
         if args.output_file:
             with open(args.output_file, "w") as f:
                 f.write(formatted_ids)
         else:
             print(formatted_ids)
     else:
-        print(_format_text_output(results, args))
+        print(format_text_output(results, args))
 
 
 if __name__ == "__main__":

--- a/tools/ops/cmr_audit/cmr_audit_disp_s1_static.py
+++ b/tools/ops/cmr_audit/cmr_audit_disp_s1_static.py
@@ -3,6 +3,7 @@ import asyncio
 import json
 import logging.handlers
 import sys
+import tempfile
 from pathlib import Path, PurePath
 from datetime import datetime
 
@@ -11,7 +12,7 @@ import pandas as pd
 from dateutil.parser import isoparse
 
 from data_subscriber.cmr import async_query_cmr_v2
-from tools.ops.cmr_audit.cmr_audit_utils import init_logging
+from tools.ops.cmr_audit.cmr_audit_utils import extract_native_ids, init_logging
 
 logging.getLogger("elasticsearch").setLevel(level=logging.WARNING)
 
@@ -62,14 +63,16 @@ def main(
         df = df[df["is_north_america"] == filter_is_north_america]
         source_frames = set(df.index)
 
-    cmr_products = asyncio.run(
-        async_query_cmr_v2(timerange=None, provider="ASF", collection="OPERA_L3_DISP-S1-STATIC_PROVISIONAL_V0",
-                           cmr_hostname="cmr.uat.earthdata.nasa.gov")
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        paths = asyncio.run(
+            async_query_cmr_v2(timerange=None, provider="ASF", collection="OPERA_L3_DISP-S1-STATIC_PROVISIONAL_V0",
+                               cmr_hostname="cmr.uat.earthdata.nasa.gov", output_dir=tmpdir)
+        )
+        native_ids = extract_native_ids(paths)
 
     # e.g. native-id: 'OPERA_L3_DISP-S1-STATIC_F16938_20140403_S1A_v1.0'
     # skip "F" prefix and leading '0' for the frame number
-    cmr_frames = {str(int(p["meta"]["native-id"].split("_")[3][1:])) for p in cmr_products}
+    cmr_frames = {str(int(nid.split("_")[3][1:])) for nid in native_ids}
     coverage = source_frames - cmr_frames
 
     logging.info(f"Number of frames in frames-to-burst DB JSON: {len(source_frames)}")

--- a/tools/ops/cmr_audit/cmr_audit_dist_s1.py
+++ b/tools/ops/cmr_audit/cmr_audit_dist_s1.py
@@ -30,6 +30,7 @@ End-to-End Usage:
 import argparse
 import asyncio
 import logging
+import logging.handlers
 import os
 import re
 import subprocess
@@ -107,8 +108,8 @@ def create_parser():
     argparser.add_argument(
         "--max-concurrent",
         type=int,
-        default=10,
-        help="Maximum number of concurrent iso.xml downloads (default: %(default)s)",
+        default=None,
+        help="Maximum number of concurrent iso.xml downloads (default: 50 on EC2/S3, 10 otherwise)",
     )
     argparser.add_argument(
         "--max-retries",
@@ -161,7 +162,6 @@ def extract_iso_xml_url(product: dict, use_s3: bool) -> str:
         if url.startswith("s3://") and url.endswith("iso.xml"):
             s3_url = url
             if use_s3:
-                logger.debug(f"Using S3 URL: {s3_url}")
                 return s3_url
 
         # Check for HTTPS URL
@@ -169,15 +169,12 @@ def extract_iso_xml_url(product: dict, use_s3: bool) -> str:
             # Temporarily replace earthdatacloud.nasa.gov portion with alaska.edu for HTTPS
             https_url = url.replace("earthdatacloud.nasa.gov", "alaska.edu")
             if not use_s3:
-                logger.debug(f"Using HTTPS URL: {https_url}")
                 return https_url
 
     # Return the first URL found based on availability
     if s3_url:
-        logger.debug(f"Using S3 URL: {s3_url}")
         return s3_url
     elif https_url:
-        logger.debug(f"Using HTTPS URL: {https_url}")
         return https_url
 
     raise RuntimeError(f"No iso.xml URL found for {product['meta']['native-id']}")
@@ -472,7 +469,7 @@ async def fetch_dist_product_inputs(
 
 
 async def query_and_format_dist_s1_async(
-    timerange: DateTimeRange, cmr_env: str, max_concurrent: int = 10, max_retries: int = 3
+    timerange: DateTimeRange, cmr_env: str, max_concurrent: Optional[int] = None, max_retries: int = 3
 ) -> tuple:
     """
     Query CMR for DIST-S1 products and return a DataFrame and a set of existing tile+time combinations.
@@ -554,34 +551,44 @@ async def query_and_format_dist_s1_async(
 
     use_s3 = use_s3_urls()
 
+    # Resolve concurrency default based on environment if not explicitly set
+    if max_concurrent is None:
+        max_concurrent = 50 if use_s3 else 10
+        logger.info(f"Auto-detected max_concurrent={max_concurrent} (use_s3={use_s3})")
+
     logger.info(
         f"Obtaining iso.xml files for {len(cmr_dist_products)} DIST-S1 products (use_s3={use_s3}, parallel, max_concurrent={max_concurrent}, max_retries={max_retries})"
     )
 
-    # Fetch all iso.xml files in parallel with concurrency limit
+    # Fetch iso.xml files in batches to limit memory usage
     semaphore = asyncio.Semaphore(max_concurrent)
-    tasks = [
-        fetch_dist_product_inputs(dist_product, semaphore, max_retries, use_s3) for dist_product in cmr_dist_products
-    ]
-    results = await asyncio.gather(*tasks)
+    batch_size = max_concurrent * 5
+    pairs = []
+    successful_fetches = 0
 
-    # Filter out None results (failed fetches)
-    dist_s1_audit_data = {r["native_id"]: r for r in results if r is not None}
+    for i in range(0, len(cmr_dist_products), batch_size):
+        batch = cmr_dist_products[i:i + batch_size]
+        tasks = [
+            fetch_dist_product_inputs(dist_product, semaphore, max_retries, use_s3)
+            for dist_product in batch
+        ]
+        results = await asyncio.gather(*tasks)
 
-    logger.info(f"Successfully obtained iso.xml for {len(dist_s1_audit_data)} / {len(cmr_dist_products)} products")
+        for r in results:
+            if r is not None:
+                successful_fetches += 1
+                for rtc_id in r["input_granules"]:
+                    pairs.append((rtc_id, r["native_id"]))
 
-    pairs = [
-        (rtc_id, dist_record["native_id"])
-        for dist_record in dist_s1_audit_data.values()
-        for rtc_id in dist_record["input_granules"]
-    ]
+    logger.info(f"Successfully obtained iso.xml for {successful_fetches} / {len(cmr_dist_products)} products")
+
     output_rtc_df = pd.DataFrame(pairs, columns=["rtc_id", "parent_dist_native_id"]).set_index("rtc_id")
 
     return output_rtc_df, existing_tile_times
 
 
 def query_and_format_dist_s1(
-    timerange: DateTimeRange, cmr_env: str, max_concurrent: int = 10, max_retries: int = 3
+    timerange: DateTimeRange, cmr_env: str, max_concurrent: Optional[int] = None, max_retries: int = 3
 ) -> tuple:
     """
     Query CMR for DIST-S1 products and return a DataFrame and a set of existing tile+time combinations.
@@ -589,7 +596,7 @@ def query_and_format_dist_s1(
     Args:
         timerange: Time range to query within
         cmr_env: CMR environment to query (PROD or UAT)
-        max_concurrent: Maximum number of concurrent downloads
+        max_concurrent: Maximum number of concurrent downloads (None = auto-detect based on environment)
         max_retries: Maximum number of retry attempts
 
     Returns:
@@ -605,7 +612,7 @@ def reduce_product_id_times(df: pd.DataFrame) -> pd.DataFrame:
     Collapse product_id_time entries into one representative "<mgrs_tile_id_acq_group>,<timestamp>" per cluster.
 
     Each product_id_time entry is a string "<mgrs_tile_id_acq_group>,<timestamp>" or a list of such strings.
-    Timestamps within the same mgrs_tile_id_acq_group are clustered when they occur ≤3 minutes apart.
+    Timestamps within the same mgrs_tile_id_acq_group are clustered when they occur ≤10 minutes apart.
     The earliest timestamp in each cluster is selected.
 
     Returns
@@ -625,7 +632,7 @@ def reduce_product_id_times(df: pd.DataFrame) -> pd.DataFrame:
     df["cluster"] = (
         df.groupby("mgrs_tile_id_acq_group")["ts"]  # group by mgrs_tile_id_acq_group
         .diff()  # time since previous value
-        .gt(pd.Timedelta(minutes=10))  # is the gap > 3 minutes?
+        .gt(pd.Timedelta(minutes=10))  # is the gap > 10 minutes?
         .fillna(True)  # first row always starts cluster
         .cumsum()  # assign cluster IDs
     )
@@ -702,7 +709,7 @@ def main(start_datetime: datetime = None, end_datetime: datetime = None, **kwarg
         cmr_env = kwargs.get("cmr_environment")
         rtc_organization = kwargs.get("rtc_output")
         full_output = kwargs.get("full_output")
-        max_concurrent = kwargs.get("max_concurrent", 10)
+        max_concurrent = kwargs.get("max_concurrent")
         max_retries = kwargs.get("max_retries", 3)
 
         # Get options for dist_s1_input_tool integration
@@ -780,65 +787,45 @@ def main(start_datetime: datetime = None, end_datetime: datetime = None, **kwarg
         # Filter out tile+time combinations that already have a DIST-S1 product
         if existing_tile_times:
             logger.info(
-                f"Checking {len(missing_dist_df)} potential missing products against {len(existing_tile_times)} existing tile+time combinations"
+                f"Checking {len(missing_dist_df)} potential missing products against "
+                f"{len(existing_tile_times)} existing tile+time combinations"
             )
-        else:
-            logger.warning("WARNING: No existing tile+time combinations to filter against!")
-
-            # Log a sample of what we're looking for
-            if len(existing_tile_times) > 0:
-                sample_existing = list(existing_tile_times)[:3]  # Take up to 3 examples
-                logger.debug(f"Sample existing tile+time combinations: {sample_existing}")
-                # Check the format of the existing tile+time combinations
-                logger.debug(
-                    f"Format of existing tile+time combinations: {type(next(iter(existing_tile_times))).__name__} - {next(iter(existing_tile_times))}"
-                )
-
-            if len(missing_dist_df) > 0:
-                # Log a sample of product_id_time values to verify format
-                sample_rows = missing_dist_df.head(3)
-                for _, row in sample_rows.iterrows():
-                    pid_times = row["product_id_time"]
-                    logger.debug(
-                        f"Sample potential missing product: mgrs={row['mgrs_tile_id_acq_group']}, product_id_time={pid_times}"
-                    )
-
-                    # Check the format of the product_id_time values
-                    if pid_times:
-                        first_pid = pid_times[0] if isinstance(pid_times, list) else pid_times
-                        logger.debug(f"Format of product_id_time: {type(first_pid).__name__} - {first_pid}")
 
             original_count = len(missing_dist_df)
             filtered_rows = []
 
-            # Instead of direct filtering, we'll check each row individually for debugging
             for idx, row in missing_dist_df.iterrows():
                 pid_times = row["product_id_time"]
                 pid_times_list = pid_times if isinstance(pid_times, list) else [pid_times]
 
-                # Check if any product_id_time value matches an existing tile+time
+                # Derive tile-only keys for comparison against existing_tile_times.
+                # product_id_time entries have format "<tile_id>_<acq_group>,<timestamp>"
+                # but existing_tile_times has format "<tile_id>,<timestamp>" (no acq_group).
                 matches_found = False
                 for pid_time in pid_times_list:
-                    if pid_time in existing_tile_times:
+                    # Extract tile_id and timestamp from "55GCQ_1,20250501T120000Z"
+                    mgrs_acq_group, _, timestamp = pid_time.partition(",")
+                    tile_id = mgrs_acq_group.rsplit("_", 1)[0]
+                    tile_time_key = f"{tile_id},{timestamp}"
+
+                    if tile_time_key in existing_tile_times:
                         matches_found = True
-                        logger.debug(f"Match found: {pid_time} exists in both missing and existing sets")
+                        logger.debug(f"Filtering: {pid_time} matches existing product at {tile_time_key}")
                         break
 
                 if not matches_found:
                     filtered_rows.append(idx)
-                else:
-                    logger.debug(
-                        f"Filtering out row with mgrs={row['mgrs_tile_id_acq_group']} (found in existing products)"
-                    )
 
-            # Create a new DataFrame with only the non-matching rows
             missing_dist_df = missing_dist_df.loc[filtered_rows]
 
             filtered_count = original_count - len(missing_dist_df)
             logger.info(
-                f"Filtered out {filtered_count} false positives (tile+time combinations that already have a DIST-S1 product)"
+                f"Filtered out {filtered_count} false positives "
+                f"(tile+time combinations that already have a DIST-S1 product)"
             )
-            logger.info(f"Potential missing products: {len(missing_dist_df)}")
+            logger.info(f"Potential missing products after filtering: {len(missing_dist_df)}")
+        else:
+            logger.warning("No existing tile+time combinations to filter against — skipping false-positive removal")
 
     if full_output:
         if rtc_organization:
@@ -893,5 +880,6 @@ def main(start_datetime: datetime = None, end_datetime: datetime = None, **kwarg
 if __name__ == "__main__":
     args = create_parser().parse_args(sys.argv[1:])
     init_logging("cmr_audit_dist_s1.log", "cmr_audit_dist_s1-error.log", level=args.log_level)
+    logger.setLevel(args.log_level)
     logger.debug(f"{__file__} invoked with {sys.argv=}")
     main(**vars(args))

--- a/tools/ops/cmr_audit/cmr_audit_dist_s1.py
+++ b/tools/ops/cmr_audit/cmr_audit_dist_s1.py
@@ -35,6 +35,7 @@ import os
 import re
 import subprocess
 import sys
+import tempfile
 import time
 import xml.etree.ElementTree as ET
 from collections import namedtuple
@@ -59,7 +60,7 @@ mock_module.load_mgrs_track_frame_db = lambda *args, **kwargs: None
 sys.modules["data_subscriber.gcov_utils"] = mock_module
 
 from data_subscriber.cmr import async_query_cmr_v2
-from tools.ops.cmr_audit.cmr_audit_utils import init_logging
+from tools.ops.cmr_audit.cmr_audit_utils import extract_fields, init_logging
 
 logging.getLogger("elasticsearch").setLevel(level=logging.WARNING)
 logger = logging.getLogger(__name__)
@@ -407,21 +408,24 @@ def normalize_tile_time_key(tile_id, timestamp):
 def query_and_format_rtc(timerange: DateTimeRange) -> pd.DataFrame:
     """Query CMR for RTC products and return as a DataFrame."""
     try:
-        cmr_rtc_products = asyncio.run(
-            async_query_cmr_v2(timerange=timerange, provider="ASF", collection="OPERA_L2_RTC-S1_V1")
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rtc_paths = asyncio.run(
+                async_query_cmr_v2(timerange=timerange, provider="ASF", collection="OPERA_L2_RTC-S1_V1",
+                                   output_dir=tmpdir)
+            )
+            rtc_records = extract_fields(rtc_paths, ["meta.native-id", "meta.revision-id", "meta.revision-date"])
     except Exception as e:
         logger.exception("Failed to query RTC products from CMR")
         raise RuntimeError("RTC CMR query failed") from e
 
-    if not cmr_rtc_products:
+    if not rtc_records:
         raise RuntimeError("RTC CMR query returned no results")
 
     rtc_audit_data = []
-    for rtc_product in cmr_rtc_products:
-        native_id = rtc_product["meta"].get("native-id")
+    for record in rtc_records:
+        native_id = record.get("meta.native-id")
         if not native_id:
-            logger.warning(f"Unable to extract native_id from {rtc_product['meta']}. Skipping.")
+            logger.warning(f"Unable to extract native_id from record. Skipping.")
             continue
 
         burst_id = extract_rtc_burst(native_id)
@@ -433,8 +437,8 @@ def query_and_format_rtc(timerange: DateTimeRange) -> pd.DataFrame:
         rtc_audit_data.append(
             {
                 "native_id": native_id,
-                "revision_id": rtc_product["meta"].get("revision-id"),
-                "revision_date": rtc_product["meta"].get("revision-date"),
+                "revision_id": record.get("meta.revision-id"),
+                "revision_date": record.get("meta.revision-date"),
                 "burst_id": burst_id,
                 "bid_acq": bid_acq,
             }
@@ -499,19 +503,28 @@ async def query_and_format_dist_s1_async(
         raise RuntimeError(f"CMR environment {cmr_env} is not supported")
 
     try:
-        cmr_dist_products = await async_query_cmr_v2(
-            timerange=timerange,
-            provider="ASF",
-            collection=DIST_S1_COLLECTION,
-            cmr_hostname=cmr_hostname,
-        )
+        with tempfile.TemporaryDirectory() as tmpdir:
+            dist_paths = await async_query_cmr_v2(
+                timerange=timerange,
+                provider="ASF",
+                collection=DIST_S1_COLLECTION,
+                cmr_hostname=cmr_hostname,
+                output_dir=tmpdir,
+            )
+            dist_records = extract_fields(dist_paths, ["meta.native-id", "umm.RelatedUrls"])
     except Exception as e:
         logger.exception("Failed to query DIST-S1 products from CMR")
         raise RuntimeError("DIST-S1 CMR query failed") from e
 
-    if not cmr_dist_products:
+    if not dist_records:
         logger.info("DIST-S1 CMR query returned no results")
         return pd.DataFrame([], columns=["rtc_id", "parent_dist_native_id"]).set_index("rtc_id"), set()
+
+    # Reconstruct minimal product dicts for downstream processing
+    cmr_dist_products = [
+        {"meta": {"native-id": r["meta.native-id"]}, "umm": {"RelatedUrls": r["umm.RelatedUrls"]}}
+        for r in dist_records
+    ]
 
     # Extract tile+time combinations from all DIST-S1 products
     existing_tile_times = set()

--- a/tools/ops/cmr_audit/cmr_audit_dist_s1.py
+++ b/tools/ops/cmr_audit/cmr_audit_dist_s1.py
@@ -30,7 +30,6 @@ End-to-End Usage:
 import argparse
 import asyncio
 import logging
-import logging.handlers
 import os
 import re
 import subprocess
@@ -51,7 +50,6 @@ from dateutil.parser import isoparse
 from requests.exceptions import RequestException
 
 # Avoid importing gcov_utils (No need for DIST-S1)
-import sys
 import types
 
 mock_module = types.ModuleType("data_subscriber.gcov_utils")
@@ -128,17 +126,6 @@ def create_parser():
         default="INFO",
         choices=("DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"),
         help="Logging level (default: %(default)s)",
-    )
-    argparser.add_argument(
-        "--log-dir",
-        default=".",
-        help="Directory to save validation log files (default: current directory)",
-    )
-    argparser.add_argument(
-        "--save-log",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Save log output to a log file",
     )
     return argparser
 
@@ -700,13 +687,7 @@ def run_dist_s1_input_tool(input_file_path: str) -> int:
     except Exception as e:
         logger.error(f"Error running dist_s1_input_tool.py: {e}")
         return 1
-    finally:
-        # Close and remove handlers to avoid resource leaks
-        for handler in logger.handlers[:]:
-            handler.close()
-            logger.removeHandler(handler)
 
-    # Log the completion
     logger.info("---------- dist_s1_input_tool.py output END ----------")
 
     return return_code
@@ -726,26 +707,6 @@ def main(start_datetime: datetime = None, end_datetime: datetime = None, **kwarg
 
         # Get options for dist_s1_input_tool integration
         run_input_validation = kwargs.get("run_input_validation", False)
-        log_dir = kwargs.get("log_dir", ".")
-        save_log = kwargs.get("save_log", False)
-
-        # Add a file handler if log saving is enabled
-        if save_log:
-            # Ensure log directory exists
-            if not os.path.exists(log_dir):
-                os.makedirs(log_dir, exist_ok=True)
-                logger.info(f"Created log directory: {log_dir}")
-
-            # Create full path to log file
-            timestamp = datetime.now().strftime("%Y%m%dT%H%M%SZ")
-            log_filename = os.path.join(log_dir, f"dist_s1_audit_{timestamp}.log")
-
-            # Create file handler
-            file_handler = logging.FileHandler(log_filename)
-            file_handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
-            logger.addHandler(file_handler)
-
-            logger.info(f"Saving output to log file: {log_filename}")
 
         # Get both the DataFrame and the set of existing tile+time combinations
         output_rtc_df, existing_tile_times = query_and_format_dist_s1(timerange, cmr_env, max_concurrent, max_retries)
@@ -924,22 +885,13 @@ def main(start_datetime: datetime = None, end_datetime: datetime = None, **kwarg
             logger.info("Running input validation with dist_s1_input_tool.py")
             ret_code = run_dist_s1_input_tool(output_path)
             if ret_code == 0:
-                if save_log:
-                    logger.info(f"Input validation complete successfully - log saved to {log_filename}")
-                else:
-                    logger.info("Input validation complete successfully")
+                logger.info("Input validation complete successfully")
             else:
-                logger.warning(f"Input validation completed with return code {ret_code}")
-                if save_log:
-                    logger.error(
-                        f"Input validation completed with return code {ret_code} - log saved to {log_filename}"
-                    )
-                else:
-                    logger.error(f"Input validation completed with return code {ret_code}")
+                logger.error(f"Input validation completed with return code {ret_code}")
 
 
 if __name__ == "__main__":
     args = create_parser().parse_args(sys.argv[1:])
-    # init_logging("cmr_audit_dist_s1.log", "cmr_audit_dist_s1-error.log", level=args.log_level)
-    # logger.debug(f"{__file__} invoked with {sys.argv=}")
+    init_logging("cmr_audit_dist_s1.log", "cmr_audit_dist_s1-error.log", level=args.log_level)
+    logger.debug(f"{__file__} invoked with {sys.argv=}")
     main(**vars(args))

--- a/tools/ops/cmr_audit/cmr_audit_dswx_s1.py
+++ b/tools/ops/cmr_audit/cmr_audit_dswx_s1.py
@@ -3,6 +3,7 @@ import asyncio
 import logging.handlers
 import re
 import sys
+import tempfile
 from collections import defaultdict, namedtuple
 from datetime import datetime, timezone
 from functools import reduce
@@ -13,7 +14,7 @@ from dateutil.parser import isoparse
 import rtc_utils
 from data_subscriber.cmr import async_query_cmr_v2
 from data_subscriber.rtc import mgrs_bursts_collection_db_client
-from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, init_logging
+from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, extract_fields, init_logging
 
 logging.getLogger("elasticsearch").setLevel(level=logging.WARNING)
 
@@ -81,25 +82,36 @@ def main(start_datetime: datetime=None, end_datetime:datetime=None, **kwargs):
 
     timerange = DateTimeRange(start_date, end_date)
 
-    # cmr_products = asyncio.run(
-    #     async_query_cmr_v2(timerange=timerange, provider="ASF", collection="OPERA_L2_RTC-S1_V1")
-    # )
-
-    cmr_granule_ids, cmr_products = asyncio.run(
-        async_get_cmr_granules(
-            collection_short_name="OPERA_L2_RTC-S1_V1",
-            temporal_date_start=timerange.start_date,
-            temporal_date_end=timerange.end_date,
-            platform_short_name=None,
-            concurrency=5
+    with tempfile.TemporaryDirectory() as tmpdir:
+        rtc_paths = asyncio.run(
+            async_get_cmr_granules(
+                collection_short_name="OPERA_L2_RTC-S1_V1",
+                temporal_date_start=timerange.start_date,
+                temporal_date_end=timerange.end_date,
+                platform_short_name=None,
+                concurrency=5,
+                output_dir=tmpdir
+            )
         )
-    )
-    cmr_products = cmr_products.values()
 
-    # CONVERT INTO AUDIT MODEL
+        dswx_paths = asyncio.run(
+            async_get_cmr_granules(
+                collection_short_name="OPERA_L3_DSWX-S1_V1",
+                temporal_date_start=timerange.start_date,
+                temporal_date_end=timerange.end_date,
+                platform_short_name=None,
+                concurrency=5,
+                output_dir=tmpdir
+            )
+        )
+
+        rtc_details = extract_fields(rtc_paths, ["meta.native-id", "meta.revision-id", "meta.revision-date"])
+        dswx_details = extract_fields(dswx_paths, ["meta.native-id", "meta.revision-id", "meta.revision-date", "umm.InputGranules"])
+
+    # CONVERT INTO AUDIT MODEL (RTC)
     rtc_audit_data = []
-    for cmr_product in cmr_products:
-        native_id = cmr_product["meta"]["native-id"]
+    for record in rtc_details:
+        native_id = record["meta.native-id"]
         burst_id = native_id[16:31]
         burst_id_normalized = burst_id.lower().replace("-","_")
         mgrs_set_ids = burst_id_to_mgrs_set_ids_map[burst_id_normalized]
@@ -109,8 +121,8 @@ def main(start_datetime: datetime=None, end_datetime:datetime=None, **kwargs):
         acquisition_cycle = rtc_utils.determine_acquisition_cycle_for_rtc_granule(granule_id=native_id)
         audit_data = {
             "native_id": native_id,  # e.g. "OPERA_L2_RTC-S1_T168-359595-IW3_20250516T053145Z_20250516T155714Z_S1A_30_v1.0"
-            "revision_id": cmr_product["meta"]["revision-id"],
-            "revision_date": cmr_product["meta"]["revision-date"],
+            "revision_id": record["meta.revision-id"],
+            "revision_date": record["meta.revision-date"],
             "burst_id": burst_id,
             "burst_id_normalized": burst_id_normalized,
             "bid_acq": native_id[16:48],  # e.g. "T168-359595-IW3_20250516T053145Z"
@@ -132,25 +144,10 @@ def main(start_datetime: datetime=None, end_datetime:datetime=None, **kwargs):
 
     ########################################################################################################
 
-    # cmr_products = asyncio.run(
-    #     async_query_cmr_v2(timerange=timerange, provider="POCLOUD", collection="OPERA_L3_DSWX-S1_V1")
-    # )
-
-    cmr_granule_ids, cmr_products = asyncio.run(
-        async_get_cmr_granules(
-            collection_short_name="OPERA_L3_DSWX-S1_V1",
-            temporal_date_start=timerange.start_date,
-            temporal_date_end=timerange.end_date,
-            platform_short_name=None,
-            concurrency=5
-        )
-    )
-    cmr_products = cmr_products.values()
-
-    # CONVERT INTO AUDIT MODEL
+    # CONVERT INTO AUDIT MODEL (DSWx-S1)
     dswx_s1_audit_data = {}
-    for cmr_product in cmr_products:
-        input_granules = {re.match(rtc_utils.rtc_granule_regex, g).group("id") for g in cmr_product["umm"]["InputGranules"]}
+    for record in dswx_details:
+        input_granules = {re.match(rtc_utils.rtc_granule_regex, g).group("id") for g in record["umm.InputGranules"]}
         input_granule_burst_ids_normalized = {g[16:31].lower().replace("-", "_") for g in input_granules}
 
         related_mgrs_set_ids = [
@@ -159,11 +156,11 @@ def main(start_datetime: datetime=None, end_datetime:datetime=None, **kwargs):
         ]
         mgrs_set_id = reduce(set.intersection, related_mgrs_set_ids)  # EDGE CASE: len(2)
 
-        native_id = cmr_product["meta"]["native-id"]
+        native_id = record["meta.native-id"]
         audit_data = {
             "native_id": native_id,  # e.g. "OPERA_L3_DSWx-S1_T55GCQ_20250512T193408Z_20250513T064736Z_S1A_30_v1.0"
-            "revision_id": cmr_product["meta"]["revision-id"],
-            "revision_date": cmr_product["meta"]["revision-date"],
+            "revision_id": record["meta.revision-id"],
+            "revision_date": record["meta.revision-date"],
             "input_granules": input_granules,
             "input_granule_burst_ids": {g[16:31] for g in input_granules},
             "input_granule_burst_ids_normalized": input_granule_burst_ids_normalized,

--- a/tools/ops/cmr_audit/cmr_audit_hls.py
+++ b/tools/ops/cmr_audit/cmr_audit_hls.py
@@ -6,6 +6,7 @@ import logging.handlers
 import os
 import re
 import sys
+import tempfile
 import urllib.parse
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
@@ -17,7 +18,7 @@ from dateutil.parser import isoparse
 from dotenv import dotenv_values
 from more_itertools import always_iterable
 
-from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, get_cmr_audit_granules, init_logging
+from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, get_cmr_audit_granules, extract_native_ids, init_logging
 
 logging.getLogger("compact_json.formatter").setLevel(level=logging.INFO)
 logging.basicConfig(
@@ -73,16 +74,18 @@ def argparse_dt(dt_str):
 # CMR AUDIT FUNCTIONS
 #######################################################################
 
-async def async_get_cmr_granules_hls_l30(temporal_date_start: str, temporal_date_end: str):
+async def async_get_cmr_granules_hls_l30(temporal_date_start: str, temporal_date_end: str, output_dir=None):
     return await async_get_cmr_granules(collection_short_name="HLSL30",
                                         temporal_date_start=temporal_date_start, temporal_date_end=temporal_date_end,
-                                        platform_short_name=["LANDSAT-8", "LANDSAT-9"])
+                                        platform_short_name=["LANDSAT-8", "LANDSAT-9"],
+                                        output_dir=output_dir)
 
 
-async def async_get_cmr_granules_hls_s30(temporal_date_start: str, temporal_date_end: str):
+async def async_get_cmr_granules_hls_s30(temporal_date_start: str, temporal_date_end: str, output_dir=None):
     return await async_get_cmr_granules(collection_short_name="HLSS30",
                                         temporal_date_start=temporal_date_start, temporal_date_end=temporal_date_end,
-                                        platform_short_name=["Sentinel-2A", "Sentinel-2B", "Sentinel-2C"])
+                                        platform_short_name=["Sentinel-2A", "Sentinel-2B", "Sentinel-2C"],
+                                        output_dir=output_dir)
 
 
 async def async_get_cmr_dswx(rtc_native_id_patterns: set, temporal_date_start: str, temporal_date_end: str):
@@ -214,11 +217,11 @@ async def run(start_datetime: datetime = None, end_datetime: datetime = None, fo
     cmr_start_dt_str = start_datetime.isoformat().replace("+00:00", "Z")
     cmr_end_dt_str = end_datetime.isoformat().replace("+00:00", "Z")
 
-    cmr_granules_l30, cmr_granules_l30_details = await async_get_cmr_granules_hls_l30(temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str)
-    cmr_granules_s30, cmr_granules_s30_details = await async_get_cmr_granules_hls_s30(temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        l30_paths = await async_get_cmr_granules_hls_l30(temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str, output_dir=tmpdir)
+        s30_paths = await async_get_cmr_granules_hls_s30(temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str, output_dir=tmpdir)
 
-    cmr_granules_hls = cmr_granules_l30.union(cmr_granules_s30)
-    cmr_granules_details = {}; cmr_granules_details.update(cmr_granules_l30_details); cmr_granules_details.update(cmr_granules_s30_details)
+        cmr_granules_hls = extract_native_ids(l30_paths).union(extract_native_ids(s30_paths))
     logger.info(f"Expected input (granules): {len(cmr_granules_hls)=:,}")
 
     dswx_native_id_patterns = hls_granule_ids_to_dswx_native_id_patterns(

--- a/tools/ops/cmr_audit/cmr_audit_hls.py
+++ b/tools/ops/cmr_audit/cmr_audit_hls.py
@@ -88,16 +88,18 @@ async def async_get_cmr_granules_hls_s30(temporal_date_start: str, temporal_date
                                         output_dir=output_dir)
 
 
-async def async_get_cmr_dswx(rtc_native_id_patterns: set, temporal_date_start: str, temporal_date_end: str):
+async def async_get_cmr_dswx(rtc_native_id_patterns: set, temporal_date_start: str, temporal_date_end: str, output_dir=None):
     return await async_get_cmr(rtc_native_id_patterns, collection_short_name="OPERA_L3_DSWX-HLS_V1",
-                               temporal_date_start=temporal_date_start, temporal_date_end=temporal_date_end)
+                               temporal_date_start=temporal_date_start, temporal_date_end=temporal_date_end,
+                               output_dir=output_dir)
 
 
 async def async_get_cmr(
         native_id_patterns: set,
         collection_short_name: Union[str, Iterable[str]],
         temporal_date_start: str, temporal_date_end: str,
-        chunk_size=1000
+        chunk_size=1000,
+        output_dir=None
 ):
     logger.debug(f"entry({len(native_id_patterns)=:,})")
 
@@ -121,12 +123,14 @@ async def async_get_cmr(
                 f"&temporal[]={urllib.parse.quote(temporal_date_start, safe='/:')},{urllib.parse.quote(temporal_date_end, safe='/:')}"
             )
             logger.debug(f"Creating request task {i} of {len(native_id_pattern_batches)}")
-            post_cmr_tasks.append(get_cmr_audit_granules(request_url, request_body, session, sem))
+            output_path = os.path.join(output_dir, f"dswx_batch_{i}.jsonl") if output_dir else None
+            post_cmr_tasks.append(get_cmr_audit_granules(request_url, request_body, session, sem, output_path=output_path))
             break
         logger.debug(f"Number of requests to make: {len(post_cmr_tasks)=}")
 
         # issue requests in batches
         logger.debug("Batching tasks")
+        paths = []
         cmr_granules = set()
         task_chunks = list(more_itertools.chunked(post_cmr_tasks, len(post_cmr_tasks)))  # CMR recommends 2-5 threads.
         for i, task_chunk in enumerate(task_chunks, start=1):
@@ -136,7 +140,13 @@ async def async_get_cmr(
                 await asyncio.gather(*task_chunk, return_exceptions=False)
             )
             for post_cmr_tasks_result in post_cmr_tasks_results:
-                cmr_granules.update(post_cmr_tasks_result[0])
+                if output_dir:
+                    paths.append(post_cmr_tasks_result)
+                else:
+                    cmr_granules.update(post_cmr_tasks_result[0])
+
+        if output_dir:
+            return extract_native_ids(paths)
         return cmr_granules
 
 
@@ -231,7 +241,8 @@ async def run(start_datetime: datetime = None, end_datetime: datetime = None, fo
     )
 
     logger.info("Querying CMR for list of expected DSWx granules")
-    cmr_dswx_products = await async_get_cmr_dswx(dswx_native_id_patterns, temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str)
+    with tempfile.TemporaryDirectory() as dswx_tmpdir:
+        cmr_dswx_products = await async_get_cmr_dswx(dswx_native_id_patterns, temporal_date_start=cmr_start_dt_str, temporal_date_end=cmr_end_dt_str, output_dir=dswx_tmpdir)
 
     cmr_dswx_prefix_expected = {prefix[:-1] for prefix in dswx_native_id_patterns}
     cmr_dswx_prefix_actual = dswx_native_ids_to_prefixes(cmr_dswx_products)

--- a/tools/ops/cmr_audit/cmr_audit_slc.py
+++ b/tools/ops/cmr_audit/cmr_audit_slc.py
@@ -420,5 +420,11 @@ if __name__ == "__main__":
     args = create_parser().parse_args(sys.argv[1:])
     init_logging('cmr_audit_slc.log', 'cmr_audit_slc-error.log', level=args.log_level)
     logger = logging.getLogger(__name__)
+    msg = (
+        "cmr_audit_slc.py is deprecated and should no longer be executed directly. "
+        "Use rtools/ops/cmr_audit/cmr_audit_burst_coverage.py instead."
+    )
+    logger.error(msg)
+    raise RuntimeError(msg)
 
-    asyncio.run(run(**args.__dict__))
+    # asyncio.run(run(**args.__dict__))

--- a/tools/ops/cmr_audit/cmr_audit_slc.py
+++ b/tools/ops/cmr_audit/cmr_audit_slc.py
@@ -422,7 +422,7 @@ if __name__ == "__main__":
     logger = logging.getLogger(__name__)
     msg = (
         "cmr_audit_slc.py is deprecated and should no longer be executed directly. "
-        "Use rtools/ops/cmr_audit/cmr_audit_burst_coverage.py instead."
+        "Use tools/ops/cmr_audit/cmr_audit_burst_coverage.py instead."
     )
     logger.error(msg)
     raise RuntimeError(msg)

--- a/tools/ops/cmr_audit/cmr_audit_tropo.py
+++ b/tools/ops/cmr_audit/cmr_audit_tropo.py
@@ -1,3 +1,7 @@
+import json
+import os
+import tempfile
+
 import requests
 from datetime import datetime, timedelta, timezone
 from collections import defaultdict
@@ -5,7 +9,10 @@ import csv
 import sys
 import argparse
 
-def query_cmr_granules_all(provider, short_name, start_date_str, end_date_str, page_size=2000):
+from tools.ops.cmr_audit.cmr_audit_utils import extract_fields
+
+
+def query_cmr_granules_all(provider, short_name, start_date_str, end_date_str, page_size=2000, output_path=None):
     base_url = 'https://cmr.earthdata.nasa.gov/search/granules.umm_json'
     page_num = 1
     all_entries = []
@@ -28,12 +35,17 @@ def query_cmr_granules_all(provider, short_name, start_date_str, end_date_str, p
         if not entries:
             break
 
-        all_entries.extend(entries)
+        if output_path:
+            with open(output_path, 'a') as f:
+                for item in entries:
+                    f.write(json.dumps(item) + '\n')
+        else:
+            all_entries.extend(entries)
         print(f"Fetched page {page_num} with {len(entries)} entries...")
 
         page_num += 1
 
-    return all_entries
+    return output_path if output_path else all_entries
 
 def daterange(start_date, end_date):
     current = start_date
@@ -44,9 +56,7 @@ def daterange(start_date, end_date):
 def count_granules_by_beginning_date(entries, start_date, end_date):
     counts = defaultdict(int)
     for entry in entries:
-        umm = entry.get('umm', {})
-        temporal = umm.get('TemporalExtent', {}).get('RangeDateTime', {})
-        begin_dt = temporal.get('BeginningDateTime', None)
+        begin_dt = entry.get('umm.TemporalExtent.RangeDateTime.BeginningDateTime', None)
 
         if begin_dt:
             date_str = begin_dt.split('T')[0]
@@ -146,12 +156,16 @@ This script generates two CSV files:
 if __name__ == "__main__":
     provider, short_name, start_date, end_date = parse_args()
 
-    entries = query_cmr_granules_all(
-        provider,
-        short_name,
-        start_date.strftime('%Y-%m-%d'),
-        end_date.strftime('%Y-%m-%d')
-    )
+    with tempfile.TemporaryDirectory() as tmpdir:
+        output_path = os.path.join(tmpdir, "tropo.jsonl")
+        query_cmr_granules_all(
+            provider,
+            short_name,
+            start_date.strftime('%Y-%m-%d'),
+            end_date.strftime('%Y-%m-%d'),
+            output_path=output_path
+        )
+        entries = extract_fields([output_path], ["umm.TemporalExtent.RangeDateTime.BeginningDateTime"])
 
     counts = count_granules_by_beginning_date(entries, start_date, end_date)
 

--- a/tools/ops/cmr_audit/cmr_audit_utils.py
+++ b/tools/ops/cmr_audit/cmr_audit_utils.py
@@ -1,9 +1,11 @@
 import argparse
 import asyncio
 import datetime
+import json
 import logging
 import urllib
 from io import StringIO
+from pathlib import Path
 from pprint import pprint
 from typing import Union, Iterable, Optional, Literal
 
@@ -150,6 +152,77 @@ def to_cmr_audit_granules(cmr_response_jsons):
         cmr_granules.update({item["meta"]["native-id"] for item in response_json["items"]})
         cmr_granules_detailed.update({item["meta"]["native-id"]: item for item in response_json["items"]})  # DEV: uncomment as needed
     return cmr_granules, cmr_granules_detailed
+
+
+def extract_native_ids(paths):
+    """Scan JSONL files and return set of native-id strings.
+
+    Args:
+        paths: List of file paths to JSONL files containing CMR granule items.
+
+    Returns:
+        Set of native-id strings extracted from all records across all files.
+    """
+    native_ids = set()
+    for path in paths:
+        with open(path) as f:
+            for line in f:
+                item = json.loads(line)
+                native_ids.add(item["meta"]["native-id"])
+    return native_ids
+
+
+def _get_nested(obj, path):
+    """Extract nested value using dot notation. Raises KeyError on missing keys.
+
+    Args:
+        obj: The dict to extract from.
+        path: Dot-notation path (e.g., "meta.native-id", "umm.InputGranules").
+
+    Returns:
+        The value at the specified path. Returns nested structures (lists, dicts)
+        without flattening.
+
+    Raises:
+        KeyError: If any key in the path is not found in the object.
+    """
+    keys = path.split(".")
+    for key in keys:
+        if obj is None:
+            return None
+        if isinstance(obj, dict):
+            if key not in obj:
+                raise KeyError(f"Key '{key}' not found in path '{path}'")
+            obj = obj[key]
+        else:
+            raise KeyError(f"Cannot access key '{key}' in non-dict object (path: '{path}')")
+    return obj
+
+
+def extract_fields(paths, fields):
+    """Read JSONL files and extract specified nested fields per item.
+
+    Fields use dot-notation (e.g., "meta.native-id", "umm.InputGranules").
+    Returns list of flat dicts keyed by field path.
+
+    Raises KeyError if any requested field is missing from a record.
+    Returns raw nested structures (lists, dicts) without flattening;
+    scripts are responsible for post-processing.
+
+    Args:
+        paths: List of file paths to JSONL files containing CMR granule items.
+        fields: List of dot-notation field paths to extract.
+
+    Returns:
+        List of dicts, one per record, keyed by the dot-notation field path.
+    """
+    records = []
+    for path in paths:
+        with open(path) as f:
+            for line in f:
+                item = json.loads(line)
+                records.append({field: _get_nested(item, field) for field in fields})
+    return records
 
 
 def pstr(o):

--- a/tools/ops/cmr_audit/cmr_audit_utils.py
+++ b/tools/ops/cmr_audit/cmr_audit_utils.py
@@ -3,6 +3,7 @@ import asyncio
 import datetime
 import json
 import logging
+import os
 import urllib
 from io import StringIO
 from pathlib import Path
@@ -22,7 +23,7 @@ logger = logging.getLogger(__name__)
 
 async def async_get_cmr_granules(collection_short_name, temporal_date_start: str, temporal_date_end: str,
                                  platform_short_name: Union[str, Iterable[str]], concurrency=None,
-                                 bounding_box: str = None):
+                                 bounding_box: str = None, output_dir=None):
     logger.debug(f"entry({collection_short_name=}, {temporal_date_start=}, {temporal_date_end=}, {platform_short_name})")
 
     sem = asyncio.Semaphore(15)
@@ -35,6 +36,7 @@ async def async_get_cmr_granules(collection_short_name, temporal_date_start: str
         temporal_start_dt = dateutil.parser.isoparse(temporal_date_start)
         temporal_end_dt = dateutil.parser.isoparse(temporal_date_end)
         range_days = rrule(freq=DAILY, dtstart=temporal_start_dt, interval=1, until=temporal_end_dt)
+        task_index = 0
         for day in range_days:
             logger.debug(f"{day=!s}")
             if day >= temporal_end_dt:
@@ -64,7 +66,13 @@ async def async_get_cmr_granules(collection_short_name, temporal_date_start: str
 
                 request_body = request_body_supplier(collection_short_name, temporal_date_start=local_start_dt_str, temporal_date_end=local_end_dt_str, platform_short_name=platform_short_name, bounding_box=bounding_box)
                 logger.debug(f"Creating request task for {local_start_dt_str=}, {local_end_dt_str=}")
-                post_cmr_tasks.append(get_cmr_audit_granules(request_url, request_body, session, sem))
+
+                if output_dir:
+                    path = os.path.join(output_dir, f"{collection_short_name}_{task_index:04d}.jsonl")
+                    post_cmr_tasks.append(get_cmr_audit_granules(request_url, request_body, session, sem, output_path=path))
+                else:
+                    post_cmr_tasks.append(get_cmr_audit_granules(request_url, request_body, session, sem))
+                task_index += 1
 
                 if local_end_dt == temporal_end_dt:  # processed last partial hour. prevent further iterations.
                     logger.debug("EDGECASE: processed last partial hour. Preempting")
@@ -73,21 +81,31 @@ async def async_get_cmr_granules(collection_short_name, temporal_date_start: str
         logger.debug(f"Number of query requests to make: {len(post_cmr_tasks)=}")
 
         logger.debug("Batching tasks")
-        cmr_granules = set()
-        cmr_granules_details = {}
         task_chunks = list(more_itertools.chunked(post_cmr_tasks, concurrency or len(post_cmr_tasks)))  # CMR recommends 2-5 threads.
-        for i, task_chunk in enumerate(task_chunks, start=1):
-            logger.debug(f"Processing batch {i} of {len(task_chunks)}")
-            post_cmr_tasks_results, post_cmr_tasks_failures = more_itertools.partition(
-                lambda it: isinstance(it, Exception),
-                await asyncio.gather(*task_chunk, return_exceptions=False))
-            for post_cmr_tasks_result in post_cmr_tasks_results:
-                cmr_granules.update(post_cmr_tasks_result[0])
-            # DEV: uncomment as needed
-                cmr_granules_details.update(post_cmr_tasks_result[1])
 
-        logger.info(f"{collection_short_name} {len(cmr_granules)=:,}")
-        return cmr_granules, cmr_granules_details
+        if output_dir:
+            paths = []
+            for i, task_chunk in enumerate(task_chunks, start=1):
+                logger.debug(f"Processing batch {i} of {len(task_chunks)}")
+                results = await asyncio.gather(*task_chunk, return_exceptions=False)
+                paths.extend(results)
+            logger.info(f"{collection_short_name} results written to {len(paths)} file(s)")
+            return paths
+        else:
+            cmr_granules = set()
+            cmr_granules_details = {}
+            for i, task_chunk in enumerate(task_chunks, start=1):
+                logger.debug(f"Processing batch {i} of {len(task_chunks)}")
+                post_cmr_tasks_results, post_cmr_tasks_failures = more_itertools.partition(
+                    lambda it: isinstance(it, Exception),
+                    await asyncio.gather(*task_chunk, return_exceptions=False))
+                for post_cmr_tasks_result in post_cmr_tasks_results:
+                    cmr_granules.update(post_cmr_tasks_result[0])
+                # DEV: uncomment as needed
+                    cmr_granules_details.update(post_cmr_tasks_result[1])
+
+            logger.info(f"{collection_short_name} {len(cmr_granules)=:,}")
+            return cmr_granules, cmr_granules_details
 
 
 def request_body_supplier(collection_short_name, temporal_date_start: str, temporal_date_end: str, platform_short_name: Union[str, Iterable[str]], bounding_box: str = None):
@@ -139,10 +157,15 @@ def request_body_supplier(collection_short_name, temporal_date_start: str, tempo
     raise Exception(f"Unsupported collection short name. {collection_short_name=}")
 
 
-async def get_cmr_audit_granules(url, data: str, session: aiohttp.ClientSession, sem: Optional[asyncio.Semaphore]):
-    response_jsons = await async_cmr_post(url, data, session, sem)
-    cmr_granules, cmr_granules_detailed = to_cmr_audit_granules(response_jsons)
-    return cmr_granules, cmr_granules_detailed
+async def get_cmr_audit_granules(url, data: str, session: aiohttp.ClientSession, sem: Optional[asyncio.Semaphore],
+                                 output_path=None):
+    if output_path:
+        await async_cmr_post(url, data, session, sem, output_path=output_path)
+        return output_path
+    else:
+        response_jsons = await async_cmr_post(url, data, session, sem)
+        cmr_granules, cmr_granules_detailed = to_cmr_audit_granules(response_jsons)
+        return cmr_granules, cmr_granules_detailed
 
 
 def to_cmr_audit_granules(cmr_response_jsons):

--- a/tools/ops/cmr_audit/cmr_client.py
+++ b/tools/ops/cmr_audit/cmr_client.py
@@ -2,6 +2,7 @@
 import asyncio
 import contextlib
 import itertools
+import json
 import math
 import os
 from math import ceil
@@ -15,23 +16,40 @@ from requests.exceptions import HTTPError
 from opera_commons.logger import get_logger
 
 
-async def async_cmr_posts(url, request_bodies: list, sem: Optional[asyncio.Semaphore] = None):
-    """Given a list of request bodies, performs CMR queries asynchronously, returning the response JSONs."""
+async def async_cmr_posts(url, request_bodies: list, sem: Optional[asyncio.Semaphore] = None,
+                           output_dir: Optional[str] = None):
+    """Given a list of request bodies, performs CMR queries asynchronously, returning the response JSONs.
+
+    When output_dir is set, streams results to JSONL files on disk and returns list of file paths instead.
+    """
     async with aiohttp.ClientSession() as session:
         tasks = []
 
         concurrency = 1 if len(request_bodies) == 1 else min(len(request_bodies), 15)
         sem = asyncio.Semaphore(concurrency) if not sem else sem
 
-        for request_body in request_bodies:
-            tasks.append(async_cmr_post(url, request_body, session, sem))
-        responses = await asyncio.gather(*tasks)
+        if output_dir:
+            paths = []
+            for i, request_body in enumerate(request_bodies):
+                path = os.path.join(output_dir, f"cmr_batch_{i}.jsonl")
+                paths.append(path)
+                tasks.append(async_cmr_post(url, request_body, session, sem, output_path=path))
+            await asyncio.gather(*tasks)
+            return paths
+        else:
+            for request_body in request_bodies:
+                tasks.append(async_cmr_post(url, request_body, session, sem))
+            responses = await asyncio.gather(*tasks)
+            return list(itertools.chain.from_iterable(responses))
 
-    return list(itertools.chain.from_iterable(responses))
 
+async def async_cmr_post(url, data: str, session: aiohttp.ClientSession, sem: Optional[asyncio.Semaphore] = None,
+                         output_path: Optional[str] = None):
+    """Issues a request asynchronously. If a semaphore is provided, it will use it as a context manager.
 
-async def async_cmr_post(url, data: str, session: aiohttp.ClientSession, sem: Optional[asyncio.Semaphore] = None):
-    """Issues a request asynchronously. If a semaphore is provided, it will use it as a context manager."""
+    When output_path is set, streams items to a JSONL file on disk instead of accumulating in memory.
+    Returns empty list when output_path is set (items are on disk), otherwise returns list of response JSONs.
+    """
     logger = get_logger()
 
     sem = sem if sem is not None else contextlib.nullcontext()
@@ -56,6 +74,12 @@ async def async_cmr_post(url, data: str, session: aiohttp.ClientSession, sem: Op
         while current_page <= max_pages:
             async with await fetch_post_url(session, url, data, headers) as response:
                 response_json = await response.json()
+
+            if output_path:
+                with open(output_path, 'a') as f:
+                    for item in response_json["items"]:
+                        f.write(json.dumps(item) + '\n')
+            else:
                 response_jsons.append(response_json)
 
             if current_page == 1:


### PR DESCRIPTION
## Purpose
- All CMR audit scripts accumulate full UMM metadata payloads in memory during pagination. This can cause multi-GB memory consumption and OOM failures. 95% of tracked memory is JSON-parsed UMM dicts that are retained long after only a few fields are needed.
- Solution: stream CMR pages to ephemeral JSONL files instead of accumulating in memory. Audit scripts extract only the fields they need from disk to reduce overall memory load and fetch phase stays bounded

## Proposed Changes
- [ADD]
   - Added a few tests to confirm changes maintained backwards compatibility
- [CHANGE]
   - Modified `data_subscriber/cmr.py`, `tools/ops/cmr_audit/cmr_audit_utils.py`, and `tools/ops/cmr_audit/cmr_client.py` to use optional `output_dir` argument which when set, streams results to JSONL files on disk and returns list of file paths.
   - Modified audit scripts to load JSONL files and extract relevant fields, reducing memory usage per granule, typically a reduction between 50% and 95%. Audit logic is not touched. 
   - Additional improvements to DIST-S1 audit suite (`tools/ops/cmr_audit/cmr_audit_dist_s1.py`, `tools/dist_s1_input_tool.py`)
   - Added swap space 200 for mozart, grq, factotum, and metrics
- [REMOVE]
   - Deprecated SLC audit tool used for RTC, CSLC auditing (`tools/ops/cmr_audit/cmr_audit_slc.py`) with message pointing to alternative `tools/ops/cmr_audit/cmr_audit_burst_coverage.py`. Maintains backwards compatibility for other tools using code from `cmr_audit_slc`

Note: did not touch `tools/ops/cmr_audit/cmr_audit_burst_coverage.py`

## Issues
- [OPERA-2518](https://hysds-core.atlassian.net/browse/OPERA-2518?atlOrigin=eyJpIjoiOWNiNjY5NDg5MTUyNDM3NWFiZjE3ZDI3MzU0NzBjOTAiLCJwIjoiaiJ9)
 
## Testing
- Tested locally
