### PR TITLE
Honour run_smoke_test in the two DISP-S1 provisioners

### DIFF
--- a/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/main.tf
+++ b/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/main.tf
@@ -141,7 +141,9 @@ resource "null_resource" "mozart" {
     inline = [<<-EOF
               set -ex
               source ~/.bash_profile
-              ~/mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/run_smoke_test.sh ~/mozart/ops/opera-pcm/cluster_provisioning/smoke_test_inputs.config || :
+              if [ "${var.run_smoke_test}" = true ]; then
+                ~/mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/run_smoke_test.sh ~/mozart/ops/opera-pcm/cluster_provisioning/smoke_test_inputs.config || :
+              fi
     EOF
     ]
   }

--- a/cluster_provisioning/dev-e2e-pge-DISP_S1/main.tf
+++ b/cluster_provisioning/dev-e2e-pge-DISP_S1/main.tf
@@ -141,7 +141,9 @@ resource "null_resource" "mozart" {
     inline = [<<-EOF
               set -ex
               source ~/.bash_profile
-              ~/mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1/run_smoke_test.sh ~/mozart/ops/opera-pcm/cluster_provisioning/smoke_test_inputs.config || :
+              if [ "${var.run_smoke_test}" = true ]; then
+                ~/mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1/run_smoke_test.sh ~/mozart/ops/opera-pcm/cluster_provisioning/smoke_test_inputs.config || :
+              fi
     EOF
     ]
   }


### PR DESCRIPTION
## Summary

Both DISP-S1 provisioners declare a `run_smoke_test` variable and never read it. Their built-in smoke test therefore runs unconditionally, and setting the flag does nothing. `dev-e2e` already gates on it correctly; this brings the other two into line.

| stack | declares `run_smoke_test` | reads it in `main.tf` |
|---|---|---|
| `dev-e2e` | yes | 4 places |
| `dev-e2e-pge-DISP_S1` | yes | **none** |
| `dev-e2e-pge-DISP_S1-all_phases` | yes | **none** |

## Why it matters

The DISP-S1 smoke test is the long pole in these deploys — the base stack runs 56 forward dates at 30–60 minutes each, so `terraform apply` does not return for roughly two and a half days. There is currently no way to stand up one of these clusters without it, even though the variable exists and looks like it should work.

That matters when the cluster is wanted for a different test than the built-in one. The case that surfaced this: validating DISP-S1 frames that have no sensing datetimes in the burst database. Such a frame cannot be processed historically — there is no acquisition series — so the built-in smoke's historical phase is correctly refused, which reads as a failure, and its forward phase then drives 56 dates when the test needs 18. The flag was the obvious control, and it silently did nothing.

## Changes

One `if` around the smoke invocation in each of the two stacks, matching the idiom `dev-e2e` already uses:

```hcl
if [ "${var.run_smoke_test}" = true ]; then
  ~/mozart/ops/opera-pcm/cluster_provisioning/<stack>/run_smoke_test.sh ... || :
fi
```

## Risk

**None for existing callers.** The variable still defaults to `true`, so the default path is byte-for-byte what it was. Nothing in the repo — no tfvars, script, config or doc — sets `run_smoke_test` today, so no current usage changes behaviour and nobody has been silently getting a smoke run they asked to skip.

The change is confined to a shell conditional inside the existing `remote-exec` heredoc; no resources, ordering or dependencies are touched.

## Testing

`terraform fmt -check` clean on both stacks.

The same construct is deployed and running: a cluster provisioned from a branch carrying this change to `dev-e2e-pge-DISP_S1`, with `run_smoke_test = false`, applied without error — confirming the HCL is valid and the heredoc still parses. Default-true behaviour is exercised by every other deploy from these stacks, two of which are running concurrently from unmodified branches.
