### PR TITLE
Improve run time for HLS/SLC query jobs

### DIFF
--- a/data_subscriber/catalog.py
+++ b/data_subscriber/catalog.py
@@ -32,6 +32,10 @@ class BulkCatalog:
             'doc': doc
         })
 
+        if len(self._operations) % 1000 == 0:
+            # Log something occasionally so we know the job is still running
+            self._logger.info(f'Added operation {len(self._operations)} to bulk action')
+
         self._complete = False
 
     def commit(self, refresh=False):

--- a/data_subscriber/catalog.py
+++ b/data_subscriber/catalog.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import elasticsearch
 import backoff
-from opensearchpy.helpers import bulk
+from opensearchpy.helpers import bulk as bulk_helper
 
 from data_subscriber import es_conn_util
 from data_subscriber.url import form_batch_id
@@ -45,7 +45,7 @@ class BulkCatalog:
         self._logger.info(f'Performing {len(self._operations):,} bulk operations')
         start_t = datetime.now()
         # TODO: Should there be error checking here?
-        bulk(self._es, self._operations)
+        bulk_helper(self._es, self._operations)
         self._logger.info(f'Completed {len(self._operations):,} bulk operations in {datetime.now() - start_t}')
 
         if refresh:
@@ -65,6 +65,7 @@ class ProductCatalog(ABC):
     # The following constants should be overwritten by inheritors at their class level
     ES_INDEX_PATTERNS = None
     NAME = None
+    BATCH_ID_KEYWORD = 'download_batch_id'
 
     def __init__(self, logger=None):
         self.logger = logger or null_logger
@@ -195,7 +196,7 @@ class ProductCatalog(ABC):
                 "query": {
                     "bool": {
                         "must": [
-                            {"match": {"download_batch_id.keyword": batch_id}}
+                            {"match": {f"{self.BATCH_ID_KEYWORD}.keyword": batch_id}}
                         ]
                     }
                 }

--- a/data_subscriber/catalog.py
+++ b/data_subscriber/catalog.py
@@ -3,6 +3,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Lock
 
 import elasticsearch
 import backoff
@@ -22,21 +23,23 @@ class BulkCatalog:
         self._es = es_conn_util.get_es_connection(logger).es
         self._operations = []
         self._complete = False
+        self._lock = Lock()
 
     def add(self, doc, doc_id, index, op_type='update', doc_as_upsert=True):
-        self._operations.append({
-            '_op_type': op_type,
-            '_index': index,
-            '_id': doc_id,
-            'doc_as_upsert': doc_as_upsert,
-            'doc': doc
-        })
+        with self._lock:
+            self._operations.append({
+                '_op_type': op_type,
+                '_index': index,
+                '_id': doc_id,
+                'doc_as_upsert': doc_as_upsert,
+                'doc': doc
+            })
 
-        if len(self._operations) % 1000 == 0:
-            # Log something occasionally so we know the job is still running
-            self._logger.info(f'Added operation {len(self._operations)} to bulk action')
+            if len(self._operations) % 1000 == 0:
+                # Log something occasionally so we know the job is still running
+                self._logger.info(f'Added operation {len(self._operations):,} to bulk action')
 
-        self._complete = False
+            self._complete = False
 
     def commit(self, refresh=False):
         if self._complete:

--- a/data_subscriber/catalog.py
+++ b/data_subscriber/catalog.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import elasticsearch
 import backoff
+from opensearchpy.helpers import bulk
 
 from data_subscriber import es_conn_util
 from data_subscriber.url import form_batch_id
@@ -13,6 +14,45 @@ from data_subscriber.url import form_batch_id
 null_logger = logging.getLogger('dummy')
 null_logger.addHandler(logging.NullHandler())
 null_logger.propagate = False
+
+
+class BulkCatalog:
+    def __init__(self, logger):
+        self._logger = logger
+        self._es = es_conn_util.get_es_connection(logger).es
+        self._operations = []
+        self._complete = False
+
+    def add(self, doc, doc_id, index, op_type='update', doc_as_upsert=True):
+        self._operations.append({
+            '_op_type': op_type,
+            '_index': index,
+            '_id': doc_id,
+            'doc_as_upsert': doc_as_upsert,
+            'doc': doc
+        })
+
+        self._complete = False
+
+    def commit(self, refresh=False):
+        if self._complete:
+            raise RuntimeError('Bulk operations already completed')
+
+        self._logger.info(f'Performing {len(self._operations):,} bulk operations')
+        start_t = datetime.now()
+        # TODO: Should there be error checking here?
+        bulk(self._es, self._operations)
+        self._logger.info(f'Completed {len(self._operations):,} bulk operations in {datetime.now() - start_t}')
+
+        if refresh:
+            indices = set([o['_index'] for o in self._operations])
+
+            for index in indices:
+                self._logger.info(f'Refreshing index {index}')
+                self._es.indices.refresh(index=index, allow_no_indices=True)
+
+        self._complete = True
+        self._operations.clear()
 
 
 class ProductCatalog(ABC):
@@ -190,7 +230,7 @@ class ProductCatalog(ABC):
 
         self.logger.info(f"Document updated: {result}")
 
-    def process_granule(self, granule):
+    def process_granule(self, granule, bulk: BulkCatalog = None):
         if self._query_existence(granule["granule_id"]):
             self.logger.warning(f'Granule {granule["granule_id"]} already exists in DB. No additional indexing needed.')
             return
@@ -206,13 +246,18 @@ class ProductCatalog(ABC):
             "creation_timestamp": datetime.now()
         }
 
