### PR TITLE
Reduce dataset metadata for all products when not updating

### DIFF
--- a/extractor/extract.py
+++ b/extractor/extract.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess
 import sys
 import traceback
+from copy import deepcopy
 from datetime import datetime, timezone
 from importlib import import_module
 from pathlib import Path
@@ -291,7 +292,7 @@ def extract_metadata(product, product_types, catalog_met=None):
                 config = product_types[product_type].get('Configuration', {})
 
                 if catalog_met is not None:
-                    config["catalog_metadata"] = catalog_met
+                    config["catalog_metadata"] = deepcopy(catalog_met)
 
                 extractor_tokens = extractor.rsplit(".", 1)  # e.g. "extractor.FilenameRegexMetExtractor"
                 module = import_module(extractor)

--- a/opera_chimera/opera_pge_job_submitter.py
+++ b/opera_chimera/opera_pge_job_submitter.py
@@ -152,7 +152,7 @@ class OperaPgeJobSubmitter(PgeJobSubmitter):
             # set additional files to triage
             self._context["_triage_additional_globs"] = [
                 "output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir",
-                "pge_output_dir", "pge_scratch_dir"
+                "pge_output_dir", "pge_scratch_dir", "sfl_output"
             ]
 
             # set force publish (disable no-clobber)

--- a/opera_chimera/run_sciflo.sh
+++ b/opera_chimera/run_sciflo.sh
@@ -8,6 +8,7 @@ export PYTHONPATH=$BASE_PATH:$CHIMERA_HOME:$PYTHONPATH
 export PATH=$BASE_PATH:$PATH
 export PGE=$(basename "${BASE_PATH}")
 export PYTHONDONTWRITEBYTECODE=1
+export PYTHONUNBUFFERED=1
 
 # source environment
 source $HOME/verdi/bin/activate

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -366,7 +366,7 @@ def scrub_dataset_met(dataset_met):
 def dataset_met_simplify_lineage(dataset_met):
     logger.info("Reducing lineage string size by truncating basepath of lineage entries")
     logger.info("dataset_met_json keys: " + str(dataset_met.keys()))
