### PR TITLE
Improvements to DIST-S1 chaining tool

### DIFF
--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -745,4 +745,4 @@ if __name__ == '__main__':
 
     with open(good_tiles_filename, 'w') as f:
         json.dump(good_tiles, f, indent=2)
-    logger.info(f'Good tile list written to {output_filename}')
+    logger.info(f'Good tile list written to {good_tiles_filename}')

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -49,6 +49,17 @@ CCIDS = {
 TILE_ID_FIELD = 3
 ACQ_TIME_FIELD = 4
 PROD_TIME_FIELD = 5
+SENSOR_FIELD = 6
+
+
+def _dist_id_to_unique_tuple(gid):
+    id_fields = gid.split('_')
+
+    return (
+        id_fields[TILE_ID_FIELD],
+        id_fields[ACQ_TIME_FIELD],
+        id_fields[SENSOR_FIELD],
+    )
 
 
 def _fatal_code(err: Exception) -> bool:
@@ -122,6 +133,7 @@ def _cmr_items_to_dicts(items):
             'tile': id_fields[TILE_ID_FIELD],
             'acquisition_time': datetime.strptime(id_fields[ACQ_TIME_FIELD], DEFAULT_GRANULE_TIME_FMT),
             'production_time': datetime.strptime(id_fields[PROD_TIME_FIELD], DEFAULT_GRANULE_TIME_FMT),
+            'unique_tuple': _dist_id_to_unique_tuple(item_id),
             'urls': urls,
             'additional_attributes': additional_attributes,
             'pge_version': item['umm'].get('PGEVersionClass', {}).get('PGEVersion')
@@ -242,7 +254,7 @@ def _group_by_tile(dist_product_dicts):
     logger.info(f'Grouped DIST-S1 products to {len(grouped_dicts):,} confirmation chains')
 
     for tile in grouped_dicts:
-        grouped_dicts[tile].sort(key=lambda x: x['acquisition_time'])
+        grouped_dicts[tile].sort(key=lambda x: (x['acquisition_time'], x['production_time']))
 
     return grouped_dicts
 

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -6,6 +6,7 @@ import re
 from contextlib import ExitStack
 from copy import deepcopy
 from datetime import datetime
+from itertools import combinations
 
 import backoff
 import boto3
@@ -36,6 +37,8 @@ DIST_S1_START_DATE = datetime(2026, 1, 1)
 SURVEY_DROPPED_PRODUCTS = []
 SURVEY_LATEST_DEDUPED_PRODUCTS = {}
 
+DUPLICATES = {}
+
 CMR_URLS = {
     'PROD': 'https://cmr.earthdata.nasa.gov/search/granules.umm_json_v1_4',
     'UAT': 'https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json'
@@ -52,8 +55,13 @@ ACQ_TIME_FIELD = 4
 PROD_TIME_FIELD = 5
 SENSOR_FIELD = 6
 
+DEFAULT_PAGE_SIZE = 2000
+
 
 def _dist_id_to_unique_tuple(gid):
+    if gid is None:
+        return None
+
     id_fields = gid.split('_')
 
     return (
@@ -174,7 +182,7 @@ def query_cmr(cmr_url, ccid, start, end, func=None, **extra_params):
 
     params = {
         'collection_concept_id': ccid,
-        'page_size': 2000
+        'page_size': DEFAULT_PAGE_SIZE
     }
 
     params.update(extra_params)
@@ -286,26 +294,59 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
     discontinuities = []
     incorrect_products = []
 
+    nominal_confirmation_chain = [_dist_id_to_unique_tuple(p['id']) for p in confirmation_chain]
+    nominal_confirmation_chain.sort(key=lambda x: x[1])
+
+    logger.debug(f'Nominal confirmation chain for tile {confirmation_chain[0]["tile"]}: {nominal_confirmation_chain}')
+
     first_product = confirmation_chain.pop(0)
 
     warn = (warn_on_first_null and (start_datetime is not None and start_datetime > DIST_S1_START_DATE)
             and first_product['previous_product_id'] is None)
 
-    expected_prev_product_id = first_product['id']
+    prev_product = first_product
 
     for product in confirmation_chain:
+        product_tuple = _dist_id_to_unique_tuple(product['id'])
+        prev_product_tuple = _dist_id_to_unique_tuple(product['previous_product_id'])
+
+        confirmation_chain_index = nominal_confirmation_chain.index(product_tuple)
+
+        if confirmation_chain_index == 0:
+            expected_prev_product_tuple = None
+        else:
+            expected_prev_product_tuple = nominal_confirmation_chain[confirmation_chain_index - 1]
+
         if product['previous_product_id'] is None:
             discontinuities.append({
                 'discontinuous_product_id': product['id'],
-                'expected_prev_product_id': expected_prev_product_id,
+                # 'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product['unique_tuple']],
+                'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product_tuple],
             })
-        elif product['previous_product_id'] != expected_prev_product_id:
+
+            if (product['unique_tuple'] == prev_product['unique_tuple'] and
+                    product['id'] != prev_product['id']):
+                DUPLICATES.setdefault(product['unique_tuple'], set())
+                DUPLICATES[product['unique_tuple']].add(product['id'])
+                DUPLICATES[product['unique_tuple']].add(prev_product['id'])
+                discontinuities[-1]['duplicate_flag'] = True
+        # elif _dist_id_to_unique_tuple(product['previous_product_id']) != expected_prev_product['unique_tuple']:
+        elif prev_product_tuple != expected_prev_product_tuple:
             incorrect_products.append({
                 'misordered_product_id': product['id'],
-                'expected_prev_product_id': expected_prev_product_id,
+                # 'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product['unique_tuple']],
+                'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product_tuple],
                 'incorrect_previous_product_id': product['previous_product_id']
             })
-        expected_prev_product_id = product['id']
+
+            for a, b in combinations((product['id'], prev_product['id'], product['previous_product_id']), r=2):
+                if a != b and _dist_id_to_unique_tuple(a) == _dist_id_to_unique_tuple(b):
+                    t = _dist_id_to_unique_tuple(a)
+                    DUPLICATES.setdefault(t, set())
+                    DUPLICATES[t].add(a)
+                    DUPLICATES[t].add(b)
+
+        prev_product = product
 
     return discontinuities, incorrect_products, warn
 
@@ -587,6 +628,20 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
         SURVEY_DROPPED_PRODUCTS.sort()
         report['dropped_products'] = SURVEY_DROPPED_PRODUCTS
 
+    if DUPLICATES:
+        logger.warning(f'Identified {len(DUPLICATES):,} sets of duplicate products')
+        duplicate_ids = []
+
+        for unique_tuple in DUPLICATES:
+            duplicate_set = list(DUPLICATES[unique_tuple])
+            duplicate_set.sort(key=lambda x: x.split('_')[PROD_TIME_FIELD], reverse=True)
+            duplicate_ids.extend(duplicate_set[1:])
+
+        duplicate_ids.sort()
+        logger.warning(f'Found {len(duplicate_ids):,} duplicate products for removal')
+
+        report['duplicate_products'] = duplicate_ids
+
     return report, list(set(grouped_products.keys()) - set(bad_tiles))
 
 
@@ -621,7 +676,6 @@ if __name__ == '__main__':
             json.dump(dist_report, f, indent=2)
         logger.info(f'Report written to {output_filename}')
     else:
-        logger.info('Nothing to report - no file written')
         logger.info('No issues to report')
 
     with open(good_tiles_filename, 'w') as f:

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -342,6 +342,9 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
         else:
             expected_prev_product_tuple = nominal_confirmation_chain[confirmation_chain_index - 1]
 
+        flagged_discontinuous = False
+        flagged_incorrect = False
+
         if product['previous_product_id'] is None:
             discontinuities.append({
                 'discontinuous_product_id': product['id'],
@@ -349,12 +352,14 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
                 'expected_prev_product_id': _get_latest_or_none(expected_prev_product_tuple),
             })
 
-            if (product['unique_tuple'] == prev_product['unique_tuple'] and
-                    product['id'] != prev_product['id']):
-                DUPLICATES.setdefault(product['unique_tuple'], set())
-                DUPLICATES[product['unique_tuple']].add(product['id'])
-                DUPLICATES[product['unique_tuple']].add(prev_product['id'])
-                discontinuities[-1]['duplicate_flag'] = True
+            flagged_discontinuous = True
+
+            # if (product['unique_tuple'] == prev_product['unique_tuple'] and
+            #         product['id'] != prev_product['id']):
+            #     DUPLICATES.setdefault(product['unique_tuple'], set())
+            #     DUPLICATES[product['unique_tuple']].add(product['id'])
+            #     DUPLICATES[product['unique_tuple']].add(prev_product['id'])
+            #     discontinuities[-1]['duplicate_flag'] = True
         # elif _dist_id_to_unique_tuple(product['previous_product_id']) != expected_prev_product['unique_tuple']:
         elif prev_product_tuple != expected_prev_product_tuple:
             incorrect_products.append({
@@ -364,12 +369,18 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
                 'incorrect_previous_product_id': product['previous_product_id']
             })
 
-            for a, b in combinations((product['id'], prev_product['id'], product['previous_product_id']), r=2):
-                if a != b and _dist_id_to_unique_tuple(a) == _dist_id_to_unique_tuple(b):
-                    t = _dist_id_to_unique_tuple(a)
-                    DUPLICATES.setdefault(t, set())
-                    DUPLICATES[t].add(a)
-                    DUPLICATES[t].add(b)
+            flagged_incorrect = True
+
+        for a, b in combinations((product['id'], prev_product['id'], product['previous_product_id']), r=2):
+            if a != b and _dist_id_to_unique_tuple(a) == _dist_id_to_unique_tuple(b):
+                t = _dist_id_to_unique_tuple(a)
+                DUPLICATES.setdefault(t, set())
+                DUPLICATES[t].add(a)
+                DUPLICATES[t].add(b)
+
+                if flagged_discontinuous:
+                    discontinuities[-1]['duplicate_flag'] = True
+                if flagged_incorrect:
                     incorrect_products[-1]['duplicate_flag'] = True
 
         prev_product = product

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -297,7 +297,7 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
     return discontinuities, incorrect_products, warn
 
 
-def _add_previous_product_id(dist_product_dict, pbar = None):
+def _add_previous_product_id(dist_product_dict, pbar=None):
     if PRIOR_PRODUCT_ADDITIONAL_ATTR_NAME in dist_product_dict['additional_attributes']:
         previous_product_id = dist_product_dict['additional_attributes'][PRIOR_PRODUCT_ADDITIONAL_ATTR_NAME]
         # TODO: May have to convert string null to python null
@@ -516,6 +516,12 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
 
     report = {}
 
+    def _count_list(x):
+        return {
+            'count': len(x),
+            'products': x,
+        }
+
     if len(bad_tiles) == 0:
         if len(warn_tiles) == 0:
             logger.info('All confirmation chains surveyed have no confirmation or production errors and no warnings')
@@ -532,25 +538,32 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
                      f'{len(chaining_discontinuities):,}, chaining order error count: '
                      f'{len(chaining_bad_orders):,}')
 
+        bad_tiles.sort()
+
         report = {
-            'bad_tiles': bad_tiles,
+            'bad_tiles': {
+                'count': len(bad_tiles),
+                'percentage': (len(bad_tiles) / len(grouped_products)) * 100,
+                'tiles': bad_tiles,
+            }
         }
 
         if production_products_misordered:
-            report['production_products_misordered'] = production_products_misordered
+            report['production_products_misordered'] = _count_list(production_products_misordered)
         if chaining_discontinuities:
-            report['chaining_discontinuities'] = chaining_discontinuities
+            report['chaining_discontinuities'] = _count_list(chaining_discontinuities)
         if chaining_bad_orders:
-            report['chaining_bad_orders'] = chaining_bad_orders
+            report['chaining_bad_orders'] = _count_list(chaining_bad_orders)
 
         if warn_tiles:
             logger.info(f'There are also warnings of potential discontinuities for {len(warn_tiles):,} tiles')
-
+            warn_tiles.sort()
             report['tiles_with_warnings'] = warn_tiles
 
     if SURVEY_DROPPED_PRODUCTS:
         logger.warning(f'{len(SURVEY_DROPPED_PRODUCTS):,} products had to be dropped from the CMR survey due to not '
                        f'having an HTTPS URL, this may have caused some false positives. Please review these closely.')
+        SURVEY_DROPPED_PRODUCTS.sort()
         report['dropped_products'] = SURVEY_DROPPED_PRODUCTS
 
     return report

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -587,7 +587,7 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
         SURVEY_DROPPED_PRODUCTS.sort()
         report['dropped_products'] = SURVEY_DROPPED_PRODUCTS
 
-    return report
+    return report, list(set(grouped_products.keys()) - set(bad_tiles))
 
 
 if __name__ == '__main__':
@@ -602,19 +602,28 @@ if __name__ == '__main__':
     if args.pge_versions is not None:
         extra_filtering_args['pge_versions'] = args.pge_versions
 
-    dist_report = main(
+    dist_report, good_tiles = main(
         args.venue, args.start_date, args.end_date, args.tiles,
         warn_on_first_null_after_start=args.warn_on_first_null,
         **extra_filtering_args
     )
 
-    if dist_report:
-        output_filename = args.output
-        if not output_filename.endswith('.json'):
-            output_filename += '.json'
+    good_tiles.sort()
 
+    output_filename = args.output
+    if not output_filename.endswith('.json'):
+        output_filename += '.json'
+
+    good_tiles_filename = output_filename.replace('.json', '.good.json')
+
+    if dist_report:
         with open(output_filename, 'w') as f:
             json.dump(dist_report, f, indent=2)
         logger.info(f'Report written to {output_filename}')
     else:
         logger.info('Nothing to report - no file written')
+        logger.info('No issues to report')
+
+    with open(good_tiles_filename, 'w') as f:
+        json.dump(good_tiles, f, indent=2)
+    logger.info(f'Good tile list written to {output_filename}')

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -34,6 +34,7 @@ DEFAULT_GRANULE_TIME_FMT = '%Y%m%dT%H%M%SZ'
 DIST_S1_START_DATE = datetime(2026, 1, 1)
 
 SURVEY_DROPPED_PRODUCTS = []
+SURVEY_LATEST_DEDUPED_PRODUCTS = {}
 
 CMR_URLS = {
     'PROD': 'https://cmr.earthdata.nasa.gov/search/granules.umm_json_v1_4',
@@ -472,6 +473,14 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
 
     if other_filtering_params:
         survey_results = _apply_extra_survey_filters(survey_results, **other_filtering_params)
+
+    for result in survey_results:
+        unique_tuple = result['unique_tuple']
+        SURVEY_LATEST_DEDUPED_PRODUCTS.setdefault(unique_tuple, []).append(result)
+
+    for unique_tuple in SURVEY_LATEST_DEDUPED_PRODUCTS:
+        SURVEY_LATEST_DEDUPED_PRODUCTS[unique_tuple].sort(key=lambda x: x['production_time'], reverse=True)
+        SURVEY_LATEST_DEDUPED_PRODUCTS[unique_tuple] = SURVEY_LATEST_DEDUPED_PRODUCTS[unique_tuple][0]['id']
 
     grouped_products = _group_by_tile(survey_results)
 

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -348,23 +348,14 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
         if product['previous_product_id'] is None:
             discontinuities.append({
                 'discontinuous_product_id': product['id'],
-                # 'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product['unique_tuple']],
                 'expected_prev_product_id': _get_latest_or_none(expected_prev_product_tuple),
             })
 
             flagged_discontinuous = True
 
-            # if (product['unique_tuple'] == prev_product['unique_tuple'] and
-            #         product['id'] != prev_product['id']):
-            #     DUPLICATES.setdefault(product['unique_tuple'], set())
-            #     DUPLICATES[product['unique_tuple']].add(product['id'])
-            #     DUPLICATES[product['unique_tuple']].add(prev_product['id'])
-            #     discontinuities[-1]['duplicate_flag'] = True
-        # elif _dist_id_to_unique_tuple(product['previous_product_id']) != expected_prev_product['unique_tuple']:
         elif prev_product_tuple != expected_prev_product_tuple:
             incorrect_products.append({
                 'misordered_product_id': product['id'],
-                # 'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product['unique_tuple']],
                 'expected_prev_product_id': _get_latest_or_none(expected_prev_product_tuple),
                 'incorrect_previous_product_id': product['previous_product_id']
             })
@@ -608,9 +599,6 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, get_toke
                         failed_metadata_retrieval.append((product['id'], e))
                         skipped_chains.add(tile)
                         pbar.update()
-
-        with open('debug.json', 'w') as f:
-            json.dump(grouped_products, f, indent=2, default=repr)
 
         for tile in tqdm(grouped_products, desc='Confirmation chains ', leave=False):
             if tile in skipped_chains:

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -531,6 +531,8 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
     production_products_misordered = []
     chaining_discontinuities = []
     chaining_bad_orders = []
+    failed_metadata_retrieval = []
+    skipped_chains = set()
 
     with logging_redirect_tqdm():
         with tqdm(total=len(survey_results),   desc='DIST product metadata ', leave=False) as pbar:
@@ -546,9 +548,23 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
 
                 logger.info(f'Gathering prev_product metadata for confirmation chain for tile {tile}')
                 for product in grouped_products[tile]:
-                    _add_previous_product_id(product, pbar)
+                    try:
+                        _add_previous_product_id(product, pbar)
+                    except Exception as e:
+                        logger.critical(f'Failed to get metadata for product {product}: {e}')
+                        failed_metadata_retrieval.append((product['id'], e))
+                        skipped_chains.add(tile)
+                        pbar.update()
+
+        with open('debug.json', 'w') as f:
+            json.dump(grouped_products, f, indent=2, default=repr)
 
         for tile in tqdm(grouped_products, desc='Confirmation chains ', leave=False):
+            if tile in skipped_chains:
+                logger.error(
+                    f'Skipping confirmation chain checks for tile {tile} as we could not gather all product metadata')
+                continue
+
             logger.info(f'Checking confirmation chain for tile {tile} for chaining errors and discontinuities')
             tile_chain_discontinuities, tile_chain_errors, warn = _find_chain_errors(
                 grouped_products[tile],
@@ -621,6 +637,12 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
             logger.info(f'There are also warnings of potential discontinuities for {len(warn_tiles):,} tiles')
             warn_tiles.sort()
             report['tiles_with_warnings'] = warn_tiles
+
+    if failed_metadata_retrieval:
+        logger.error(f'Tool was unable to get metadata for {len(failed_metadata_retrieval):,} products, so their '
+                     f'chains could not be checked')
+        report['failed_metadata_retrieval'] = {p: str(e) for p, e in failed_metadata_retrieval}
+        report['skipped_chains'] = len(sorted(skipped_chains))
 
     if SURVEY_DROPPED_PRODUCTS:
         logger.warning(f'{len(SURVEY_DROPPED_PRODUCTS):,} products had to be dropped from the CMR survey due to not '

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -429,9 +429,10 @@ def parse_args():
     )
 
     def _tile(v):
-        if not re.fullmatch(r'\d{2}[A-Z]{3}', v):
+        v = v.upper()
+        if not re.fullmatch(r'T?\d{2}[A-Z]{3}', v):
             raise ValueError(f'Invalid tile: {v}')
-        return v
+        return v.removeprefix('T')
 
     product_selection_group.add_argument(
         '-t', '--tiles',

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -326,6 +326,11 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
 
     prev_product = first_product
 
+    def _get_latest_or_none(uniq_t):
+        if uniq_t is None:
+            return None
+        return SURVEY_LATEST_DEDUPED_PRODUCTS[uniq_t]
+
     for product in confirmation_chain:
         product_tuple = _dist_id_to_unique_tuple(product['id'])
         prev_product_tuple = _dist_id_to_unique_tuple(product['previous_product_id'])
@@ -341,7 +346,7 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
             discontinuities.append({
                 'discontinuous_product_id': product['id'],
                 # 'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product['unique_tuple']],
-                'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product_tuple],
+                'expected_prev_product_id': _get_latest_or_none(expected_prev_product_tuple),
             })
 
             if (product['unique_tuple'] == prev_product['unique_tuple'] and
@@ -355,7 +360,7 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
             incorrect_products.append({
                 'misordered_product_id': product['id'],
                 # 'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product['unique_tuple']],
-                'expected_prev_product_id': SURVEY_LATEST_DEDUPED_PRODUCTS[expected_prev_product_tuple],
+                'expected_prev_product_id': _get_latest_or_none(expected_prev_product_tuple),
                 'incorrect_previous_product_id': product['previous_product_id']
             })
 
@@ -365,6 +370,7 @@ def _find_chain_errors(confirmation_chain, start_datetime, warn_on_first_null=Fa
                     DUPLICATES.setdefault(t, set())
                     DUPLICATES[t].add(a)
                     DUPLICATES[t].add(b)
+                    incorrect_products[-1]['duplicate_flag'] = True
 
         prev_product = product
 

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -34,26 +34,30 @@ PRIOR_PRODUCT_ADDITIONAL_ATTR_NAME = '__PLACEHOLDER__'  # TODO: Update when/if a
 DEFAULT_GRANULE_TIME_FMT = '%Y%m%dT%H%M%SZ'
 DIST_S1_START_DATE = datetime(2026, 1, 1)
 
-SURVEY_DROPPED_PRODUCTS = []
-SURVEY_LATEST_DEDUPED_PRODUCTS = {}
-
-DUPLICATES = {}
-
-CMR_URLS = {
-    'PROD': 'https://cmr.earthdata.nasa.gov/search/granules.umm_json_v1_4',
-    'UAT': 'https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json'
-}
-
 CCIDS = {
     'PROD': 'C4090131664-ASF',
     # 'UAT': 'C1275699124-ASF',  # OPERA_L3_DIST-ALERT-S1_PROVISIONAL_V0
     'UAT': 'C1275699127-ASF',  # OPERA_L3_DIST-ALERT-S1_V1
 }
 
+CMR_URLS = {
+    'PROD': 'https://cmr.earthdata.nasa.gov/search/granules.umm_json_v1_4',
+    'UAT': 'https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json'
+}
+
+EDL_URLS = {
+    'PROD': 'urs.earthdata.nasa.gov',
+    'UAT': 'uat.urs.earthdata.nasa.gov'
+}
+
 TILE_ID_FIELD = 3
 ACQ_TIME_FIELD = 4
 PROD_TIME_FIELD = 5
 SENSOR_FIELD = 6
+
+SURVEY_DROPPED_PRODUCTS = []
+SURVEY_LATEST_DEDUPED_PRODUCTS = {}
+DUPLICATES = {}
 
 DEFAULT_PAGE_SIZE = 2000
 

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -27,6 +27,8 @@ logging.getLogger('botocore').setLevel(logging.WARNING)
 
 DEBUG_BREAK_SURVEY_EARLY = False  # TODO: Remove this when dev wraps up
 TRY_S3 = True
+DEFAULT_S3_RETRY_INTERVAL = 250
+
 PRIOR_PRODUCT_META_KEY = 'prior_product_name'
 PRIOR_PRODUCT_META_KEY_ALT = 'prior_dist_s1_product'
 PRIOR_PRODUCT_ADDITIONAL_ATTR_NAME = '__PLACEHOLDER__'  # TODO: Update when/if available
@@ -564,7 +566,12 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, get_toke
 
     with logging_redirect_tqdm():
         with tqdm(total=len(survey_results),   desc='DIST product metadata ', leave=False) as pbar:
-            for tile in tqdm(grouped_products, desc='  Confirmation chains ', leave=False):
+            for i, tile in enumerate(tqdm(grouped_products, desc='  Confirmation chains ', leave=False)):
+                if i > 0 and i % DEFAULT_S3_RETRY_INTERVAL == 0:
+                    global TRY_S3
+                    TRY_S3 = True
+                    logger.info('Reset S3 attempts')
+
                 logger.info(f'Checking confirmation chain for tile {tile} for production misorderings')
                 tile_prod_discontinuities = _find_production_order_errors(grouped_products[tile])
                 if tile_prod_discontinuities:

--- a/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
+++ b/tools/ops/dist_s1_confirmation/dist_s1_confirmation.py
@@ -75,6 +75,17 @@ def _dist_id_to_unique_tuple(gid):
     )
 
 
+def _get_token(venue):
+    import netrc
+    from data_subscriber.aws_token import supply_token
+
+    edl = EDL_URLS[venue]
+    username, _, password = netrc.netrc().authenticators(edl)
+    token = supply_token(edl, username, password)
+
+    return token
+
+
 def _fatal_code(err: Exception) -> bool:
     if isinstance(err, requests.exceptions.RequestException) and err.response is not None:
         return err.response.status_code not in [401, 418, 429, 500, 502, 503, 504]
@@ -181,13 +192,16 @@ def _do_cmr_query(url, params, func=None, headers=None):
     return response_items, response.headers.get('CMR-Search-After', None)
 
 
-def query_cmr(cmr_url, ccid, start, end, func=None, **extra_params):
+def query_cmr(cmr_url, ccid, start, end, func=None, token=None, **extra_params):
     granules = []
 
     params = {
         'collection_concept_id': ccid,
         'page_size': DEFAULT_PAGE_SIZE
     }
+
+    if token is not None:
+        params['token'] = token
 
     params.update(extra_params)
 
@@ -471,6 +485,13 @@ def parse_args():
              'this option is set, these warnings are inhibited.'
     )
 
+    parser.add_argument(
+        '--get-token',
+        action='store_true',
+        help='Retrieve an EDL token for the CMR queries. This should only be needed temporarily while the prod '
+             'DIST-S1 collection is non-public'
+    )
+
     return parser.parse_args()
 
 
@@ -496,7 +517,7 @@ def _apply_extra_survey_filters(survey, **filters):
     return filtered_survey
 
 
-def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_filtering_params):
+def main(venue, start, end, tiles, warn_on_first_null_after_start=True, get_token=False, **other_filtering_params):
     extra_survey_params = {}
 
     if tiles is not None:
@@ -505,12 +526,15 @@ def main(venue, start, end, tiles, warn_on_first_null_after_start=True, **other_
         if len(tile_params) > 1:
             extra_survey_params['options[attribute][or]'] = 'true'
 
+    token = _get_token(venue) if get_token else None
+
     survey_results = query_cmr(
         cmr_url=CMR_URLS[venue],
         ccid=CCIDS[venue],
         start=start,
         end=end,
         func=_cmr_items_to_dicts,
+        token=token,
         **extra_survey_params
     )
 
@@ -686,6 +710,7 @@ if __name__ == '__main__':
     dist_report, good_tiles = main(
         args.venue, args.start_date, args.end_date, args.tiles,
         warn_on_first_null_after_start=args.warn_on_first_null,
+        get_token=args.get_token,
         **extra_filtering_args
     )
 


### PR DESCRIPTION
## Purpose
Add the following improvements to the chaining tool
- Handling of duplicates
  - Add duplicate products to report
  - Handle duplicates in chain checking
    - Expected previous can no longer be a duplicate
    - A mismatch won't be raised if expected previous product and actual previous product are duplicates
- Add option to use EDL token in CMR query - important for running checks while DIST-S1 is not public
- Rework reporting
  - Sort tile lists
  - Add counts to product lists
  - Add count and percentage to bad tile list
  - Add separate report listing valid tiles
- Handle errors during product metadata retrieval, skipping the failing chain and reporting it
- Periodically reset attempting S3 metadata retrieval so that transient errors don't permanently impact script run time
- Improve parsing of tile filter (case insensitive + accepts leading `T`)

## Issues
- [OPERA-2600](https://hysds-core.atlassian.net/browse/OPERA-2600)
