### PR TITLE
Improve exception handling and resource cleanup in checksum_util and cslc_utils

### DIFF
--- a/data_subscriber/cslc_utils.py
+++ b/data_subscriber/cslc_utils.py
@@ -57,7 +57,7 @@ def localize_disp_frame_burst_hist(settings_yaml_path=None):
 
     try:
         file = localize_anc_json("DISP_S1_BURST_DB_S3PATH", settings_yaml_path)
-    except:
+    except Exception:
         logger.warning(f"Could not download DISP-S1 burst database json from settings.yaml field DISP_S1_BURST_DB_S3PATH from S3. "
                        f"Attempting to use local copy named {DEFAULT_DISP_FRAME_BURST_DB_NAME}.")
         file = DEFAULT_DISP_FRAME_BURST_DB_NAME
@@ -69,7 +69,7 @@ def localize_frame_geo_json(settings_yaml_path=None):
 
     try:
         file = localize_anc_json("DISP_S1_FRAME_GEO_SIMPLE", settings_yaml_path=None)
-    except:
+    except Exception:
         logger.warning(f"Could not download DISP-S1 frame geo simple json {DEFAULT_FRAME_GEO_SIMPLE_JSON_NAME} from S3. "
                        f"Attempting to use local copy named {DEFAULT_FRAME_GEO_SIMPLE_JSON_NAME}.")
         file = DEFAULT_FRAME_GEO_SIMPLE_JSON_NAME
@@ -169,10 +169,12 @@ def process_disp_frame_burst_hist(file):
     '''Process the disp frame burst map json file intended and return 3 dictionaries'''
 
     try:
-        j = json.load(open(file))["data"]
-    except:
+        with open(file) as f:
+            j = json.load(f)["data"]
+    except KeyError:
         logger.warning("No 'data' key found in the json file. Attempting to load the json file as an older format.")
-        j = json.load(open(file))
+        with open(file) as f:
+            j = json.load(f)
 
     frame_to_bursts = defaultdict(_HistBursts)
     burst_to_frames = defaultdict(list)         # List of frame numbers
@@ -209,7 +211,8 @@ def process_frame_geo_json(file):
     '''Process the frame-geometries-simple.geojson file as dictionary used for determining frame bounding box'''
 
     frame_geo_map = {}
-    j = json.load(open(file))
+    with open(file) as f:
+        j = json.load(f)
     for feature in j["features"]:
         frame_id = feature["id"]
         geom = feature["geometry"]
@@ -259,7 +262,8 @@ def localize_frame_geojson_map(settings_yaml_path=None):
         file = DEFAULT_FRAME_GEO_SIMPLE_JSON_NAME
 
     frame_geojson_map = {}
-    j = json.load(open(file))
+    with open(file) as f:
+        j = json.load(f)
     for feature in j["features"]:
         frame_geojson_map[feature["id"]] = feature["geometry"]
     return frame_geojson_map

--- a/util/checksum_util.py
+++ b/util/checksum_util.py
@@ -103,24 +103,15 @@ def create_dataset_checksums(dataset_dir, algo, globs=[], regex=[]):
                             f.close()
 
 
-def get_file_checksum(file_content, checksum_type):
+def get_file_checksum(file_content: bytes, checksum_type: str) -> str:
     """
         Perform checksum depending on which type.
-        :param file_content:
-        :param checksum_type:
-        :return:
+        :param file_content: The raw bytes to checksum.
+        :param checksum_type: Algorithm name (e.g. "md5", "sha256").
+        :return: Hex digest string.
         """
-    if checksum_type == "md5":
-        return hashlib.md5(file_content).hexdigest()
-    elif checksum_type == "sha1":
-        return hashlib.sha1(file_content).hexdigest()
-    elif checksum_type == "sha224":
-        return hashlib.sha224(file_content).hexdigest()
-    elif checksum_type == "sha256":
-        return hashlib.sha256(file_content).hexdigest()
-    elif checksum_type == "sha384":
-        return hashlib.sha384(file_content).hexdigest()
-    elif checksum_type == "sha512":
-        return hashlib.sha512(file_content).hexdigest()
-    else:
-        raise RuntimeError("Invalid checksum type : {}".format(checksum_type))
+    try:
+        return hashlib.new(checksum_type,file_content).hexdigest()
+    except ValueError:
+        raise ValueError(f"Unsupported checksum type:{checksum_type}. "
+                         f"Supported:{sorted(hashlib.algorithms_guaranteed)}")


### PR DESCRIPTION
## What
Cleaned up a few rough edges I hit while reading through `checksum_util.py` and `cslc_utils.py`.

## Changes

**checksum_util.py**
`get_file_checksum()` was a 6-branch if-elif picking md5/sha1/sha224/sha256/sha384/sha512 by string. Swapped it for `hashlib.new(algorithm)` - works for anything hashlib supports, one less place to touch when someone wants a new algo.

**cslc_utils.py**
- Two bare `except:` (lines 60, 72) were catching everything including Ctrl+C and SystemExit. Changed to `except Exception:`.
- Line 173's bare except is specifically catching a missing `"data"` key when falling back to the old JSON format, so tightened that one to `except KeyError:` instead - more honest about what it's actually handling.
- `json.load(open(file))` at lines 172, 175, 212, 262 never closes the fd. Switched to `with open(file) as f: json.load(f)`.

## Testing
- Checked `hashlib.new(name, data)` gives identical digests to the old constructors for all 6 original types.
- `get_file_checksum()` has no callers in-repo, so the RuntimeError->ValueError change on bad input is a non-issue here.
- Manually exercised both fallback paths (S3 fail -> local, missing `data` key -> old format) to confirm they still trigger correctly after narrowing the excepts.
- No unit tests exist for either function currently - worth adding separately.

No behavior change intended anywhere here, just tightening up error handling and fixing the fd leak.