### PR TITLE
Integrate R2 PGEs with S1D support

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -374,7 +374,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.4"
-    "cslc_s1"  = "2.1.3"
+    "cslc_s1"  = "2.1.4"
     "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"

--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -375,7 +375,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.4"
     "cslc_s1"  = "2.1.3"
-    "rtc_s1"   = "2.1.4"
+    "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -119,7 +119,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.4"
-    "cslc_s1"  = "2.1.3"
+    "cslc_s1"  = "2.1.4"
     "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -120,7 +120,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.4"
     "cslc_s1"  = "2.1.3"
-    "rtc_s1"   = "2.1.4"
+    "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -374,7 +374,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.4"
     "cslc_s1"  = "2.1.3"
-    "rtc_s1"   = "2.1.4"
+    "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -373,7 +373,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.4"
-    "cslc_s1"  = "2.1.3"
+    "cslc_s1"  = "2.1.4"
     "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -37,7 +37,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.4"
-    "cslc_s1"  = "2.1.3"
+    "cslc_s1"  = "2.1.4"
     "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -38,7 +38,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.4"
     "cslc_s1"  = "2.1.3"
-    "rtc_s1"   = "2.1.4"
+    "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -965,7 +965,7 @@ variable "pge_releases" {
   type = map(string)
   default = {
     "dswx_hls" = "1.0.4"
-    "cslc_s1"  = "2.1.3"
+    "cslc_s1"  = "2.1.4"
     "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -966,7 +966,7 @@ variable "pge_releases" {
   default = {
     "dswx_hls" = "1.0.4"
     "cslc_s1"  = "2.1.3"
-    "rtc_s1"   = "2.1.4"
+    "rtc_s1"   = "2.1.5"
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -209,6 +209,8 @@ DSWX_HLS:
 RTC_S1:
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 200
+  # Number of workers as percent (0.0 to 1.0) of available cores, null for default
+  N_WORKERS_SCALE: 1.0
   # Estimated geometric accuracy values needed for CEOS compliance
   ESTIMATED_GEOMETRIC_ACCURACY:
     BIAS_X: -0.72
@@ -221,6 +223,8 @@ RTC_S1_STATIC:
   DATA_VALIDITY_START_DATE: 20140403
   # Amount of margin in km to apply to staged ancillaries (DEM)
   ANCILLARY_MARGIN: 200
+  # Number of workers as percent (0.0 to 1.0) of available cores, null for default
+  N_WORKERS_SCALE: 1.0
   # Estimated geometric accuracy values needed for CEOS compliance
   ESTIMATED_GEOMETRIC_ACCURACY:
     BIAS_X: -0.72

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.3",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.4",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.4.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.3",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.4",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.4.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_STATIC_hist
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.3",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.4",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.4.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
+++ b/docker/job-spec.json.SCIFLO_L2_CSLC_S1_hist
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/cslc_s1:2.1.3",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
+      "container_image_name": "opera_pge/cslc_s1:2.1.4",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.4.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.1.4",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.4.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.5",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.5.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
+++ b/docker/job-spec.json.SCIFLO_L2_RTC_S1_STATIC
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/rtc_s1:2.1.4",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.4.tar.gz",
+      "container_image_name": "opera_pge/rtc_s1:2.1.5",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.5.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -51,8 +51,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/cslc_s1:2.1.3",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.3.tar.gz",
+          "container_image_name": "opera_pge/cslc_s1:2.1.4",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-cslc_s1-2.1.4.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -59,8 +59,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/rtc_s1:2.1.4",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.4.tar.gz",
+          "container_image_name": "opera_pge/rtc_s1:2.1.5",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-rtc_s1-2.1.5.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -1856,8 +1856,13 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         available_cores = os.cpu_count()
 
-        # Use 3/4th of the available cores for standard processing
-        num_workers = max(int(round((available_cores * 3) / 4)), 1)
+        scale = self._settings.get('RTC_S1', {}).get('N_WORKERS_SCALE', None)
+
+        if scale is not None:
+            num_workers = max(min(int(round(available_cores * scale)), available_cores), 1)
+        else:
+            # Use 3/4th of the available cores for standard processing
+            num_workers = max(int(round((available_cores * 3) / 4)), 1)
 
         logger.info(f"Allocating {num_workers} core(s) out of {available_cores} available")
 
@@ -1879,8 +1884,13 @@ class OperaPreConditionFunctions(PreConditionFunctions):
 
         available_cores = os.cpu_count()
 
-        # Use 1/2 of the available cores for static layer processing
-        num_workers = max(int(round(available_cores / 2)), 1)
+        scale = self._settings.get('RTC_S1_STATIC', {}).get('N_WORKERS_SCALE', None)
+
+        if scale is not None:
+            num_workers = max(min(int(round(available_cores * scale)), available_cores), 1)
+        else:
+            # Use 3/4th of the available cores for standard processing
+            num_workers = max(int(round((available_cores * 3) / 4)), 1)
 
         logger.info(f"Allocating {num_workers} core(s) out of {available_cores} available")
 


### PR DESCRIPTION
## Purpose
Integrate latest releases of the following PGEs
- RTC-S1
- CSLC-S1

For RTC-S1 & RTC-S1-STATIC, a new setting `N_WORKERS_SCALE` was added to set the number of parallel workers as a percentage (0.0 to 1.0) of the worker instance's total (previously only used 0.75).

## Issues
- [OPERA-2594](https://hysds-core.atlassian.net/browse/OPERA-2594)
- [OPERA-2587](https://hysds-core.atlassian.net/browse/OPERA-2587)
## Testing
- [x] Cluster deploy
- [x] PGE testing:
  - [x] RTC-S1
    - [x] Smoke test
    - [x] Sim mode
    - [x] Real mode (S1A/B/C)
    - [x] Real mode (S1D)
  - [x] RTC-S1-STATIC
    - [x] Smoke test
    - [x] Sim mode
    - [x] Real mode (S1A/B/C)
    - [x] Real mode (S1D)
  - [x] CSLC-S1
    - [x] Smoke test
    - [x] Sim mode
    - [x] Real mode (S1A/B/C)
    - [x] Real mode (S1D)
  - [x] CSLC-S1-STATIC
    - [x] Smoke test
    - [x] Sim mode
    - [x] Real mode (S1A/B/C)
    - [x] Real mode (S1D)