-        result = self.es_util.index_document(index=self.generate_es_index_name(), body=doc, id=granule["granule_id"])
+        index = self.generate_es_index_name()
 
-        self.logger.debug(f"Granule {granule['granule_id']} indexed: {result}")
+        if bulk is None:
+            result = self.es_util.index_document(index=self.generate_es_index_name(), body=doc, id=granule["granule_id"])
+
+            self.logger.debug(f"Granule {granule['granule_id']} indexed: {result}")
+        else:
+            bulk.add(doc, granule['granule_id'], index)
 
     def process_url(self, urls: list[str], granule: dict, job_id: str, query_dt: datetime,
                     temporal_extent_beginning_dt: datetime, revision_date_dt: datetime,
-                    filename=None, *args, **kwargs):
+                    filename=None, bulk: BulkCatalog = None, *args, **kwargs):
 
         if filename is None:
             if len(urls) == 0: # This is the case for CSLCProductCatalog and its children
@@ -242,9 +287,12 @@ class ProductCatalog(ABC):
 
         index = self._get_index_name_for(_id=doc['id'], default=self.generate_es_index_name())
 
-        result = self.es_util.update_document(index=index, body={"doc_as_upsert": True, "doc": doc}, id=doc['id'])
+        if bulk is None:
+            result = self.es_util.update_document(index=index, body={"doc_as_upsert": True, "doc": doc}, id=doc['id'])
 
-        self.logger.debug(f"Document {filename} upserted: {result}")
+            self.logger.debug(f"Document {filename} upserted: {result}")
+        else:
+            bulk.add(doc, doc['id'], index)
 
     def refresh(self):
         """

--- a/data_subscriber/catalog.py
+++ b/data_subscriber/catalog.py
@@ -179,6 +179,15 @@ class ProductCatalog(ABC):
     def granule_and_revision(self, es_id: str):
         pass
 
+    def get_query_for_download_job_marking(self, batch_id):
+        return {
+            "bool": {
+                "must": [
+                    {"match": {f"{self.BATCH_ID_KEYWORD}.keyword": batch_id}}
+                ]
+            }
+        }
+
     @backoff.on_exception(backoff.expo, exception=Exception, max_tries=3, factor=10, jitter=None)
     def mark_download_job_id(self, batch_id, job_id):
         """Stores the download_job_id in the catalog for all granules in this batch"""
@@ -193,13 +202,7 @@ class ProductCatalog(ABC):
                     },
                     "lang": "painless"
                 },
-                "query": {
-                    "bool": {
-                        "must": [
-                            {"match": {f"{self.BATCH_ID_KEYWORD}.keyword": batch_id}}
-                        ]
-                    }
-                }
+                "query": self.get_query_for_download_job_marking(batch_id),
             },
             refresh=True # refresh every time so that we don't run into doc version conflicts
         )

--- a/data_subscriber/hls/hls_catalog.py
+++ b/data_subscriber/hls/hls_catalog.py
@@ -6,6 +6,7 @@ class HLSProductCatalog(ProductCatalog):
     """Cataloging class for downloaded Harmonized Landsat and Sentinel-1 (HLS) products."""
     NAME = "hls_catalog"
     ES_INDEX_PATTERNS = "hls_catalog*"
+    BATCH_ID_KEYWORD = 'granule_id'
 
     def process_query_result(self, query_result : list[dict]):
         return [

--- a/data_subscriber/hls/hls_catalog.py
+++ b/data_subscriber/hls/hls_catalog.py
@@ -27,6 +27,18 @@ class HLSProductCatalog(ProductCatalog):
         """
         return es_id.split('-')[0], es_id.split('-r')[1]
 
+    def get_query_for_download_job_marking(self, batch_id):
+        granule_id, revision_id = self.granule_and_revision(batch_id)
+
+        return {
+            "bool": {
+                "must": [
+                    {"match": {f"{self.BATCH_ID_KEYWORD}": granule_id}},
+                    {"match": {"revision_id": revision_id}},
+                ]
+            }
+        }
+
 
 class HLSSpatialProductCatalog(HLSProductCatalog):
     """Cataloging class for spatial regions of downloaded Harmonized Landsat and Sentinel-1 (HLS) products."""

--- a/data_subscriber/hls/hls_query.py
+++ b/data_subscriber/hls/hls_query.py
@@ -5,7 +5,7 @@ from data_subscriber.hls.hls_catalog import HLSSpatialProductCatalog
 
 class HlsCmrQuery(BaseQuery):
     """Class used to query the Common Metadata Repository (CMR) for Harmonized Landsat and Sentinel-1 (HLS) products."""
-    def update_granule_index(self, granule):
+    def update_granule_index(self, granule, bulk=None):
         spatial_catalog_conn = HLSSpatialProductCatalog(self.logger)
         spatial_catalog_conn.process_granule(granule)
 

--- a/data_subscriber/hls/hls_query.py
+++ b/data_subscriber/hls/hls_query.py
@@ -7,7 +7,7 @@ class HlsCmrQuery(BaseQuery):
     """Class used to query the Common Metadata Repository (CMR) for Harmonized Landsat and Sentinel-1 (HLS) products."""
     def update_granule_index(self, granule, bulk=None):
         spatial_catalog_conn = HLSSpatialProductCatalog(self.logger)
