### PR TITLE
Fix bug in HLS/SLC deduping

### DIFF
--- a/data_subscriber/hls/hls_query.py
+++ b/data_subscriber/hls/hls_query.py
@@ -16,11 +16,33 @@ class HlsCmrQuery(BaseQuery):
 
         filtered_granules = []
 
+        flag_unsubmitted = False
+
         for granule in granules:
-            if len(self.es_conn.get_cataloged_granule_by_granule_id(granule['granule_id'])) == 0:
+            catalog_entries = self.es_conn.get_cataloged_granule_by_granule_id(granule['granule_id'])
+
+            if len(catalog_entries) == 0:
                 self.logger.info(f'Found new granule {granule["granule_id"]}')
                 filtered_granules.append(granule)
             else:
-                self.logger.info(f'Dropping granule {granule["granule_id"]} as it has already been cataloged')
+                download_job_ids = set([
+                    r['_source']['download_job_id'] for r in catalog_entries if 'download_job_id' in r['_source']
+                ])
+
+                if len(download_job_ids) == 0:
+                    self.logger.info(f'Found unsubmitted granule {granule["granule_id"]}')
+                    filtered_granules.append(granule)
+                    flag_unsubmitted = True
+                else:
+                    if len(download_job_ids) > 1:
+                        self.logger.warning(f'Granule {granule["granule_id"]} has multiple associated '
+                                            f'download_job_ids. This should not happen and may be indicative of a '
+                                            f'duplicate submission.')
+
+                    self.logger.info(f'Dropping granule {granule["granule_id"]} as it has already been cataloged')
+
+        if flag_unsubmitted:
+            self.logger.warning('Query job has detected granules that were previously cataloged but don\'t appear to '
+                                'have been submitted. There is a very small chance for duplicate creation.')
 
         return filtered_granules

--- a/data_subscriber/slc/slc_query.py
+++ b/data_subscriber/slc/slc_query.py
@@ -78,11 +78,33 @@ class SlcCmrQuery(BaseQuery):
 
         filtered_granules = []
 
+        flag_unsubmitted = False
+
         for granule in granules:
-            if len(self.es_conn.get_cataloged_granule_by_granule_id(granule['granule_id'])) == 0:
+            catalog_entries = self.es_conn.get_cataloged_granule_by_granule_id(granule['granule_id'])
+
+            if len(catalog_entries) == 0:
                 self.logger.info(f'Found new granule {granule["granule_id"]}')
                 filtered_granules.append(granule)
             else:
-                self.logger.info(f'Dropping granule {granule["granule_id"]} as it has already been cataloged')
+                download_job_ids = set([
+                    r['_source']['download_job_id'] for r in catalog_entries if 'download_job_id' in r['_source']
+                ])
+
+                if len(download_job_ids) == 0:
+                    self.logger.info(f'Found unsubmitted granule {granule["granule_id"]}')
+                    filtered_granules.append(granule)
+                    flag_unsubmitted = True
+                else:
+                    if len(download_job_ids) > 1:
+                        self.logger.warning(f'Granule {granule["granule_id"]} has multiple associated '
+                                            f'download_job_ids. This should not happen and may be indicative of a '
+                                            f'duplicate submission.')
+
+                    self.logger.info(f'Dropping granule {granule["granule_id"]} as it has already been cataloged')
+
+        if flag_unsubmitted:
+            self.logger.warning('Query job has detected granules that were previously cataloged but don\'t appear to '
+                                'have been submitted. There is a very small chance for duplicate creation.')
 
         return filtered_granules


### PR DESCRIPTION
## Purpose
Improve dedupe logic to pass granules that have been cataloged but not submitted for download

