### PR TITLE
Fix CMR burst-audit off-by-one tracks at SLC boundaries (annotation-only derivation)

### DIFF
--- a/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
+++ b/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
@@ -758,9 +758,18 @@ async def fetch_opera_products(
                     headers={"Content-Type": "application/x-www-form-urlencoded"},
                     timeout=aiohttp.ClientTimeout(total=30),
                 ) as resp:
-                    if resp.status == 429:
-                        await asyncio.sleep(0.5 * (2 ** attempt))
-                        continue
+                    if resp.status == 429 or resp.status >= 500:
+                        if attempt < 2:
+                            await asyncio.sleep(0.5 * (2 ** attempt))
+                            continue
+                        # All retries exhausted on 429/5xx - return WITHOUT caching
+                        # so we don't poison the cache with false-empty results
+                        logger = logging.getLogger(__name__)
+                        logger.warning(
+                            f"CMR returned status {resp.status} for burst "
+                            f"{burst.filename_pattern} after 3 attempts - NOT caching"
+                        )
+                        return set()
                     if resp.status != 200:
                         return set()
 
@@ -769,10 +778,16 @@ async def fetch_opera_products(
                     cache.set("cmr_opera", cache_params, product_ids)
                     return set(product_ids)
 
-            except (asyncio.TimeoutError, aiohttp.ClientError):
+            except (asyncio.TimeoutError, aiohttp.ClientError) as exc:
                 if attempt < 2:
                     await asyncio.sleep(0.5 * (2 ** attempt))
                     continue
+                # All retries exhausted - return WITHOUT caching
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    f"CMR network error for burst {burst.filename_pattern} "
+                    f"after 3 attempts: {exc} - NOT caching"
+                )
                 return set()
 
     return set()

