### PR TITLE
Add covered burst IDs to SLC metadata

### DIFF
--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -4,6 +4,7 @@ import json
 import netrc
 import os
 from datetime import datetime, timedelta, timezone
+from glob import glob
 from pathlib import PurePath, Path
 from os.path import abspath, getsize, join
 
@@ -11,6 +12,7 @@ import requests
 
 from data_subscriber import ionosphere_download
 from data_subscriber.download import BaseDownload
+from data_subscriber.slc.slc_utils import get_bursts
 from data_subscriber.url import (
     _has_url, _to_urls, _to_https_urls, _slc_url_to_chunk_id, form_batch_id
 )
@@ -99,6 +101,12 @@ class AsfDaacSlcDownload(BaseDownload):
             # Check for any empty files now, so we can fail during this download job
             # rather than during the SCIFLO job.
             self.check_for_empty_orbit_files(new_dataset_dir)
+
+            try:
+                self.insert_burst_coverage_to_metadata(new_dataset_dir)
+            except Exception as e:
+                # TODO: Should this be caught or should this fail out?
+                self.logger.error(f'Failed to get burst info: {e}')
 
             if additional_metadata['processing_mode'] in ("historical", "reprocessing"):
                 self.logger.info(
@@ -281,3 +289,18 @@ class AsfDaacSlcDownload(BaseDownload):
     def get_dataspace_login(self):
         username, _, password = netrc.netrc().authenticators(DEFAULT_DATASPACE_ENDPOINT)
         return username, password
+
+    def insert_burst_coverage_to_metadata(self, dataset_dir: PurePath):
+        safe_path = glob(str(dataset_dir / '*.zip'))[0]
+        orbit_path = glob(str(dataset_dir / '*.EOF'))[0]
+        met_path = glob(str(dataset_dir / '*.met.json'))[0]
+
+        burst_ids = get_bursts(safe_path, orbit_path)
+
+        with open(met_path, "r") as fp:
+            met_data = json.load(fp)
+
+        met_data['bursts'] = burst_ids
+
+        with open(met_path, "w") as fp:
+            json.dump(met_data, fp, indent=4)

--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -4,7 +4,6 @@ import json
 import netrc
 import os
 from datetime import datetime, timedelta, timezone
-from glob import glob
 from pathlib import PurePath, Path
 from os.path import abspath, getsize, join
 
@@ -291,9 +290,9 @@ class AsfDaacSlcDownload(BaseDownload):
         return username, password
 
     def insert_burst_coverage_to_metadata(self, dataset_dir: PurePath):
-        safe_path = glob(str(dataset_dir / '*.zip'))[0]
-        orbit_path = glob(str(dataset_dir / '*.EOF'))[0]
-        met_path = glob(str(dataset_dir / '*.met.json'))[0]
+        safe_path = glob.glob(str(dataset_dir / '*.zip'))[0]
+        orbit_path = glob.glob(str(dataset_dir / '*.EOF'))[0]
+        met_path = glob.glob(str(dataset_dir / '*.met.json'))[0]
 
         burst_ids = get_bursts(safe_path, orbit_path)
 

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -525,7 +525,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
         self.logger.info(f"{len(k_granules)=}")
         return k_granules
 
-    def download_job_submission_handler(self, total_granules, query_timerange, **kwargs):
+    def download_job_submission_handler(self, total_granules, query_timerange):
 
         def add_filtered_urls(granule, filtered_urls: list, polarization_preference: Union[set, None] =None):
             self.logger.debug(f'add_filtered_urls:: {polarization_preference=} {granule["granule_id"]}')

--- a/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
+++ b/data_subscriber/rtc_for_dist/rtc_for_dist_query.py
@@ -525,7 +525,7 @@ You should update the cmr_rtc_cache using tools/populate_cmr_rtc_cache.py first.
         self.logger.info(f"{len(k_granules)=}")
         return k_granules
 
-    def download_job_submission_handler(self, total_granules, query_timerange):
+    def download_job_submission_handler(self, total_granules, query_timerange, **kwargs):
 
         def add_filtered_urls(granule, filtered_urls: list, polarization_preference: Union[set, None] =None):
             self.logger.debug(f'add_filtered_urls:: {polarization_preference=} {granule["granule_id"]}')

--- a/data_subscriber/slc/slc_utils.py
+++ b/data_subscriber/slc/slc_utils.py
@@ -1,7 +1,7 @@
 import os
 
 try:
-    from s1reader.s1reader import load_bursts as _load_bursts
+    from s1reader.s1_reader import load_bursts as _load_bursts
 except ImportError:
     def _load_bursts(*args, **kwargs):
         raise NotImplementedError('S1 Reader not available in environment')

--- a/data_subscriber/slc/slc_utils.py
+++ b/data_subscriber/slc/slc_utils.py
@@ -1,0 +1,37 @@
+import os
+
+try:
+    from s1reader.s1reader import load_bursts as _load_bursts
+except ImportError:
+    def _load_bursts(*args, **kwargs):
+        raise NotImplementedError('S1 Reader not available in environment')
+
+
+def get_file_polarization_mode(file_path: str) -> str:
+    safe_pol_mode = os.path.basename(file_path).split('_')[-6][2:]
+    return safe_pol_mode
+
+
+def mode_to_pols(mode: str) -> list[str]:
+    return {
+        'SH': ['HH'],
+        'SV': ['VV'],
+        'DH': ['HH', 'HV'],
+        'DV': ['VV', 'VH'],
+    }.get(mode, [])
+
+
+def get_bursts(safe_path, orbit_path) -> list[str]:
+    safe_pol_mode = get_file_polarization_mode(safe_path)
+    pols = mode_to_pols(safe_pol_mode)
+
+    i_subswaths = [1, 2, 3]
+    pol_subswath_index_pairs = [(pol, i) for pol in pols for i in i_subswaths]
+
+    bursts = set()
+
+    for pol, i_subswath in pol_subswath_index_pairs:
+        for burst in _load_bursts(safe_path, orbit_path, i_subswath, pol, flag_apply_eap=False):
+            bursts.add(str(burst.burst_id))
+
+    return list(bursts)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,9 @@ RUN \
   # we previously had caused a conda solver conflict on python=3.12 (pinned
   # in the base image) -> libxml2/libgdal-core unsatisfiable -- the
   # combination diverged from the curated base-image channel state.
-  sudo /opt/conda/bin/conda install -y conda poppler gdal eccodes pandas s1reader
+  ###
+  # Restrict scipy version as v1.18 does not support numpy<2
+  sudo /opt/conda/bin/conda install -y conda poppler gdal eccodes pandas s1reader 'scipy<1.18'
 EOT
 
 RUN \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   # we previously had caused a conda solver conflict on python=3.12 (pinned
   # in the base image) -> libxml2/libgdal-core unsatisfiable -- the
   # combination diverged from the curated base-image channel state.
-  sudo /opt/conda/bin/conda install -y conda poppler gdal eccodes pandas
+  sudo /opt/conda/bin/conda install -y conda poppler gdal eccodes pandas s1reader
 EOT
 
 RUN \


### PR DESCRIPTION
## Purpose
- Inspect downloaded SLC files and add contained burst IDs to the GRQ metadata

## Issues
- [OPERA-2580](https://hysds-core.atlassian.net/browse/OPERA-2580)
## Testing
- [x] Cluster deploy
- [x] Verify bursts are populated in GRQ