-        spatial_catalog_conn.process_granule(granule)
+        spatial_catalog_conn.process_granule(granule, bulk=bulk)
 
     def determine_download_granules(self, granules):
         if not self.args.granule_dedupe or self.args.native_id:

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -72,6 +72,11 @@ class BaseQuery:
             download_granules = self.determine_download_granules(granules)
 
             self.logger.info("Granule Cataloguing STARTED")
+
+            # TODO: Can we make this reduction for ALL/MORE product types?
+            if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] in [ProductType.HLS, ProductType.SLC]:
+                self.logger.info('[HLS/SLC] Reducing catalog entries to deduped granules')
+                granules = download_granules
             self.logger.info(f"Number of granules to be catalogued: {len(granules)}")
             self.catalog_granules(granules, query_dt)
             self.logger.info("Granule Cataloguing FINISHED")

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -251,7 +251,7 @@ class BaseQuery:
         exec_class = ThreadPoolExecutor if parallelize else DummyThreadPoolExecutor
 
         with exec_class() as executor:
-            self.logger(f'Cataloging granules with executor {type(executor)}, n_workers={executor._max_workers}')
+            self.logger.info(f'Cataloging granules with executor {type(executor)}, n_workers={executor._max_workers}')
             futures = []
 
             for granule in granules:
@@ -379,7 +379,7 @@ class BaseQuery:
         exec_class = ThreadPoolExecutor if mark_docs_in_parallel else DummyThreadPoolExecutor
 
         with exec_class() as executor:
-            self.logger(f'Submitting download jobs with executor {type(executor)}, n_workers={executor._max_workers}')
+            self.logger.info(f'Submitting download jobs with executor {type(executor)}, n_workers={executor._max_workers}')
             futures = []
 
             for batch_chunk in self.get_download_chunks(batch_id_to_urls_map):

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -18,6 +18,7 @@ from data_subscriber.cmr import (async_query_cmr, response_jsons_to_cmr_granules
                                  COLLECTION_TO_PRODUCT_TYPE_MAP,
                                  COLLECTION_TO_PROVIDER_TYPE_MAP,
                                  Provider)
+from data_subscriber.catalog import BulkCatalog
 from data_subscriber.cslc.cslc_dependency import CSLCDependency
 from data_subscriber.cslc_utils import split_download_batch_id, save_blocked_download_job, PENDING_TYPE_CSLC_DOWNLOAD
 from data_subscriber.esa_dataspace import async_query_dataspace
@@ -77,8 +78,14 @@ class BaseQuery:
             if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] in [ProductType.HLS, ProductType.SLC]:
                 self.logger.info('[HLS/SLC] Reducing catalog entries to deduped granules')
                 granules = download_granules
+                use_bulk = True
+            else:
+                use_bulk = False
+
             self.logger.info(f"Number of granules to be catalogued: {len(granules)}")
-            self.catalog_granules(granules, query_dt)
+            res = self.catalog_granules(granules, query_dt, use_bulk=use_bulk)
+            if res is not None:
+                res.commit()
             self.logger.info("Granule Cataloguing FINISHED")
         else:
             # DSWX-NI needs cataloging done before download determination
@@ -208,9 +215,10 @@ class BaseQuery:
     def determine_download_granules(self, granules):
         return granules
 
-    def catalog_granules(self, granules, query_dt, force_es_conn = None):
-
+    def catalog_granules(self, granules, query_dt, force_es_conn=None, use_bulk=False):
         es_conn = force_es_conn if force_es_conn else self.es_conn
+
+        bulk = BulkCatalog(self.logger) if use_bulk else None
 
         for granule in granules:
             granule_id = granule.get("granule_id")
@@ -225,10 +233,13 @@ class BaseQuery:
                 query_dt,
                 temporal_extent_beginning_dt=dateutil.parser.isoparse(granule["temporal_extent_beginning_datetime"]),
                 revision_date_dt=dateutil.parser.isoparse(granule["revision_date"]),
+                bulk=bulk,
                 **additional_fields
             )
 
-            self.update_granule_index(granule)
+            self.update_granule_index(granule, bulk=bulk)
+
+        return bulk
 
     def update_url_index(
             self,
@@ -239,6 +250,7 @@ class BaseQuery:
             query_dt: datetime,
             temporal_extent_beginning_dt: datetime,
             revision_date_dt: datetime,
+            bulk: BulkCatalog = None,
             *args,
             **kwargs
     ):
@@ -250,9 +262,9 @@ class BaseQuery:
 
         for filename, filename_urls in filename_to_urls_map.items():
             es_conn.process_url(filename_urls, granule, job_id, query_dt, temporal_extent_beginning_dt,
-                                revision_date_dt, *args, **kwargs)
+                                revision_date_dt, bulk=bulk, *args, **kwargs)
 
-    def update_granule_index(self, granule):
+    def update_granule_index(self, granule, bulk: BulkCatalog = None):
         pass
 
     def refresh_index(self):

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -109,6 +109,8 @@ class BaseQuery:
 
             parallelize = False
 
+        self.es_conn.es_util.es.indices.refresh(index=self.es_conn.ES_INDEX_PATTERNS)
+
         '''TODO: Optional. For CSLC query jobs, make sure that we got all the bursts here according to database json.
         Otherwise, fail this job'''
 

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -88,7 +88,7 @@ class BaseQuery:
                 parallelize = False
 
             self.logger.info(f"Number of granules to be catalogued: {len(granules)}")
-            res = self.catalog_granules(granules, query_dt, use_bulk=use_bulk)
+            res = self.catalog_granules(granules, query_dt, use_bulk=use_bulk, parallelize=parallelize)
             if res is not None:
                 res.commit()
             self.logger.info("Granule Cataloguing FINISHED")