--- a/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
+++ b/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
@@ -710,9 +710,9 @@ async def process_slcs_to_expected_bursts(
     """
     logger = logging.getLogger(__name__)
 
-    # Fetch bursts from ASF API
+    # Derive bursts per SLC (annotation XMLs + manifest.safe via HTTP range)
     primary_pol = polarizations[0] if polarizations else None
-    logger.info(f"  Fetching burst IDs from ASF (polarization: {primary_pol})...")
+    logger.info(f"  Deriving burst IDs from SLC annotations (polarization: {primary_pol})...")
 
     sem = asyncio.Semaphore(max_concurrent)
     async with aiohttp.ClientSession() as session:

--- a/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
+++ b/tools/ops/cmr_audit/cmr_audit_burst_coverage.py
@@ -61,9 +61,8 @@ from tools.ops.cmr_audit.cmr_audit_utils import async_get_cmr_granules, init_log
 from tools.ops.cmr_audit.slc_annotation_extract import (
     get_slc_download_url,
     get_edl_token,
-    extract_annotations,
-    parse_burst_anx_times,
-    derive_burst_ids,
+    extract_slc_metadata,
+    derive_burst_ids_from_metadata,
 )
 
 # Suppress noisy loggers
@@ -74,7 +73,6 @@ logging.getLogger("compact_json.formatter").setLevel(logging.INFO)
 # =============================================================================
 
 CMR_GRANULE_URL = "https://cmr.earthdata.nasa.gov/search/granules.umm_json"
-ASF_BURST_API_URL = "https://api.daac.asf.alaska.edu/services/search/param"
 
 # OPERA product short names in CMR
 OPERA_PRODUCTS = {
@@ -82,7 +80,7 @@ OPERA_PRODUCTS = {
     "RTC-S1": "OPERA_L2_RTC-S1_V1",
 }
 
-# Sentinel-1 platform name mapping (ASF API format)
+# Sentinel-1 platform name mapping (kept for reference, no longer used in queries)
 PLATFORM_MAP = {
     "S1A": "SENTINEL-1A",
     "S1B": "SENTINEL-1B",
@@ -406,99 +404,10 @@ def generate_time_chunks(start: datetime, end: datetime, days: int = 30) -> Iter
 
 
 # =============================================================================
-# ASF Burst API
+# Burst ID derivation (annotation XML + manifest.safe via HTTP range requests)
 # =============================================================================
 
-async def _parse_asf_burst_response(
-    data: list, polarization: str = None, slc_product_id: str = None,
-) -> list[str]:
-    """Parse ASF SLC-BURST API response and return unique burst IDs.
-
-    Parameters
-    ----------
-    data : list
-        Raw JSON response from the ASF SLC-BURST API.
-    polarization : str, optional
-        Filter to this polarization (e.g. "VV").
-    slc_product_id : str, optional
-        Parent SLC product ID (native_id without the ``-SLC`` suffix).
-        When provided, only bursts whose ``downloadUrl`` references this
-        SLC are returned.  This prevents including bursts from adjacent
-        SLCs whose acquisition windows overlap.
-    """
-    items = data[0] if data and isinstance(data[0], list) else data
-    seen = set()
-    burst_ids = []
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if polarization and item.get('polarization', '').upper() != polarization.upper():
-            continue
-        if slc_product_id:
-            download_url = item.get('downloadUrl', '')
-            if slc_product_id not in download_url:
-                continue
-        bid = item.get('burst', {}).get('fullBurstID')
-        if bid and bid not in seen:
-            seen.add(bid)
-            burst_ids.append(bid)
-    return burst_ids
-
-
 _edl_token: str | None = None  # Lazy-initialized on first annotation derivation
-
-
-async def _derive_bursts_from_annotation(
-    slc: SLCGranule,
-    asf_burst_ids: list[str],
-    ref_burst_anx_time: float,
-    polarization: str,
-) -> list[str] | None:
-    """Derive complete burst IDs from SLC annotation XMLs.
-
-    Uses one ASF burst as reference anchor to compute burst numbers for all
-    bursts found in the annotation XMLs. This ensures complete burst coverage
-    regardless of how many bursts ASF returned.
-    """
-    global _edl_token
-    logger = logging.getLogger(__name__)
-
-    try:
-        # Lazy-init EDL token
-        if _edl_token is None:
-            try:
-                _edl_token = await asyncio.to_thread(get_edl_token)
-            except Exception as exc:
-                logger.warning(f"EDL token acquisition failed: {exc}")
-                _edl_token = ""  # sentinel to avoid retrying
-                return None
-
-        if _edl_token == "":
-            return None
-
-        # Get download URL and extract annotations
-        zip_url = await asyncio.to_thread(get_slc_download_url, slc.native_id)
-        annotations = await asyncio.to_thread(extract_annotations, zip_url, _edl_token)
-        anx_times = parse_burst_anx_times(annotations)
-
-        if not anx_times:
-            logger.warning(f"No ANX times parsed from annotations for {slc.native_id}")
-            return None
-
-        # Parse reference burst from first ASF burst ID
-        ref_bid = asf_burst_ids[0]
-        ref_track_str, ref_burst_str, ref_sw = ref_bid.split("_")
-        ref_track = int(ref_track_str)
-        ref_burst_num = int(ref_burst_str)
-
-        all_ids = derive_burst_ids(
-            anx_times, ref_track, ref_burst_num, ref_burst_anx_time, ref_sw,
-        )
-        return all_ids
-
-    except Exception as exc:
-        logger.warning(f"Annotation burst derivation failed for {slc.native_id}: {exc}")
-        return None
 
 
 def _estimate_expected_bursts(slc: "SLCGranule") -> int:
@@ -521,133 +430,76 @@ async def fetch_bursts_for_slc(
     sem: asyncio.Semaphore,
     polarization: str = None,
 ) -> list[BurstInfo]:
-    """
-    Query ASF SLC-BURST API to get burst IDs for an SLC granule.
+    """Derive burst IDs for an SLC using its own annotation XMLs + manifest.safe.
 
-    Uses caching and retry logic with exponential backoff for rate limiting.
-    Always derives complete burst set from annotation XMLs when ASF returns
-    at least one burst (ASF data is used only as a reference anchor).
+    Self-contained per SLC — no ASF SLC-BURST API call. Uses the ESA
+    burst-ID formula (same as OPERA's PGE via s1-reader). This avoids the
+    "boundary-overlap" bug where ASF's time-range query returns bursts from
+    adjacent SLC acquisitions on different tracks, causing the audit to
+    anchor on the wrong SLC and produce off-by-one track numbers.
+
+    Results are cached under the ``asf_bursts`` namespace (name kept for
+    backward compatibility with the cache layout). The cache version key
+    distinguishes annotation-only derivation from older ASF-anchored entries.
     """
+    global _edl_token
     logger = logging.getLogger(__name__)
     cache = get_cache()
 
-    # Build cache key.  Includes 'slc' and '_v' (version) so that results
-    # cached before logic changes are automatically invalidated.
+    # Build cache key. The 'derivation' field distinguishes annotation-only
+    # results from older ASF-anchored entries with the same SLC.
     cache_params = {
         'platform': slc.platform,
         'orbit': slc.absolute_orbit,
         'start': slc.start_time.isoformat(),
         'end': slc.end_time.isoformat(),
-        'pol': polarization,
         'slc': slc.native_id,
-        '_v': 5,  # bump when burst-fetching logic changes
+        'derivation': 'annotation_v1',
+        '_v': 6,  # bump when burst-derivation logic changes
     }
 
-    # Check cache
     cached = cache.get("asf_bursts", cache_params)
     if cached is not None:
-        if cached:  # non-empty cached result
+        if cached:
             return [BurstInfo.from_asf_id(bid) for bid in cached]
-        else:  # empty cached result (polarization mismatch)
+        else:
             return []
 
-    # Build API request
-    params = {
-        'dataset': 'SLC-BURST',
-        'platform': PLATFORM_MAP.get(slc.platform, slc.platform),
-        'absoluteOrbit': slc.absolute_orbit,
-        'start': slc.start_time.strftime('%Y-%m-%dT%H:%M:%S'),
-        'end': slc.end_time.strftime('%Y-%m-%dT%H:%M:%S'),
-        'output': 'json',
-        'maxResults': 500,
-    }
-    if polarization:
-        params['polarization'] = polarization.upper()
+    # Lazy-init EDL token (sentinel "" means previously failed; don't retry)
+    if _edl_token is None:
+        try:
+            _edl_token = await asyncio.to_thread(get_edl_token)
+        except Exception as exc:
+            logger.warning(f"EDL token acquisition failed: {exc}")
+            _edl_token = ""
+            return []
+    if _edl_token == "":
+        return []
 
-    url = f"{ASF_BURST_API_URL}?{urllib.parse.urlencode(params)}"
-
-    # Derive parent SLC product ID for filtering bursts from adjacent SLCs.
-    # native_id format: S1A_IW_SLC__1SDV_..._EA33-SLC → strip "-SLC" suffix.
-    slc_product_id = slc.native_id.removesuffix("-SLC")
-
-    # Retry with exponential backoff, keeping the best response
-    best_burst_ids = []
-    best_ref_anx = 0.0  # Reference ANX time for annotation fallback
-    successful_attempts = 0
-
-    for attempt in range(3):
-        async with sem:
-            try:
-                async with session.get(url, timeout=aiohttp.ClientTimeout(total=60)) as resp:
-                    if resp.status == 429:  # Rate limited
-                        await asyncio.sleep(2 ** attempt)
-                        continue
-                    if resp.status != 200:
-                        return []
-
-                    data = await resp.json()
-                    burst_ids = await _parse_asf_burst_response(data, polarization, slc_product_id)
-                    successful_attempts += 1
-
-                    # Keep the response with the most bursts
-                    if burst_ids and len(burst_ids) > len(best_burst_ids):
-                        best_burst_ids = burst_ids
-                        # Save reference ANX time for annotation fallback
-                        items = data[0] if data and isinstance(data[0], list) else data
-                        ref_bid = burst_ids[0]
-                        for item in items:
-                            if isinstance(item, dict) and item.get('burst', {}).get('fullBurstID') == ref_bid:
-                                best_ref_anx = float(item['burst'].get('azimuthAnxTime', 0))
-                                break
-
-                    # Got at least one burst — can proceed to annotation fallback
-                    if best_burst_ids:
-                        break
-
-                    # 0 bursts — retry (unless consistently empty)
-                    if successful_attempts >= 2:
-                        # Two successful requests both returned 0 bursts.
-                        # This is likely a polarization mismatch (e.g., SDH SLC
-                        # queried with VV), not a transient issue. Cache as empty.
-                        logger.debug(
-                            f"No bursts for {slc.native_id} after "
-                            f"{successful_attempts} attempts — caching empty result "
-                            f"(likely polarization mismatch)"
-                        )
-                        cache.set("asf_bursts", cache_params, [])
-                        return []
-
-                    await asyncio.sleep(2 ** attempt)
-
-            except (asyncio.TimeoutError, aiohttp.ClientError):
-                if attempt < 2:
-                    await asyncio.sleep(2 ** attempt)
-                    continue
-                logger.debug(f"Failed to get bursts for {slc.native_id}")
-                break
-
-    # If ASF returned at least one burst, derive complete set from annotation XMLs
-    # (ASF burst is used as reference anchor for burst ID calculation)
-    if best_burst_ids:
-        all_ids = await _derive_bursts_from_annotation(
-            slc, best_burst_ids, best_ref_anx, polarization or "VV",
+    # Fetch SLC metadata (annotation XMLs + manifest.safe) via HTTP range
+    # requests — typically ~1 MB total instead of 4-8 GB for the full ZIP.
+    try:
+        zip_url = await asyncio.to_thread(get_slc_download_url, slc.native_id)
+        annotations, manifest_bytes = await asyncio.to_thread(
+            extract_slc_metadata, zip_url, _edl_token,
         )
-        if all_ids:
-            logger.info(
-                f"Annotation-derived bursts for {slc.native_id}: "
-                f"{len(all_ids)} (ASF reference: {len(best_burst_ids)})"
-            )
-            cache.set("asf_bursts", cache_params, all_ids)
-            return [BurstInfo.from_asf_id(bid) for bid in all_ids]
-        else:
-            # Annotation derivation failed — fall back to ASF data only
-            logger.warning(
-                f"Annotation derivation failed for {slc.native_id}, "
-                f"using ASF data only ({len(best_burst_ids)} bursts). Result NOT cached."
-            )
-            return [BurstInfo.from_asf_id(bid) for bid in best_burst_ids]
+        burst_ids = derive_burst_ids_from_metadata(annotations, manifest_bytes)
+    except Exception as exc:
+        logger.warning(
+            f"Burst derivation failed for {slc.native_id}: {exc}. "
+            f"Result NOT cached."
+        )
+        return []
 
-    return []
+    if not burst_ids:
+        logger.warning(f"No bursts derived for {slc.native_id}. Result NOT cached.")
+        return []
+
+    logger.info(
+        f"Annotation-derived bursts for {slc.native_id}: {len(burst_ids)}"
+    )
+    cache.set("asf_bursts", cache_params, burst_ids)
+    return [BurstInfo.from_asf_id(bid) for bid in burst_ids]
 
 
 # =============================================================================

--- a/tools/ops/cmr_audit/slc_annotation_extract.py
+++ b/tools/ops/cmr_audit/slc_annotation_extract.py
@@ -71,8 +71,10 @@ enabling verification of ASF API results without downloading the full SLC.
 """
 
 import argparse
+import datetime as _dt
 import io
 import logging
+import math
 import pathlib
 import re
 import sys
@@ -359,6 +361,45 @@ def extract_annotations(zip_url: str, token: str) -> dict[str, bytes]:
     return annotations
 
 
+def extract_slc_metadata(zip_url: str, token: str) -> tuple[dict[str, bytes], bytes]:
+    """Extract annotation XMLs AND manifest.safe from a remote SLC ZIP.
+
+    The manifest.safe contains the relativeOrbitNumber start/stop values
+    needed for ESA burst-ID computation; the annotation XMLs contain per-burst
+    sensing times and the ascending node time.
+
+    Returns:
+        (annotations, manifest_bytes) where annotations is the same dict as
+        extract_annotations() and manifest_bytes is the raw manifest.safe XML.
+    """
+    remote = HTTPRangeFile(zip_url, token)
+
+    annotations: dict[str, bytes] = {}
+    manifest_bytes: bytes = b""
+    with zipfile.ZipFile(remote) as zf:
+        for entry in zf.namelist():
+            if (
+                "/annotation/" in entry
+                and entry.endswith(".xml")
+                and "/calibration/" not in entry
+            ):
+                logger.debug("Extracting: %s", entry)
+                annotations[entry] = zf.read(entry)
+            elif entry.endswith("/manifest.safe") or entry.endswith("manifest.safe"):
+                logger.debug("Extracting: %s", entry)
+                manifest_bytes = zf.read(entry)
+
+    logger.info(
+        "Extracted %d annotation XMLs + manifest.safe (%d HTTP requests, %.1f KB)",
+        len(annotations),
+        remote._request_count,
+        remote._bytes_downloaded / 1024,
+    )
+    if not manifest_bytes:
+        raise IOError("manifest.safe not found in SLC ZIP")
+    return annotations, manifest_bytes
+
+
 # ---------------------------------------------------------------------------
 # 5. Parse burst information from annotation XML
 # ---------------------------------------------------------------------------
@@ -511,6 +552,215 @@ def derive_burst_ids(
             burst_num = anchor_num + (i - anchor_idx)
             burst_ids.append(f"{track:03d}_{burst_num:06d}_{subswath}")
 
+    return burst_ids
+
+
+# ---------------------------------------------------------------------------
+# 5b. ESA burst-ID derivation (pure Python port of s1reader.S1BurstId)
+# ---------------------------------------------------------------------------
+# Constants per Table 9-7 of "Sentinel-1 Level 1 Detailed Algorithm Definition"
+_T_BEAM = 2.758273              # burst interval [s]
+_T_PRE = 2.299849               # preamble time interval [s]
+_T_ORBIT = (12 * 86400.0) / 175.0  # nominal Sentinel-1 orbit period [s]
+# Burst-to-burst times within a row: IW1→IW2, IW2→IW3, IW3→(next row's IW1)
+_BURST_TIMES = (0.832, 1.078, 0.848)
+
+
+def _parse_iso_dt(text: str) -> _dt.datetime:
+    """Parse Sentinel-1 ISO timestamp (possibly with fractional seconds)."""
+    text = text.rstrip("Z").strip()
+    if "." in text:
+        base, frac = text.split(".", 1)
+        frac = (frac + "000000")[:6]
+        text = f"{base}.{frac}"
+        fmt = "%Y-%m-%dT%H:%M:%S.%f"
+    else:
+        fmt = "%Y-%m-%dT%H:%M:%S"
+    return _dt.datetime.strptime(text, fmt).replace(tzinfo=_dt.timezone.utc)
+
+
+def compute_esa_burst_id(
+    sensing_time: _dt.datetime,
+    ascending_node_dt: _dt.datetime,
+    start_track: int,
+    end_track: int,
+    subswath: str,
+) -> tuple[int, int, str]:
+    """Compute (track_number, esa_burst_id, subswath) for one burst.
+
+    Pure-Python reimplementation of ``s1reader.s1_burst_id.S1BurstId.from_burst_params``.
+    No external dependencies.
+
+    Parameters
+    ----------
+    sensing_time : datetime
+        UTC sensing time of the first input line of the burst
+        (``sensingTime`` from the annotation XML).
+    ascending_node_dt : datetime
+        UTC time of the ascending node prior to the start of the scene
+        (``ascendingNodeTime`` from the annotation XML).
+    start_track : int
+        Relative orbit number at the start of the acquisition (1-175,
+        from manifest.safe).
+    end_track : int
+        Relative orbit number at the end of the acquisition (1-175,
+        from manifest.safe). Same as start_track unless the scene
+        crosses the equator.
+    subswath : str
+        Subswath name: ``IW1``, ``IW2``, or ``IW3`` (case-insensitive).
+
+    Returns
+    -------
+    (track_number, esa_burst_id, subswath) tuple.
+    """
+    subswath = subswath.upper()
+    swath_num = int(subswath[-1])
+
+    iw1_start_offsets = (
+        0.0,
+        -_BURST_TIMES[0],
+        -_BURST_TIMES[0] - _BURST_TIMES[1],
+    )
+    offset = iw1_start_offsets[swath_num - 1]
+    start_iw1 = sensing_time + _dt.timedelta(seconds=offset)
+
+    start_iw1_to_mid_iw2 = _BURST_TIMES[0] + _BURST_TIMES[1] / 2
+    mid_iw2 = start_iw1 + _dt.timedelta(seconds=start_iw1_to_mid_iw2)
+
+    has_anx_crossing = (end_track == start_track + 1) or (
+        end_track == 1 and start_track == 175
+    )
+
+    time_since_anx_iw1 = (start_iw1 - ascending_node_dt).total_seconds()
+    time_since_anx = (mid_iw2 - ascending_node_dt).total_seconds()
+
+    if (time_since_anx_iw1 - _T_ORBIT) < 0:
+        track_number = start_track
+    else:
+        track_number = end_track
+        if not has_anx_crossing:
+            time_since_anx = time_since_anx - _T_ORBIT
+
+    # Eq. 9-89:  ∆tb = tb − t_anx + (r - 1) * T_orb
+    dt_b = time_since_anx + (start_track - 1) * _T_ORBIT
+
+    # Eq. 9-91:  1 + floor((∆tb − T_pre) / T_beam)
+    esa_burst_id = 1 + int(math.floor((dt_b - _T_PRE) / _T_BEAM))
+
+    return (track_number, esa_burst_id, subswath)
+
+
+def parse_relative_orbit_numbers(manifest_bytes: bytes) -> tuple[int, int]:
+    """Extract (start_track, end_track) from a manifest.safe XML.
+
+    XPath: ``metadataSection/.../safe:orbitReference/safe:relativeOrbitNumber``
+    with attributes ``type="start"`` / ``type="stop"``.
+    """
+    root = ET.fromstring(manifest_bytes)
+    start_track: int | None = None
+    end_track: int | None = None
+    # The element may be in any namespace; match by local name.
+    for el in root.iter():
+        if not el.tag.endswith("relativeOrbitNumber"):
+            continue
+        ttype = el.get("type")
+        try:
+            val = int(el.text)
+        except (TypeError, ValueError):
+            continue
+        if ttype == "start":
+            start_track = val
+        elif ttype == "stop":
+            end_track = val
+    if start_track is None:
+        raise ValueError("relativeOrbitNumber type=start not found in manifest.safe")
+    if end_track is None:
+        end_track = start_track
+    return (start_track, end_track)
+
+
+def parse_ascending_node_time(annotations: dict[str, bytes]) -> _dt.datetime:
+    """Extract ``ascendingNodeTime`` from any annotation XML.
+
+    The value is identical across the SLC's annotation files; reads the first.
+    """
+    for path in sorted(annotations):
+        root = ET.fromstring(annotations[path])
+        for el in root.iter():
+            if el.tag.endswith("ascendingNodeTime") and el.text:
+                return _parse_iso_dt(el.text)
+    raise ValueError("ascendingNodeTime not found in any annotation XML")
+
+
+def parse_burst_sensing_times(annotations: dict[str, bytes]) -> dict[str, list[_dt.datetime]]:
+    """Parse per-burst ``sensingTime`` keyed by subswath.
+
+    Only processes one polarization per subswath (VV preferred) since burst
+    structure is identical across polarizations.
+
+    Returns e.g. ``{"IW1": [datetime, datetime, ...], ...}``.
+    """
+    entries: dict[str, dict[str, str]] = {}
+    for path in sorted(annotations):
+        filename = path.rsplit("/", 1)[-1]
+        parts = filename.split("-")
+        subswath = parts[1].upper()
+        polarization = parts[3].upper()
+        entries.setdefault(subswath, {})[polarization] = path
+
+    result: dict[str, list[_dt.datetime]] = {}
+    for subswath in sorted(entries):
+        pols = entries[subswath]
+        chosen_path = pols.get("VV") or next(iter(pols.values()))
+        root = ET.fromstring(annotations[chosen_path])
+        burst_list = None
+        for el in root.iter():
+            if el.tag.endswith("burstList"):
+                burst_list = el
+                break
+        if burst_list is None:
+            continue
+        times: list[_dt.datetime] = []
+        for burst_el in burst_list:
+            if not burst_el.tag.endswith("burst"):
+                continue
+            for child in burst_el:
+                if child.tag.endswith("sensingTime") and child.text:
+                    times.append(_parse_iso_dt(child.text))
+                    break
+        if times:
+            result[subswath] = times
+    return result
+
+
+def derive_burst_ids_from_metadata(
+    annotations: dict[str, bytes],
+    manifest_bytes: bytes,
+) -> list[str]:
+    """Derive complete ASF-format burst IDs for an SLC using only its own metadata.
+
+    This is the recommended derivation: it uses the SLC's own annotation XMLs
+    and manifest.safe, with no dependency on the ASF SLC-BURST API. As a
+    result it is immune to the "boundary-overlap" bug where the SLC-BURST API
+    returns bursts from adjacent SLC acquisitions and the audit picks an
+    anchor from the wrong acquisition (yielding off-by-one track numbers).
+
+    Bit-perfect agreement with OPERA's PGE, which uses s1-reader's
+    ``S1BurstId.from_burst_params()`` with the same inputs.
+
+    Returns list of ASF-format burst IDs like ``["173_370215_IW1", ...]``.
+    """
+    start_track, end_track = parse_relative_orbit_numbers(manifest_bytes)
+    ascending_node_dt = parse_ascending_node_time(annotations)
+    sensing_times = parse_burst_sensing_times(annotations)
+
+    burst_ids: list[str] = []
+    for subswath in sorted(sensing_times):
+        for sensing_time in sensing_times[subswath]:
+            track, esa_id, sw = compute_esa_burst_id(
+                sensing_time, ascending_node_dt, start_track, end_track, subswath,
+            )
+            burst_ids.append(f"{track:03d}_{esa_id:06d}_{sw}")
     return burst_ids
 
 


### PR DESCRIPTION
## Summary

Fix a longstanding bug in `cmr_audit_burst_coverage.py` (and the supporting `slc_annotation_extract.py`) that produced wrong burst-IDs for SLCs whose ASF SLC-BURST API response included bursts from adjacent acquisitions on a different relative-orbit track. Switches burst-ID derivation to use only the SLC's own annotation XMLs + `manifest.safe`, with a pure-Python port of the ESA formula (matches OPERA's PGE bit-perfect via `s1reader.S1BurstId.from_burst_params()`). Also includes a small fix making CMR 5xx errors retryable (instead of silently caching as "no products found").

## Background

The CMR burst-coverage audit tool reports per-burst missing OPERA RTC/CSLC products for a given date range, so we can request reprocessing of the responsible SLCs. The tool used the ASF SLC-BURST API to look up burst IDs per SLC; that API's time-range query intermittently returns bursts from adjacent SLC acquisitions. When those adjacent bursts were on a different relative-orbit track, our code anchored its annotation-XML derivation on a burst from the wrong SLC, producing off-by-one track numbers (e.g. T131 instead of T130). The audit then looked for the wrong burst-ID pattern in CMR and reported real products as missing while ignoring the actual products that did exist.

Concrete example caught by an OPS user: SLC `S1A_..._063027_07E8C5_7795` actually has 27 RTC products in CMR spanning tracks T130 / T131 (genuine ANX-crossing acquisition). Old code reported 7 of those bursts as "missing"; new code derives all 27 burst IDs identically to what is published in CMR.

## Changes

### `tools/ops/cmr_audit/slc_annotation_extract.py`
- `extract_slc_metadata(zip_url, token)` — fetches annotation XMLs **and** `manifest.safe` via HTTP range requests (~50 KB extra; total still ~1 MB per SLC vs 4-8 GB for the full ZIP).
- `parse_relative_orbit_numbers(manifest_bytes)` — extracts `(start_track, end_track)` from `manifest.safe`.
- `parse_ascending_node_time(annotations)` — extracts `ascendingNodeTime` from the annotation XML.
- `parse_burst_sensing_times(annotations)` — extracts per-burst `sensingTime` per subswath.
- `compute_esa_burst_id(...)` — pure-Python port of `s1reader.s1_burst_id.S1BurstId.from_burst_params()` (handles ANX-crossing scenes via the published ESA formula and constants from Table 9-7).
- `derive_burst_ids_from_metadata(annotations, manifest_bytes)` — wraps the above and returns ASF-format burst IDs (e.g. `"130_279229_IW1"`).
- Older `derive_burst_ids(...)` (the buggy ASF-anchored one) is left in place but no longer called from the audit; kept for potential debugging.

### `tools/ops/cmr_audit/cmr_audit_burst_coverage.py`
- `fetch_bursts_for_slc()` rewritten to use the new annotation-only derivation. Drops the ASF SLC-BURST API call entirely.
- `_parse_asf_burst_response()` and `ASF_BURST_API_URL` removed (dead).
- Cache key bumped (`_v: 6`, plus `derivation: annotation_v1`) so pre-fix `asf_bursts` entries auto-invalidate.
- (Earlier commit on this branch) `fetch_opera_products()` now retries 429/5xx for 3 attempts and refuses to cache the result if all retries fail, so transient CMR errors no longer pollute `cmr_opera` with false-empty entries.

## Validation

- New derivation tested against `S1A_..._063027_07E8C5_7795-SLC` (the SLC where the bug was first observed). Generates 27 burst IDs that match exactly the 27 OPERA RTC products in CMR (mix of T130 + T131, due to genuine ANX crossing mid-acquisition).
- Pure-Python formula matches `s1reader.S1BurstId.from_burst_params()` constants (T_beam=2.758273, T_pre=2.299849, T_orb=12·86400/175, subswath offsets 0.832 / 1.078 / 0.848).
- No new external dependency added.

## Test plan

- [ ] Re-run Jan-Jun 2026 RTC + CSLC audits with this branch (cache invalidation will force fresh derivations).
- [ ] Diff resulting "missing SLC" batches against batches already sent (1-10) to identify previously-listed false positives we can tell OPS to skip.
- [ ] Verify `NOT caching` warnings stay correlated with real CMR degradations (not silent loss).
