### PR TITLE
Continually retry orbit file downloading for recent SLCs when none can be found

### DIFF
--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -27,7 +27,7 @@ from util.dataspace_util import (NoQueryResultsException,
                                  DEFAULT_DATASPACE_ENDPOINT)
 
 
-ORBIT_FILE_LATENCY_CUTOFF = timedelta(hours=2)
+ORBIT_FILE_LATENCY_CUTOFF = timedelta(hours=2.5)
 """
 Cutoff age of a SAFE file for which a missing orbit file will raise an error. 
 SAFE files created earlier will continually retry

--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import PurePath, Path
 from os.path import abspath, getsize, join
 
+import backoff
 import requests
 
 from data_subscriber import ionosphere_download
@@ -20,9 +21,15 @@ from tools.stage_ionosphere_file import IonosphereFileNotFoundException
 from tools.stage_orbit_file import (parse_orbit_time_range_from_safe,
                                     T_ORBIT,
                                     ORBIT_PAD)
+from util.backoff_util import backoff_logger
 from util.dataspace_util import (NoQueryResultsException,
                                  NoSuitableOrbitFileException,
                                  DEFAULT_DATASPACE_ENDPOINT)
+
+
+class OrbitFileLatencyException(Exception):
+    """Custom exception to wrap orbit file staging exceptions when in the product latency window"""
+    pass
 
 
 class AsfDaacSlcDownload(BaseDownload):
@@ -155,6 +162,12 @@ class AsfDaacSlcDownload(BaseDownload):
         with Path(dataset_dir / f"{dataset_dir.name}.dataset.json").open("w") as fp:
             json.dump(dataset_json, fp)
 
+    @backoff.on_exception(
+        backoff.constant,
+        OrbitFileLatencyException,
+        max_time=2 * 60 * 60,
+        on_backoff=backoff_logger
+    )
     def download_orbit_file(self, dataset_dir, product_filepath):
         self.logger.info("Downloading associated orbit file")
 
@@ -199,41 +212,49 @@ class AsfDaacSlcDownload(BaseDownload):
                 )
                 stage_orbit_file.main(stage_orbit_file_args)
             except (NoQueryResultsException, NoSuitableOrbitFileException):
-                self.logger.warning("Single RESORB file could not be found, querying for consecutive RESORB files")
+                try:
+                    self.logger.warning("Single RESORB file could not be found, querying for consecutive RESORB files")
 
-                self.logger.info("Querying for RESORB with range [sensing_start - 1 min, sensing_end + 1 min]")
-                sensing_start_range = safe_start_datetime - timedelta(seconds=ORBIT_PAD)
-                sensing_stop_range = safe_stop_datetime + timedelta(seconds=ORBIT_PAD)
+                    self.logger.info("Querying for RESORB with range [sensing_start - 1 min, sensing_end + 1 min]")
+                    sensing_start_range = safe_start_datetime - timedelta(seconds=ORBIT_PAD)
+                    sensing_stop_range = safe_stop_datetime + timedelta(seconds=ORBIT_PAD)
 
-                stage_orbit_file_args = stage_orbit_file.get_parser().parse_args(
-                    [
-                        f"--output-directory={str(dataset_dir)}",
-                        "--orbit-type=RESORB",
-                        f"--username={username}",
-                        f"--password={password}",
-                        f"--sensing-start-range={sensing_start_range.strftime('%Y%m%dT%H%M%S')}",
-                        f"--sensing-stop-range={sensing_stop_range.strftime('%Y%m%dT%H%M%S')}",
-                        str(product_filepath)
-                    ]
-                )
-                stage_orbit_file.main(stage_orbit_file_args)
+                    stage_orbit_file_args = stage_orbit_file.get_parser().parse_args(
+                        [
+                            f"--output-directory={str(dataset_dir)}",
+                            "--orbit-type=RESORB",
+                            f"--username={username}",
+                            f"--password={password}",
+                            f"--sensing-start-range={sensing_start_range.strftime('%Y%m%dT%H%M%S')}",
+                            f"--sensing-stop-range={sensing_stop_range.strftime('%Y%m%dT%H%M%S')}",
+                            str(product_filepath)
+                        ]
+                    )
+                    stage_orbit_file.main(stage_orbit_file_args)
 
-                self.logger.info("Querying for RESORB with range [sensing_start – T_orb – 1 min, sensing_start – T_orb + 1 min]")
-                sensing_start_range = safe_start_datetime - timedelta(seconds=T_ORBIT + ORBIT_PAD)
-                sensing_stop_range = safe_start_datetime - timedelta(seconds=T_ORBIT - ORBIT_PAD)
+                    self.logger.info("Querying for RESORB with range [sensing_start – T_orb – 1 min, sensing_start – T_orb + 1 min]")
+                    sensing_start_range = safe_start_datetime - timedelta(seconds=T_ORBIT + ORBIT_PAD)
+                    sensing_stop_range = safe_start_datetime - timedelta(seconds=T_ORBIT - ORBIT_PAD)
 
-                stage_orbit_file_args = stage_orbit_file.get_parser().parse_args(
-                    [
-                        f"--output-directory={str(dataset_dir)}",
-                        "--orbit-type=RESORB",
-                        f"--username={username}",
-                        f"--password={password}",
-                        f"--sensing-start-range={sensing_start_range.strftime('%Y%m%dT%H%M%S')}",
-                        f"--sensing-stop-range={sensing_stop_range.strftime('%Y%m%dT%H%M%S')}",
-                        str(product_filepath)
-                    ]
-                )
-                stage_orbit_file.main(stage_orbit_file_args)
+                    stage_orbit_file_args = stage_orbit_file.get_parser().parse_args(
+                        [
+                            f"--output-directory={str(dataset_dir)}",
+                            "--orbit-type=RESORB",
+                            f"--username={username}",
+                            f"--password={password}",
+                            f"--sensing-start-range={sensing_start_range.strftime('%Y%m%dT%H%M%S')}",
+                            f"--sensing-stop-range={sensing_stop_range.strftime('%Y%m%dT%H%M%S')}",
+                            str(product_filepath)
+                        ]
+                    )
+                    stage_orbit_file.main(stage_orbit_file_args)
+                except (NoQueryResultsException, NoSuitableOrbitFileException) as e:
+                    if datetime.now(timezone.utc).replace(tzinfo=None) - safe_stop_datetime < timedelta(hours=2):
+                        self.logger.warning(f'Orbit file may not be available yet')
+                        raise OrbitFileLatencyException(e)
+                    else:
+                        raise
+
         finally:
             # Clear the username and password from memory
             del username

--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -174,7 +174,8 @@ class AsfDaacSlcDownload(BaseDownload):
         OrbitFileLatencyException,
         max_time=int(ORBIT_FILE_LATENCY_CUTOFF * 60 * 60),
         on_backoff=backoff_logger,
-        interval=60
+        interval=60,
+        jitter=None
     )
     def download_orbit_file(self, dataset_dir, product_filepath):
         self.logger.info("Downloading associated orbit file")

--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -27,6 +27,13 @@ from util.dataspace_util import (NoQueryResultsException,
                                  DEFAULT_DATASPACE_ENDPOINT)
 
 
+ORBIT_FILE_LATENCY_CUTOFF = timedelta(hours=2)
+"""
+Cutoff age of a SAFE file for which a missing orbit file will raise an error. 
+SAFE files created earlier will continually retry
+"""
+
+
 class OrbitFileLatencyException(Exception):
     """Custom exception to wrap orbit file staging exceptions when in the product latency window"""
     pass
@@ -166,7 +173,8 @@ class AsfDaacSlcDownload(BaseDownload):
         backoff.constant,
         OrbitFileLatencyException,
         max_time=2 * 60 * 60,
-        on_backoff=backoff_logger
+        on_backoff=backoff_logger,
+        interval=60
     )
     def download_orbit_file(self, dataset_dir, product_filepath):
         self.logger.info("Downloading associated orbit file")
@@ -249,10 +257,15 @@ class AsfDaacSlcDownload(BaseDownload):
                     )
                     stage_orbit_file.main(stage_orbit_file_args)
                 except (NoQueryResultsException, NoSuitableOrbitFileException) as e:
-                    if datetime.now(timezone.utc).replace(tzinfo=None) - safe_stop_datetime < timedelta(hours=2):
+                    safe_age = datetime.now(timezone.utc).replace(tzinfo=None) - safe_stop_datetime
+                    self.logger.info(f'Failed to find orbit file for SAFE that is {safe_age} old')
+
+                    if safe_age < ORBIT_FILE_LATENCY_CUTOFF:
                         self.logger.warning(f'Orbit file may not be available yet')
                         raise OrbitFileLatencyException(e)
                     else:
+                        self.logger.error('Giving up orbit file download attempts. May need to retry later or '
+                                          'investigate why the orbit file is missing')
                         raise
 
         finally:

--- a/data_subscriber/asf_slc_download.py
+++ b/data_subscriber/asf_slc_download.py
@@ -27,9 +27,9 @@ from util.dataspace_util import (NoQueryResultsException,
                                  DEFAULT_DATASPACE_ENDPOINT)
 
 
-ORBIT_FILE_LATENCY_CUTOFF = timedelta(hours=2.5)
+ORBIT_FILE_LATENCY_CUTOFF = 2.5
 """