@@ -242,7 +242,6 @@ class BaseQuery:
         )
 
         self.update_granule_index(granule, bulk=bulk)
-
 
     def catalog_granules(self, granules, query_dt, force_es_conn=None, use_bulk=False, parallelize=False):
         es_conn = force_es_conn if force_es_conn else self.es_conn

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -249,9 +249,9 @@ class BaseQuery:
 
         bulk = BulkCatalog(self.logger) if use_bulk else None
         exec_class = ThreadPoolExecutor if parallelize else DummyThreadPoolExecutor
-        self.logger(f'Cataloging granules with executor {type(exec_class)}, n_workers={exec_class._max_workers}')
 
         with exec_class() as executor:
+            self.logger(f'Cataloging granules with executor {type(executor)}, n_workers={executor._max_workers}')
             futures = []
 
             for granule in granules:
@@ -377,9 +377,9 @@ class BaseQuery:
             )
 
         exec_class = ThreadPoolExecutor if mark_docs_in_parallel else DummyThreadPoolExecutor
-        self.logger(f'Submitting download jobs with executor {type(exec_class)}, n_workers={exec_class._max_workers}')
 
         with exec_class() as executor:
+            self.logger(f'Submitting download jobs with executor {type(executor)}, n_workers={executor._max_workers}')
             futures = []
 
             for batch_chunk in self.get_download_chunks(batch_id_to_urls_map):

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -350,7 +350,7 @@ class BaseQuery:
         )
 
         for batch_id, urls in batch_chunk:
-            self.es_conn.mark_download_job_id(download_job_id, batch_id)
+            self.es_conn.mark_download_job_id(batch_id, download_job_id)
 
         return download_job_id
 

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -4,7 +4,9 @@ import asyncio
 import hashlib
 import uuid
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from functools import partial
 from pathlib import Path
 import json
 
@@ -27,6 +29,7 @@ from data_subscriber.geojson_utils import (localize_include_exclude,
 from data_subscriber.rtc.rtc_download_job_submitter import submit_rtc_download_job_submissions_tasks
 from data_subscriber.url import form_batch_id, _slc_url_to_chunk_id
 from hysds_commons.job_utils import submit_mozart_job
+from util.exec_util import DummyThreadPoolExecutor
 
 
 class BaseQuery:
@@ -79,8 +82,10 @@ class BaseQuery:
                 self.logger.info('[HLS/SLC] Reducing catalog entries to deduped granules')
                 granules = download_granules
                 use_bulk = True
+                parallel_mark = True
             else:
                 use_bulk = False
+                parallel_mark = False
 
             self.logger.info(f"Number of granules to be catalogued: {len(granules)}")
             res = self.catalog_granules(granules, query_dt, use_bulk=use_bulk)
@@ -101,6 +106,8 @@ class BaseQuery:
 
             gcov_granules, mgrs_sets_and_cycle_numbers, docs = self.determine_download_granules(granules)
             download_granules = mgrs_sets_and_cycle_numbers
+
+            parallel_mark = False
 
         '''TODO: Optional. For CSLC query jobs, make sure that we got all the bursts here according to database json.
         Otherwise, fail this job'''
@@ -140,7 +147,9 @@ class BaseQuery:
             job_submission_tasks = self.submit_gcov_download_job_submission_handler(mgrs_sets_and_cycle_numbers, gcov_granules, docs)
             results = job_submission_tasks
         else:
-            job_submission_tasks = self.download_job_submission_handler(download_granules, query_timerange)
+            job_submission_tasks = self.download_job_submission_handler(
+                download_granules, query_timerange, mark_docs_in_parallel=parallel_mark
+            )
             results = job_submission_tasks
 
         succeeded = [job_id for job_id in results if isinstance(job_id, str)]
@@ -270,7 +279,7 @@ class BaseQuery:
     def refresh_index(self):
         pass
 
-    def download_job_submission_handler(self, granules, query_timerange):
+    def download_job_submission_handler(self, granules, query_timerange, mark_docs_in_parallel=False):
         batch_id_to_urls_map = defaultdict(set)
 
         # DIST-S1 products are generated from RTC input files. RTC input files are also used by DSWx-S1 products.
@@ -312,14 +321,16 @@ class BaseQuery:
 
         self.logger.debug(f"{batch_id_to_urls_map=}")
 
-        job_submission_tasks = self.submit_download_job_submissions_tasks(batch_id_to_urls_map, query_timerange)
+        job_submission_tasks = self.submit_download_job_submissions_tasks(
+            batch_id_to_urls_map, query_timerange, mark_docs_in_parallel=mark_docs_in_parallel
+        )
 
         return job_submission_tasks
 
     def get_download_chunks(self, batch_id_to_urls_map):
         return chunked(batch_id_to_urls_map.items(), n=self.args.chunk_size)
 
-    def submit_download_job_submissions_tasks(self, batch_id_to_urls_map, query_timerange):
+    def submit_download_job_submissions_tasks(self, batch_id_to_urls_map, query_timerange, mark_docs_in_parallel=False):
         job_submission_tasks = []
 
         if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.CSLC:
@@ -395,9 +406,19 @@ class BaseQuery:
                     payload_hash = payload_hash
                 )
 