-    if len(dataset_met["lineage"]) > 0:
+    if len(dataset_met["lineage"]) > 1:
         lineage_basepath = os.path.commonpath(dataset_met["lineage"])
         if not lineage_basepath.endswith('/'):
             lineage_basepath += '/'

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -188,6 +188,7 @@ def convert(
                 dataset_met_json["input_granule_id"] = str(PurePath(product_metadata["id"]))  # strip band from ID to get granule ID
             elif pge_name in ("L2_CSLC_S1", "L2_CSLC_S1_STATIC", "L2_RTC_S1", "L2_RTC_S1_STATIC"):
                 dataset_met_json["input_granule_id"] = product_metadata["id"]
+                logger.info(f'extra_met={json.dumps(extra_met, indent=2)}')
                 dataset_met_json["orbit_file"] = PurePath(extra_met["runconfig"]["localize"][0]).name
             elif pge_name == "L3_DSWx_S1":
                 dataset_met_json["input_granule_id"] = product_metadata["id"]

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -189,7 +189,6 @@ def convert(
                 dataset_met_json["input_granule_id"] = str(PurePath(product_metadata["id"]))  # strip band from ID to get granule ID
             elif pge_name in ("L2_CSLC_S1", "L2_CSLC_S1_STATIC", "L2_RTC_S1", "L2_RTC_S1_STATIC"):
                 dataset_met_json["input_granule_id"] = product_metadata["id"]
-                print(f'extra_met={json.dumps(extra_met, indent=2)}', flush=True)
                 dataset_met_json["orbit_file"] = PurePath(extra_met["runconfig"]["localize"][0]).name
             elif pge_name == "L3_DSWx_S1":
                 dataset_met_json["input_granule_id"] = product_metadata["id"]

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -327,13 +327,9 @@ def convert(
         dataset_met_json.update(extra_met)
         dataset_met_json_path = os.path.join(dataset_dir, f"{dataset_id}.met.json")
 
-        if pge_name == "L3_DISP_S1" and job_json_dict["params"]["wf_name"] != 'Product_Update':
+        if job_json_dict["params"]["wf_name"] != 'Product_Update':
             # Get rid of bunch of data that we don't care about but takes up a lot of space
-            logger.info("Removing superfluous data from DISP-S1 metadata")
-            scrub_dataset_met(dataset_met_json)
-            dataset_met_simplify_lineage(dataset_met_json)
-        elif pge_name == 'L3_DIST_S1':
-            logger.info("Removing superfluous data from DIST-S1 metadata")
+            logger.info(f"Removing superfluous data from {pge_name} metadata")
             scrub_dataset_met(dataset_met_json)
             dataset_met_simplify_lineage(dataset_met_json)
 

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -201,6 +201,7 @@ def convert(
 
                 # When running PGE simulation mode the iso xml product will be fake,
                 # so we need to handle that accordingly here
+                raise RuntimeError('TRIAGE TEST')
                 try:
                     iso_xml = iso_xml_reader.read_iso_xml_as_dict(iso_xml_path)
                 except Exception as err:

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -201,7 +201,6 @@ def convert(
 
                 # When running PGE simulation mode the iso xml product will be fake,
                 # so we need to handle that accordingly here
-                raise RuntimeError('TRIAGE TEST')
                 try:
                     iso_xml = iso_xml_reader.read_iso_xml_as_dict(iso_xml_path)
                 except Exception as err:

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -15,6 +15,7 @@ import shutil
 import subprocess
 import sys
 import traceback
+from copy import deepcopy
 from pathlib import PurePath, Path
 from typing import Union, Tuple
 
@@ -325,7 +326,7 @@ def convert(
 
         logger.info(f"Setting CollectionName {collection_name} for DAAC delivery.")
 
-        dataset_met_json.update(extra_met)
+        dataset_met_json.update(deepcopy(extra_met))
         dataset_met_json_path = os.path.join(dataset_dir, f"{dataset_id}.met.json")
 
         if job_json_dict["params"]["wf_name"] != 'Product_Update':

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -188,7 +188,7 @@ def convert(
                 dataset_met_json["input_granule_id"] = str(PurePath(product_metadata["id"]))  # strip band from ID to get granule ID
             elif pge_name in ("L2_CSLC_S1", "L2_CSLC_S1_STATIC", "L2_RTC_S1", "L2_RTC_S1_STATIC"):
                 dataset_met_json["input_granule_id"] = product_metadata["id"]
-                logger.info(f'extra_met={json.dumps(extra_met, indent=2)}')
+                print(f'extra_met={json.dumps(extra_met, indent=2)}', flush=True)
                 dataset_met_json["orbit_file"] = PurePath(extra_met["runconfig"]["localize"][0]).name
             elif pge_name == "L3_DSWx_S1":
                 dataset_met_json["input_granule_id"] = product_metadata["id"]

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -365,10 +365,13 @@ def dataset_met_simplify_lineage(dataset_met):
     logger.info("Reducing lineage string size by truncating basepath of lineage entries")
     logger.info("dataset_met_json keys: " + str(dataset_met.keys()))
     if len(dataset_met["lineage"]) > 0:
-        dataset_met["lineage_basepath"] = '/'.join(dataset_met["lineage"][0].split('/')[:-1])
+        lineage_basepath = os.path.commonpath(dataset_met["lineage"])
+        if not lineage_basepath.endswith('/'):
+            lineage_basepath += '/'
+        dataset_met["lineage_basepath"] = lineage_basepath
         lineage_arr = []
         for l in dataset_met["lineage"]:
-            lineage_arr.append(l.split('/')[-1])
+            lineage_arr.append(l.removeprefix(lineage_basepath))
         dataset_met["lineage"] = lineage_arr
 
     return dataset_met

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -86,8 +86,7 @@ def main(job_json_file: str, workdir: str):
     # set additional files to triage
     jc.set(
         '_triage_additional_globs',
-        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir",
-         "pge_output_dir", "pge_scratch_dir", "sfl_output"]
+        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir", "pge_scratch_dir"]
     )
 
     # Disable no-clobber errors for published files. Either the file naming conventions

--- a/wrapper/opera_pge_wrapper.py
+++ b/wrapper/opera_pge_wrapper.py
@@ -86,7 +86,8 @@ def main(job_json_file: str, workdir: str):
     # set additional files to triage
     jc.set(
         '_triage_additional_globs',
-        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir", "pge_output_dir", "pge_scratch_dir"]
+        ["output", "RunConfig.yaml", "pge_input_dir", "pge_runconfig_dir",
+         "pge_output_dir", "pge_scratch_dir", "sfl_output"]
     )
 
     # Disable no-clobber errors for published files. Either the file naming conventions


### PR DESCRIPTION
## Purpose
- For all products:
  - Remove highly duplicated fields
  - Simplify lineage metadata paths
- Also added SCIFLO output dir to triage globs as important logging information was being lost in there on error

## Issues
- [OPERA-2452](https://hysds-core.atlassian.net/browse/OPERA-2452)
## Testing
- [x] DSWx-HLS
- [x] RTC-S1
- [x] CSLC-S1
- [x] RTC-S1-STATIC
- [x] CSLC-S1-STATIC
- [x] DSWx-S1
- [x] DISP-S1
- [x] DISP-S1-STATIC
- [x] TROPO
- [x] DIST-S1
- [x] DSWx-NI
- [x] DISP-NI
- [x] CAL-DISP
- [x] Triage