-Cutoff age of a SAFE file for which a missing orbit file will raise an error. 
+Cutoff age in hours of a SAFE file for which a missing orbit file will raise an error. 
 SAFE files created earlier will continually retry
 """
 
@@ -172,7 +172,7 @@ class AsfDaacSlcDownload(BaseDownload):
     @backoff.on_exception(
         backoff.constant,
         OrbitFileLatencyException,
-        max_time=2 * 60 * 60,
+        max_time=int(ORBIT_FILE_LATENCY_CUTOFF * 60 * 60),
         on_backoff=backoff_logger,
         interval=60
     )
@@ -260,7 +260,7 @@ class AsfDaacSlcDownload(BaseDownload):
                     safe_age = datetime.now(timezone.utc).replace(tzinfo=None) - safe_stop_datetime
                     self.logger.info(f'Failed to find orbit file for SAFE that is {safe_age} old')
 
-                    if safe_age < ORBIT_FILE_LATENCY_CUTOFF:
+                    if safe_age < timedelta(hours=ORBIT_FILE_LATENCY_CUTOFF):
                         self.logger.warning(f'Orbit file may not be available yet')
                         raise OrbitFileLatencyException(e)
                     else:

--- a/tools/stage_orbit_file.py
+++ b/tools/stage_orbit_file.py
@@ -305,7 +305,7 @@ def query_orbit_file_service(endpoint_url, query):
 
     # Check for empty list of results
     if not query_results:
-        raise NoQueryResultsException('No results returned from parsed query results')
+        raise NoQueryResultsException('No results returned from parsed query results. Try again later.')
 
     return query_results
 


### PR DESCRIPTION
## Purpose
We've seen frequent SLC download job failures due to being unable to find any suitable orbit file for the associated SLC.

```
util.dataspace_util.NoQueryResultsException: No results returned from parsed query results
```

This occurs when the orbit file is not yet published when the SLC is being downloaded, so this PR adds a check to continually backoff the orbit file download until the SLC has reached a certain age.

## Issues
- [OPERA-2448](https://hysds-core.atlassian.net/browse/OPERA-2448)

## Testing
- [x] Ran in dev with S1C/D timers running every 10 minutes, verified orbit files retried until available.