-            # Record download job id in ES
-            for batch_id, urls in batch_chunk:
-                self.es_conn.mark_download_job_id(batch_id, download_job_id)
+            exec_class = ThreadPoolExecutor if mark_docs_in_parallel else DummyThreadPoolExecutor
+
+            with exec_class() as executor:
+                futures = []
+                fn = partial(self.es_conn.mark_download_job_id, job_id=download_job_id)
+
+                # Record download job id in ES
+                for batch_id, urls in batch_chunk:
+                    futures.append(executor.submit(fn, batch_id))
+                    # self.es_conn.mark_download_job_id(batch_id, download_job_id)
+
+                for future in futures:
+                    future.result()
 
             job_submission_tasks.append(download_job_id)
 

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -330,6 +330,30 @@ class BaseQuery:
     def get_download_chunks(self, batch_id_to_urls_map):
         return chunked(batch_id_to_urls_map.items(), n=self.args.chunk_size)
 
+    def _submit_and_mark_one_job(
+            self,
+            batch_chunk,
+            release_version,
+            product_type,
+            params,
+            job_queue,
+            job_name,
+            payload_hash
+    ):
+        download_job_id = submit_download_job(
+            release_version=release_version,
+            product_type=product_type,
+            params=params,
+            job_queue=job_queue,
+            job_name=job_name,
+            payload_hash=payload_hash
+        )
+
+        for batch_id, urls in batch_chunk:
+            self.es_conn.mark_download_job_id(download_job_id, batch_id)
+
+        return download_job_id
+
     def submit_download_job_submissions_tasks(self, batch_id_to_urls_map, query_timerange, mark_docs_in_parallel=False):
         job_submission_tasks = []
 
@@ -340,87 +364,81 @@ class BaseQuery:
                 self.token, self.cmr, self.settings, self.blackout_dates_obj
             )
 
-        for batch_chunk in self.get_download_chunks(batch_id_to_urls_map):
-            chunk_batch_ids = []
-            chunk_urls = []
-            for batch_id, urls in batch_chunk:
-                chunk_batch_ids.append(batch_id)
-                chunk_urls.extend(urls)
+        exec_class = ThreadPoolExecutor if mark_docs_in_parallel else DummyThreadPoolExecutor
 
-            # If we are downlaoding SLC input data, we will compute payload hash using the granule_id without the revision_id
-            # NOTE: This will only work properly if the chunk size is 1 which should always be the case for SLC downloads
-            payload_hash = None
-            if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.SLC:
-                granule_to_hash = ''
-                for batch_id in chunk_batch_ids:
-                    granule_id, revision_id = self.es_conn.granule_and_revision(batch_id)
-                    granule_to_hash += granule_id
+        with exec_class() as executor:
+            futures = []
 
-                payload_hash = hashlib.md5(granule_to_hash.encode()).hexdigest()
+            for batch_chunk in self.get_download_chunks(batch_id_to_urls_map):
+                chunk_batch_ids = []
+                chunk_urls = []
+                for batch_id, urls in batch_chunk:
+                    chunk_batch_ids.append(batch_id)
+                    chunk_urls.extend(urls)
 
-            self.logger.debug(f"{chunk_batch_ids=}")
-            self.logger.debug(f"{payload_hash=}")
-            self.logger.debug(f"{chunk_urls=}")
+                # If we are downlaoding SLC input data, we will compute payload hash using the granule_id without the revision_id
+                # NOTE: This will only work properly if the chunk size is 1 which should always be the case for SLC downloads
+                payload_hash = None
+                if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.SLC:
+                    granule_to_hash = ''
+                    for batch_id in chunk_batch_ids:
+                        granule_id, revision_id = self.es_conn.granule_and_revision(batch_id)
+                        granule_to_hash += granule_id
 
-            params = self.create_download_job_params(query_timerange, chunk_batch_ids)
+                    payload_hash = hashlib.md5(granule_to_hash.encode()).hexdigest()
 
-            product_type = COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection].lower()
-            if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.CSLC:
-                frame_id = split_download_batch_id(chunk_batch_ids[0])[0]
-                acq_indices = [split_download_batch_id(chunk_batch_id)[1] for chunk_batch_id in chunk_batch_ids]
-                job_name = f"job-WF-{product_type}_download-frame-{frame_id}-acq_indices-{min(acq_indices)}-to-{max(acq_indices)}"
+                self.logger.debug(f"{chunk_batch_ids=}")
+                self.logger.debug(f"{payload_hash=}")
+                self.logger.debug(f"{chunk_urls=}")
 
-                # See if all the compressed cslcs are satisfied. If not, do not submit the job. Instead, save all the job info in ES
-                # and wait for the next query to come in. Any acquisition index will work because all batches
-                # require the same compressed cslcs
-                if not cslc_dependency.compressed_cslc_satisfied(frame_id, acq_indices[0], self.es_conn.es_util):
-                    self.logger.info(f"Not all compressed CSLCs are satisfied so this download job is blocked until they are satisfied.")
-                    add_attributes = {
-                        "frame_id": frame_id,
-                        "acq_index": acq_indices[0],
-                        "k": self.args.k,
-                        "m": self.args.m,
-                        "batch_ids": chunk_batch_ids
-                    }
-                    save_blocked_download_job(self.es_conn.es_util, PENDING_TYPE_CSLC_DOWNLOAD, self.settings["RELEASE_VERSION"],
-                                              product_type, params, self.args.job_queue, job_name, add_attributes)
+                params = self.create_download_job_params(query_timerange, chunk_batch_ids)
 
