### PR TITLE
Clean up pge tarballs after deploy

### DIFF
--- a/tools/deploy_pges.py
+++ b/tools/deploy_pges.py
@@ -192,6 +192,14 @@ def main():
             if FAILED in result:
                 failed.append(os.path.basename(result[FAILED]))
 
+    for pge in pge_files:
+        if os.path.basename(pge_files[pge]) not in failed:
+            try:
+                os.unlink(pge_files[pge])
+                logger.info(f'Cleaned up PGE tarball for PGE {pge}')
+            except Exception as e:
+                logger.warning(f'Failed to remove PGE tarball for PGE {pge}: {e}')
+
     if len(failed) != 0:
         logger.error("The following PGEs failed to get deployed: {}".format(failed))
         sys.exit(1)


### PR DESCRIPTION
## Purpose
In the `deploy_pges.py` script, delete downloaded PGE tarballs after deployment completes (if successful). This should free up a decent chunk of disk space.

## Issues
- N/A (can create an associated ticket if needed)

## Testing
- [x] Ran manually