### PR TITLE
Integrate DIST-S1 PGE v6.0.3

### DIFF
--- a/cluster_provisioning/dev-e2e/variables.tf
+++ b/cluster_provisioning/dev-e2e/variables.tf
@@ -379,7 +379,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"
-    "dist_s1"  = "6.0.2"
+    "dist_s1"  = "6.0.3"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.2.0"
     "cal_disp" = "7.0.0-er.1.0"

--- a/cluster_provisioning/dev-int/override.tf
+++ b/cluster_provisioning/dev-int/override.tf
@@ -125,7 +125,7 @@ variable "pge_releases" {
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"
     "tropo"    = "3.0.0-er.3.0-tropo"
-    "dist_s1"  = "6.0.2"
+    "dist_s1"  = "6.0.3"
     "disp_ni"  = "6.0.0-er.2.0"
     "cal_disp" = "7.0.0-er.1.0"
   }

--- a/cluster_provisioning/dev/variables.tf
+++ b/cluster_provisioning/dev/variables.tf
@@ -378,7 +378,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"
-    "dist_s1"  = "6.0.2"
+    "dist_s1"  = "6.0.3"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.2.0"
     "cal_disp" = "7.0.0-er.1.0"

--- a/cluster_provisioning/ebs-snapshot/variables.tf
+++ b/cluster_provisioning/ebs-snapshot/variables.tf
@@ -42,7 +42,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"
-    "dist_s1"  = "6.0.2"
+    "dist_s1"  = "6.0.3"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.2.0"
     "cal_disp" = "7.0.0-er.1.0"

--- a/cluster_provisioning/modules/common/variables.tf
+++ b/cluster_provisioning/modules/common/variables.tf
@@ -970,7 +970,7 @@ variable "pge_releases" {
     "dswx_s1"  = "3.0.4"
     "disp_s1"  = "3.0.10"
     "dswx_ni"  = "4.0.0-rc.2.0"
-    "dist_s1"  = "6.0.2"
+    "dist_s1"  = "6.0.3"
     "tropo"    = "3.0.0-rc.1.0-tropo"
     "disp_ni"  = "6.0.0-er.2.0"
     "cal_disp" = "7.0.0-er.1.0"

--- a/conf/RunConfig.yaml.L3_DIST_S1.jinja2.tmpl
+++ b/conf/RunConfig.yaml.L3_DIST_S1.jinja2.tmpl
@@ -30,7 +30,7 @@ RunConfig:
       PrimaryExecutable:
         ProductIdentifier: DIST_S1
         ProductVersion: "{{ runconfig.product_path_group.product_version }}"
-        ProgramPath: /opt/conda/envs/dist-s1-env/bin/dist-s1
+        ProgramPath: /home/ops/dist-s1/.pixi/envs/default/bin/dist-s1
         ProgramOptions:
         - run_sas
         - --run_config_path

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -279,9 +279,9 @@ DIST_S1:
 
   # S3 path to the algorithm parameters YAML file
   # ADT-provided, supports up to 4-3-3
-  # ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.14/algorithm_parameters_transformer_optimized.yaml"
+  # ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.18/algorithm_parameters_transformer_optimized.yaml"
   # Same params but with more workers for despeckling
-  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.14/algorithm_parameters_transformer_optimized_more_parallel.yaml"
+  ALGORITHM_PARAMETERS: "s3://opera-ancillaries/algorithm_parameters/dist_s1/2.0.18/algorithm_parameters_transformer_optimized_more_parallel.yaml"
 
   # For testing with 8-6-6
 #  ALGORITHM_PARAMETERS: ~

--- a/docker/job-spec.json.SCIFLO_L3_DIST_S1
+++ b/docker/job-spec.json.SCIFLO_L3_DIST_S1
@@ -11,8 +11,8 @@
   },
   "dependency_images": [
     {
-      "container_image_name": "opera_pge/dist_s1:6.0.2",
-      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.2.tar.gz",
+      "container_image_name": "opera_pge/dist_s1:6.0.3",
+      "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.3.tar.gz",
       "container_mappings": {
         "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
         "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]

--- a/docker/job-spec.json.pge_smoke_test
+++ b/docker/job-spec.json.pge_smoke_test
@@ -43,8 +43,8 @@
           }
         },
         {
-          "container_image_name": "opera_pge/dist_s1:6.0.2",
-          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.2.tar.gz",
+          "container_image_name": "opera_pge/dist_s1:6.0.3",
+          "container_image_url": "$CODE_BUCKET_URL/opera_pge-dist_s1-6.0.3.tar.gz",
           "container_mappings": {
             "$HOST_VERDI_HOME/.netrc": ["/root/.netrc"],
             "$HOST_VERDI_HOME/.aws": ["/root/.aws", "ro"]


### PR DESCRIPTION
## Purpose
Integrate latest release v6.0.3 of the DIST-S1 PGE with the "Final" v2.0.18 SAS release adding support for S1D.

## Issues
- [OPERA-2569](https://hysds-core.atlassian.net/browse/OPERA-2569)
## Testing
- [x] Cluster deploy
- [x] PGE testing:
  - [x] Smoke test
  - [x] Sim mode
  - [x] Real mode
  - [x] Confirmation chaining