-                    # While we technically do not have a download job here, we mark it as so in ES.
-                    # That's because this flag is used to determine if the granule has been triggered or not
-                    for batch_id, urls in batch_chunk:
-                        self.es_conn.mark_download_job_id(batch_id, "PENDING")
+                product_type = COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection].lower()
+                if COLLECTION_TO_PRODUCT_TYPE_MAP[self.args.collection] == ProductType.CSLC:
+                    frame_id = split_download_batch_id(chunk_batch_ids[0])[0]
+                    acq_indices = [split_download_batch_id(chunk_batch_id)[1] for chunk_batch_id in chunk_batch_ids]
+                    job_name = f"job-WF-{product_type}_download-frame-{frame_id}-acq_indices-{min(acq_indices)}-to-{max(acq_indices)}"
 
-                    continue # don't actually submit download job
-            elif self.args.product == PGEProduct.DIST_1:
-                product_type = "rtc_for_dist"
-                job_name = f"job-WF-{product_type}_download-{chunk_batch_ids[0]}"
+                    # See if all the compressed cslcs are satisfied. If not, do not submit the job. Instead, save all the job info in ES
+                    # and wait for the next query to come in. Any acquisition index will work because all batches
+                    # require the same compressed cslcs
+                    if not cslc_dependency.compressed_cslc_satisfied(frame_id, acq_indices[0], self.es_conn.es_util):
+                        self.logger.info(f"Not all compressed CSLCs are satisfied so this download job is blocked until they are satisfied.")
+                        add_attributes = {
+                            "frame_id": frame_id,
+                            "acq_index": acq_indices[0],
+                            "k": self.args.k,
+                            "m": self.args.m,
+                            "batch_ids": chunk_batch_ids
+                        }
+                        save_blocked_download_job(self.es_conn.es_util, PENDING_TYPE_CSLC_DOWNLOAD, self.settings["RELEASE_VERSION"],
+                                                  product_type, params, self.args.job_queue, job_name, add_attributes)
 
-            else:
-                job_name = f"job-WF-{product_type}_download-{chunk_batch_ids[0]}"
+                        # While we technically do not have a download job here, we mark it as so in ES.
+                        # That's because this flag is used to determine if the granule has been triggered or not
+                        for batch_id, urls in batch_chunk:
+                            self.es_conn.mark_download_job_id(batch_id, "PENDING")
 
-            download_job_id = submit_download_job(release_version=self.args.release_version or self.settings["RELEASE_VERSION"],
+                        continue # don't actually submit download job
+                elif self.args.product == PGEProduct.DIST_1:
+                    product_type = "rtc_for_dist"
+                    job_name = f"job-WF-{product_type}_download-{chunk_batch_ids[0]}"
+
+                else:
+                    job_name = f"job-WF-{product_type}_download-{chunk_batch_ids[0]}"
+
+                futures.append(executor.submit(
+                    self._submit_and_mark_one_job,
+                    batch_chunk,
+                    release_version=self.args.release_version or self.settings['RELEASE_VERSION'],
                     product_type=product_type,
                     params=params,
                     job_queue=self.args.job_queue,
-                    job_name = job_name,
-                    payload_hash = payload_hash
-                )
+                    job_name=job_name,
+                    payload_hash=payload_hash,
+                ))
 
-            exec_class = ThreadPoolExecutor if mark_docs_in_parallel else DummyThreadPoolExecutor
-
-            with exec_class() as executor:
-                futures = []
-                fn = partial(self.es_conn.mark_download_job_id, job_id=download_job_id)
-
-                # Record download job id in ES
-                for batch_id, urls in batch_chunk:
-                    futures.append(executor.submit(fn, batch_id))
-                    # self.es_conn.mark_download_job_id(batch_id, download_job_id)
-
-                for future in futures:
-                    future.result()
-
-            job_submission_tasks.append(download_job_id)
+            job_submission_tasks.extend([f.result() for f in futures])
 
         return job_submission_tasks
 

--- a/data_subscriber/query.py
+++ b/data_subscriber/query.py
@@ -82,10 +82,10 @@ class BaseQuery:
                 self.logger.info('[HLS/SLC] Reducing catalog entries to deduped granules')
                 granules = download_granules
                 use_bulk = True
-                parallel_mark = True
+                parallelize = True
             else:
                 use_bulk = False
-                parallel_mark = False
+                parallelize = False
 
             self.logger.info(f"Number of granules to be catalogued: {len(granules)}")
             res = self.catalog_granules(granules, query_dt, use_bulk=use_bulk)
@@ -107,7 +107,7 @@ class BaseQuery:
             gcov_granules, mgrs_sets_and_cycle_numbers, docs = self.determine_download_granules(granules)
             download_granules = mgrs_sets_and_cycle_numbers
 
-            parallel_mark = False
+            parallelize = False
 
         '''TODO: Optional. For CSLC query jobs, make sure that we got all the bursts here according to database json.
         Otherwise, fail this job'''
@@ -148,7 +148,7 @@ class BaseQuery:
             results = job_submission_tasks
         else:
             job_submission_tasks = self.download_job_submission_handler(
-                download_granules, query_timerange, mark_docs_in_parallel=parallel_mark
+                download_granules, query_timerange, mark_docs_in_parallel=parallelize
             )
             results = job_submission_tasks
 
@@ -224,29 +224,41 @@ class BaseQuery:
     def determine_download_granules(self, granules):
         return granules
 