## Issues
- [OPERA-2583](https://hysds-core.atlassian.net/browse/OPERA-2583)

## Testing
- [x] Cluster deploy
- [x] Validate deduping
  - [x] Run HLS/SLC queries for baseline
  - [x] Reset cluster
  - [x] Rerun HLS/SLC queries, but interrupt each during catalog write or job submission phases and run again to completion

## Testing Outcome

Commands:

```shell
# HLS.S:
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -s 2026-07-01T00:00:00Z -e 2026-07-03T00:00:00Z -c HLSS30 --job-queue=opera-job_worker-hls_data_download --chunk-size=1 --use-temporal 2>&1 | tee query_hlss.log

# HLS.L:
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -s 2026-07-01T00:00:00Z -e 2026-07-03T00:00:00Z -c HLSL30 --job-queue=opera-job_worker-hls_data_download --chunk-size=1 --use-temporal 2>&1 | tee query_hlsl.log

# SLCA:
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -s 2025-07-01T00:00:00Z -e 2025-07-03T00:00:00Z -c SENTINEL-1A_SLC -p ASF --job-queue=opera-job_worker-slc_data_download --chunk-size=1 --use-temporal 2>&1 | tee query_slca.log

# SLCC:
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -s 2026-07-01T00:00:00Z -e 2026-07-03T00:00:00Z -c SENTINEL-1C_SLC -p ASF --job-queue=opera-job_worker-slc_data_download --chunk-size=1 --use-temporal 2>&1 | tee query_slcc.log

# SLCD:
python3 ~/mozart/ops/opera-pcm/data_subscriber/daac_data_subscriber.py query -s 2026-07-01T00:00:00Z -e 2026-07-03T00:00:00Z -c SENTINEL-1D_SLC -p ASF --job-queue=opera-job_worker-slc_data_download --chunk-size=1 --use-temporal 2>&1 | tee query_slcd.log
```

### Baseline Query Stats

- HLS-S
  - CMR Query Result Count: 18,427
  - Catalog Document Count: 128,989 (7 docs/granule -> 18,427 granules)
  - GRQ Download Count: 18,427
- HLS-L
  - CMR Query Result Count: 12,716
  - Catalog Document Count: 89,012 (7 docs/granule -> 12,716 granules)
  - GRQ Download Count: 12,716
- SLC-S1A
  - CMR Query Result Count: 1,112
  - Catalog Document Count: 999 (1 docs/granule -> 999 granules)
  - GRQ Download Count: 999
- SLC-S1C
  - CMR Query Result Count: 949
  - Catalog Document Count: 851 (1 docs/granule -> 851 granules)
  - GRQ Download Count: 851
- SLC-S1D
  - CMR Query Result Count: 1,088
  - Catalog Document Count: 981 (1 docs/granule -> 981 granules)
  - GRQ Download Count: 981

### Interrupted Query Stats

- HLS-S
  - CMR Query 1 Result Count: 18,427
  - CMR Query 2 Result Count: 18,427
  - Interrupted at: Job submission
  - Catalog Document Count Interrupted: 128,989 (7 docs/granule -> 18,427 granules)
  - Catalog Document Count Re-run: 128,989 (7 docs/granule -> 18,427 granules)
  - GRQ Download Count Interrupted: 2,767
  - GRQ Download Count Re-run: 18,427
- HLS-L
  - CMR Query 1 Result Count: 12,716
  - CMR Query 2 Result Count: 12,716
  - Interrupted at: Cataloging
  - Catalog Document Count Interrupted: 38,944 (7 docs/granule -> 5563.43 granules)
  - Catalog Document Count Re-run: 89,012 (7 docs/granule -> 12,716 granules)
  - GRQ Download Count Interrupted: 0
  - GRQ Download Count Re-run: 12,716
- SLC-S1A
  - CMR Query 1 Result Count: 1,112
  - CMR Query 2 Result Count: 1,112
  - Interrupted at: Job submission
  - Catalog Document Count Interrupted: 999 (1 docs/granule -> 999 granules)
  - Catalog Document Count Re-run: 999 (1 docs/granule -> 999 granules)
  - GRQ Download Count Interrupted: 225
  - GRQ Download Count Re-run: 999
- SLC-S1C
  - CMR Query 1 Result Count: 949
  - CMR Query 2 Result Count: 949
  - Interrupted at: Job submission
  - Catalog Document Count Interrupted: 851 (1 docs/granule -> 851 granules)
  - Catalog Document Count Re-run: 851 (1 docs/granule -> 851 granules)
  - GRQ Download Count Interrupted: 140
  - GRQ Download Count Re-run: 851
- SLC-S1D
  - CMR Query 1 Result Count: 1,088
  - CMR Query 2 Result Count: 1,088
  - Interrupted at: Job submission
  - Catalog Document Count Interrupted: 981 (1 docs/granule -> 981 granules)
  - Catalog Document Count Re-run: 981 (1 docs/granule -> 981 granules)
  - GRQ Download Count Interrupted: 193
  - GRQ Download Count Re-run: 981 