### PR TITLE
Improve backoff decorators

### DIFF
--- a/data_subscriber/dataspace_download.py
+++ b/data_subscriber/dataspace_download.py
@@ -135,7 +135,9 @@ class DataspaceDownload(AsfDaacSlcDownload):
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=300)
-    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                          max_tries=2)
     def _do_request(self, url, token):
         headers = {"Authorization": f"Bearer {token}"}
 

--- a/data_subscriber/download.py
+++ b/data_subscriber/download.py
@@ -163,7 +163,9 @@ class BaseDownload:
                           # jitter=None,
                           giveup=fatal_code,
                           on_backoff=backoff_logger)
-    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                          max_tries=2)
     def _get_aws_creds(self, token, endpoint=None):
         settings_daac_s3_cred_urls_key = "UAT_DAAC_S3_CRED_URLS" if endpoint == "UAT" else "DAAC_S3_CRED_URLS"
         self.logger.info(f'Getting AWS creds from {self.cfg[settings_daac_s3_cred_urls_key][self.daac_s3_cred_settings_key]}')

--- a/product_update/disp_s1_r4_bperp/update.py
+++ b/product_update/disp_s1_r4_bperp/update.py
@@ -182,7 +182,9 @@ def _validate_frames(frame_list):
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def _do_cmr_query(url, params, headers=None):
     if headers is None:
         headers = {}

--- a/tools/dataspace_s1_download.py
+++ b/tools/dataspace_s1_download.py
@@ -149,7 +149,9 @@ def build_query_filter(*args, platforms=('A',), sort_by='ContentDate/Start', sor
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def _do_query(url, **kwargs):
     response = requests.get(url, **kwargs)
 
@@ -220,7 +222,9 @@ def main():
                                   giveup=fatal_code,
                                   on_backoff=backoff_logger,
                                   interval=15)
-            @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+            @backoff.on_exception(backoff.expo,
+                                  (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                                  max_tries=2)
             def do_download(gid, filename):
                 start_t = datetime.now()
                 filename = f"{os.path.splitext(filename)[0]}.zip"

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -132,7 +132,9 @@ def _cmr_items_to_dicts(items):
 
 @backoff.on_exception(backoff.constant, requests.exceptions.RequestException,
                       max_time=300, giveup=_fatal_code, on_backoff=_backoff_logger, interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def _do_cmr_query(url, params, func=None, headers=None):
     if headers is None:
         headers = {}

--- a/tools/ops/duplicates/dswx-hls/dswx-hls-input-map.py
+++ b/tools/ops/duplicates/dswx-hls/dswx-hls-input-map.py
@@ -64,7 +64,9 @@ def _backoff_logger(details):
                       giveup=_fatal_code,
                       on_backoff=_backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def _do_cmr_query(url, params, func=None, headers=None):
     if headers is None:
         headers = {}

--- a/tools/ops/duplicates/duplicate_check.py
+++ b/tools/ops/duplicates/duplicate_check.py
@@ -177,8 +177,10 @@ PRODUCTS = {
 }
 
 
-def _fatal_code(err: requests.exceptions.RequestException) -> bool:
-    return err.response.status_code not in [401, 418, 429, 500, 502, 503, 504]
+def _fatal_code(err: Exception) -> bool:
+    if isinstance(err, requests.exceptions.RequestException) and err.response is not None:
+        return err.response.status_code not in [401, 418, 429, 500, 502, 503, 504]
+    return False
 
 
 def _backoff_logger(details):
@@ -195,7 +197,9 @@ def _backoff_logger(details):
                       giveup=_fatal_code,
                       on_backoff=_backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def _do_cmr_query(url, params, headers=None):
     if headers is None:
         headers = {}

--- a/tools/set_daac_urls.py
+++ b/tools/set_daac_urls.py
@@ -48,6 +48,9 @@ def get_product(es_conn, product_id):
                       max_time=120,
                       giveup=fatal_code,
                       on_backoff=backoff_logger)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def get_cmr(cmr_catalog_url: str, cmr_doc_urls: frozenset) -> dict:
     cmr_doc_urls = dict(cmr_doc_urls)
 

--- a/tools/slc_latency_survey.py
+++ b/tools/slc_latency_survey.py
@@ -101,7 +101,9 @@ def get_parser():
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def _do_cmr_query(url, params, headers=None):
     if headers is None:
         headers = {}

--- a/tools/stage_orbit_file.py
+++ b/tools/stage_orbit_file.py
@@ -254,7 +254,9 @@ def construct_orbit_file_query(mission_id, orbit_type, search_start_time, search
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def query_orbit_file_service(endpoint_url, query):
     """
     Submits a request to the Orbit file query REST service, and returns the
@@ -413,7 +415,9 @@ def select_orbit_file(query_results, req_start_time, req_stop_time):
                       giveup=fatal_code,
                       on_backoff=backoff_logger,
                       interval=15)
-@backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+@backoff.on_exception(backoff.expo,
+                      (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                      max_tries=2)
 def download_orbit_file(request_url, output_directory, orbit_file_name, access_token):
     """
     Downloads an Orbit file using the provided request URL, which should contain

--- a/util/backoff_util.py
+++ b/util/backoff_util.py
@@ -5,9 +5,11 @@ import requests
 from opera_commons.logger import logger
 
 
-def fatal_code(err: requests.exceptions.RequestException) -> bool:
+def fatal_code(err: Exception) -> bool:
     """Only retry for common transient errors"""
-    return err.response.status_code not in [401, 418, 429, 500, 502, 503, 504]
+    if isinstance(err, requests.exceptions.RequestException) and err.response is not None:
+        return err.response.status_code not in [401, 418, 429, 500, 502, 503, 504]
+    return False
 
 
 def backoff_logger(details):

--- a/util/dataspace_util.py
+++ b/util/dataspace_util.py
@@ -64,7 +64,9 @@ class DataspaceSession:
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=15)
-    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                          max_tries=2)
     def _refresh(self) -> Tuple[str, str, str, datetime]:
         """
         Performs an access token refresh request using the refresh token acquired
@@ -117,7 +119,9 @@ class DataspaceSession:
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=15)
-    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                          max_tries=2)
     def _get_token(self, username: str, password: str) -> Tuple[str, str, str, datetime]:
         """
         Acquires an access token from the CDSE authentication endpoint using the
@@ -185,7 +189,9 @@ class DataspaceSession:
                           giveup=fatal_code,
                           on_backoff=backoff_logger,
                           interval=15)
-    @backoff.on_exception(backoff.expo, requests.exceptions.Timeout, max_tries=2)
+    @backoff.on_exception(backoff.expo,
+                          (requests.exceptions.Timeout, requests.exceptions.ConnectionError),
+                          max_tries=2)
     def _delete_token(self):
         """
         Submits a delete request on the provided endpoint URL for the provided


### PR DESCRIPTION
## Purpose
- Ensure the `fatal_code` giveup functions ensure a status code is present to check
- All instances of a backoff wrapper using the `fatal_code` giveup function are preceded by a wrapper checking for connection and timeout errors

## Issues
- [OPERA-2524](https://hysds-core.atlassian.net/browse/OPERA-2524)
## Testing
- TBD