-    def catalog_granules(self, granules, query_dt, force_es_conn=None, use_bulk=False):
+    def _catalog_one_granule(self, granule, es_conn, query_dt, bulk=None):
+        granule_id = granule.get("granule_id")
+
+        additional_fields = self.prepare_additional_fields(granule, self.args, granule_id)
+
+        self.update_url_index(
+            es_conn,
+            granule.get("filtered_urls"),
+            granule,
+            self.job_id,
+            query_dt,
+            temporal_extent_beginning_dt=dateutil.parser.isoparse(granule["temporal_extent_beginning_datetime"]),
+            revision_date_dt=dateutil.parser.isoparse(granule["revision_date"]),
+            bulk=bulk,
+            **additional_fields
+        )
+
+        self.update_granule_index(granule, bulk=bulk)
+
+
+    def catalog_granules(self, granules, query_dt, force_es_conn=None, use_bulk=False, parallelize=False):
         es_conn = force_es_conn if force_es_conn else self.es_conn
 
         bulk = BulkCatalog(self.logger) if use_bulk else None
+        exec_class = ThreadPoolExecutor if parallelize else DummyThreadPoolExecutor
+        self.logger(f'Cataloging granules with executor {type(exec_class)}, n_workers={exec_class._max_workers}')
 
-        for granule in granules:
-            granule_id = granule.get("granule_id")
+        with exec_class() as executor:
+            futures = []
 
-            additional_fields = self.prepare_additional_fields(granule, self.args, granule_id)
+            for granule in granules:
+                futures.append(executor.submit(self._catalog_one_granule, granule, es_conn, query_dt, bulk=bulk))
 
-            self.update_url_index(
-                es_conn,
-                granule.get("filtered_urls"),
-                granule,
-                self.job_id,
-                query_dt,
-                temporal_extent_beginning_dt=dateutil.parser.isoparse(granule["temporal_extent_beginning_datetime"]),
-                revision_date_dt=dateutil.parser.isoparse(granule["revision_date"]),
-                bulk=bulk,
-                **additional_fields
-            )
-
-            self.update_granule_index(granule, bulk=bulk)
+            for future in futures:
+                _ = future.result()
 
         return bulk
 
@@ -365,6 +377,7 @@ class BaseQuery:
             )
 
         exec_class = ThreadPoolExecutor if mark_docs_in_parallel else DummyThreadPoolExecutor
+        self.logger(f'Submitting download jobs with executor {type(exec_class)}, n_workers={exec_class._max_workers}')
 
         with exec_class() as executor:
             futures = []

--- a/data_subscriber/rtc/rtc_catalog.py
+++ b/data_subscriber/rtc/rtc_catalog.py
@@ -218,7 +218,7 @@ class RTCProductCatalog(ProductCatalog):
 
     def update_granule_index(self, granule: dict, job_id: str, query_dt: datetime,
                              mgrs_set_id_acquisition_ts_cycle_indexes: list[str],
-                             **kwargs):
+                             bulk=None, **kwargs):
         urls = granule.get("filtered_urls")
         granule_id = granule.get("granule_id")
         temporal_extent_beginning_dt: datetime = dateutil.parser.isoparse(granule["temporal_extent_beginning_datetime"])
@@ -242,11 +242,14 @@ class RTCProductCatalog(ProductCatalog):
             doc.update(kwargs)
             index = self._get_index_name_for(_id=doc['id'], default=self.generate_es_index_name())
 
-            body = {
-                "doc_as_upsert": True,
-                "doc": doc
-            }
+            if bulk is None:
+                body = {
+                    "doc_as_upsert": True,
+                    "doc": doc
+                }
 
-            self.es_util.update_document(index=index, body=body, id=doc['id'])
+                self.es_util.update_document(index=index, body=body, id=doc['id'])
+            else:
+                bulk.add(doc, doc['id'], index)
 
 

--- a/data_subscriber/rtc/rtc_query.py
+++ b/data_subscriber/rtc/rtc_query.py
@@ -321,6 +321,7 @@ def update_url_index(
         query_dt: datetime,
         temporal_extent_beginning_dt: datetime,
         revision_date_dt: datetime,
+        bulk=None,
         *args,
         **kwargs
 ):
@@ -331,11 +332,11 @@ def update_url_index(
         filename_to_urls_map[filename].append(url)
 
     for filename, filename_urls in filename_to_urls_map.items():
-        es_conn.process_url(filename_urls, granule_id, job_id, query_dt, temporal_extent_beginning_dt, revision_date_dt, *args, **kwargs)
+        es_conn.process_url(filename_urls, granule_id, job_id, query_dt, temporal_extent_beginning_dt, revision_date_dt, bulk=bulk, *args, **kwargs)
 
 
-def update_granule_index(es_spatial_conn, granule, *args, **kwargs):
-    es_spatial_conn.process_granule(granule, *args, **kwargs)
+def update_granule_index(es_spatial_conn, granule, bulk=None, *args, **kwargs):
+    es_spatial_conn.process_granule(granule, bulk=bulk, *args, **kwargs)
 
 
 def does_granule_intersect_regions(granule, intersect_regions):

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -525,7 +525,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
         self.logger.info(f"{len(k_granules)=}")
         return k_granules
 
-    def download_job_submission_handler(self, total_granules, query_timerange):
+    def download_job_submission_handler(self, total_granules, query_timerange, **kwargs):
 
         def add_filtered_urls(granule, filtered_urls: list, polarization_preference: Union[set, None] =None):
             self.logger.debug(f'add_filtered_urls:: {polarization_preference=} {granule["granule_id"]}')

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -918,11 +918,12 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
             query_dt: datetime,
             temporal_extent_beginning_dt: datetime,
             revision_date_dt: datetime,
+            bulk=None,
             *args,
             **kwargs
     ):
         # We store the entire filtered_urls in the ES index from the granule dict in RTCForDistProductCatalog.form_document()
-        es_conn.process_url([], granule, job_id, query_dt, temporal_extent_beginning_dt, revision_date_dt, *args, **kwargs)
+        es_conn.process_url([], granule, job_id, query_dt, temporal_extent_beginning_dt, revision_date_dt, bulk=bulk, *args, **kwargs)
 
 
 def rtc_native_id_patterns_from_tiles(tiles: Union[list[str], set[str]]) -> set:

--- a/data_subscriber/slc/slc_catalog.py
+++ b/data_subscriber/slc/slc_catalog.py
@@ -6,6 +6,7 @@ class SLCProductCatalog(ProductCatalog):
     """Cataloging class for downloaded Single Look Complex (SLC) products."""
     NAME = "slc_catalog"
     ES_INDEX_PATTERNS = "slc_catalog*"
+    BATCH_ID_KEYWORD = 'id'
 
     def process_query_result(self, query_result: list[dict]):
         return [result['_source'] for result in (query_result or [])]

--- a/data_subscriber/slc/slc_query.py
+++ b/data_subscriber/slc/slc_query.py
@@ -16,9 +16,9 @@ class SlcCmrQuery(BaseQuery):
         # For SLC downloads we need to mark whether the granule intersects with North America
         localize_geojsons([_NORTH_AMERICA])
 
-    def update_granule_index(self, granule):
+    def update_granule_index(self, granule, bulk=None):
         spatial_catalog_conn = SLCSpatialProductCatalog(self.logger)
-        spatial_catalog_conn.process_granule(granule)
+        spatial_catalog_conn.process_granule(granule, bulk=bulk)
 
     def prepare_additional_fields(self, granule, args, granule_id):
         additional_fields = super().prepare_additional_fields(granule, args, granule_id)
@@ -41,6 +41,7 @@ class SlcCmrQuery(BaseQuery):
             query_dt: datetime,
             temporal_extent_beginning_dt: datetime,
             revision_date_dt: datetime,
+            bulk=None,
             *args,
             **kwargs
     ):
@@ -55,7 +56,7 @@ class SlcCmrQuery(BaseQuery):
 
             for filename, filename_urls in filename_to_urls_map.items():
                 es_conn.process_url(filename_urls, granule, job_id, query_dt, temporal_extent_beginning_dt,
-                                    revision_date_dt, *args, filename=filename, provider='ESA', **kwargs)
+                                    revision_date_dt, bulk=bulk, *args, filename=filename, provider='ESA', **kwargs)
         else:
             super().update_url_index(
                 es_conn,
@@ -65,6 +66,7 @@ class SlcCmrQuery(BaseQuery):
                 query_dt,
                 temporal_extent_beginning_dt,
                 revision_date_dt,
+                bulk=bulk,
                 *args,
                 **kwargs
             )

--- a/tools/send_notify_msg.sh
+++ b/tools/send_notify_msg.sh
@@ -18,5 +18,8 @@ echo "Setting workdir as $WORKDIR"
 # source environment
 source $HOME/verdi/bin/activate
 
+echo "Waiting for 6 (GRQ refresh interval + 1s) seconds to allow for GRQ documents to be indexed"
+sleep 6
+
 #$HOME/verdi/ops/CNM_product_delivery/product_delivery/utils/send_notify_msg.py $CONTEXT_FILE --reuse_md5
 $HOME/verdi/ops/CNM_product_delivery/product_delivery/utils/send_notify_msg.py $CONTEXT_FILE 

--- a/util/exec_util.py
+++ b/util/exec_util.py
@@ -5,6 +5,7 @@ import sys
 import os
 import traceback
 import json
+from concurrent.futures import Executor, Future
 from datetime import datetime, timezone
 
 from subprocess import check_output, STDOUT, CalledProcessError
@@ -108,3 +109,21 @@ def call_noerr(cmd, work_dir, logr=logger):
         logr.info("writing _pge_info.json: {}".format(info_dict))
         with open(pge_info_path, "w+") as pge_info:
             json.dump(info_dict, pge_info, indent=4)
+
+
+class DummyThreadPoolExecutor(Executor):
+    """Dummy thread pool executor to keep single threaded execution using the TPE structure."""
+
+    def __init__(self, max_workers=None, **kwargs):
+        self._max_workers = max_workers
+
+    def submit(self, fn, /, *args, **kwargs) -> Future:
+        future = Future()
+        future.set_result(fn(*args, **kwargs))
+        return future
+
+    def shutdown(self, wait = True, *, cancel_futures = False):
+        pass
+
+    def map(self, fn, *iterables, **kwargs):
+        return map(fn, *iterables)


### PR DESCRIPTION
## Purpose
This PR tries to reduce the time spent on HLS/SLC query jobs with large windows. Significant time is being spent on the cataloging and marking operations (deduping takes some time too, but significantly less so is not being addressed here)

This is accomplished with the following changes (applied to HLS/SLC):
- Only catalog granules that have been deduped
- Use ES bulk update operations for cataloging
- Parallelize download job ID marking
  - Also, fixed query for HLS so jobs are now successfully marked

## Issues
- [OPERA-2573](https://hysds-core.atlassian.net/browse/OPERA-2573)
## Testing
- [x] HLS job improved time
  - [x] Manual run on Mozart
  - [x] With timer (& optional simulated load on ES machines?)
- [x] SLC queries
- [x] Other collections to ensure things aren't broken 
