### PR TITLE
OPERA-2629: publish CSLC burst metadata at the dataset level so DISP-S1 forward triggers

### DIFF
--- a/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/run_smoke_test.sh
+++ b/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/run_smoke_test.sh
@@ -68,18 +68,6 @@ sds ship
 
 cd ${TEST_DIR}
 
-# Frame 17235 is in region 4, and trigger-SCIFLO_L3_DISP_S1 gates on a region whitelist whose
-# shipped default is ["0"]. Every historical k-set still publishes without this -- those SCIFLOs are
-# submitted by the cslc_download job and never go through the rule -- but no forward-phase KSC ever
-# fires, so the walk completes at 100% owing exactly the forward products.
-python ~/mozart/ops/opera-pcm/tools/disp_s1_set_whitelist.py --whitelist-regions 4
-
-restore_whitelist() {
-  echo "Disabling the DISP-S1 region whitelist"
-  python ~/mozart/ops/opera-pcm/tools/disp_s1_set_whitelist.py --disable-whitelist || true
-}
-trap restore_whitelist EXIT
-
 # pcm_batch rejects a phased batch proc whose frames are not annotated, whose
 # annotations would be quarantined, or whose k differs from the batch size the
 # labels were generated for. A failure here means the deployed burst database

--- a/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/run_smoke_test.sh
+++ b/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/run_smoke_test.sh
@@ -68,6 +68,18 @@ sds ship
 
 cd ${TEST_DIR}
 
+# Frame 17235 is in region 4, and trigger-SCIFLO_L3_DISP_S1 gates on a region whitelist whose
+# shipped default is ["0"]. Every historical k-set still publishes without this -- those SCIFLOs are
+# submitted by the cslc_download job and never go through the rule -- but no forward-phase KSC ever
+# fires, so the walk completes at 100% owing exactly the forward products.
+python ~/mozart/ops/opera-pcm/tools/disp_s1_set_whitelist.py --whitelist-regions 4
+
+restore_whitelist() {
+  echo "Disabling the DISP-S1 region whitelist"
+  python ~/mozart/ops/opera-pcm/tools/disp_s1_set_whitelist.py --disable-whitelist || true
+}
+trap restore_whitelist EXIT
+
 # pcm_batch rejects a phased batch proc whose frames are not annotated, whose
 # annotations would be quarantined, or whose k differs from the batch size the
 # labels were generated for. A failure here means the deployed burst database

--- a/cluster_provisioning/dev-e2e-pge-DISP_S1/check_pcm.py
+++ b/cluster_provisioning/dev-e2e-pge-DISP_S1/check_pcm.py
@@ -46,6 +46,12 @@ class TestPCM(unittest.TestCase):
         logger = logging.getLogger(__name__)
         self.check_expected("/tmp/datasets_fwd.txt", logger)
 
+    def test_pge_cslc_feed(self):
+        """Test that CSLCs produced by the local CSLC-S1 PGE drove a forward DISP-S1 product."""
+
+        logger = logging.getLogger(__name__)
+        self.check_expected("/tmp/pge_cslc_feed.txt", logger)
+
     def tearDown(self):
         pass
 

--- a/cluster_provisioning/dev-e2e-pge-DISP_S1/run_smoke_test.sh
+++ b/cluster_provisioning/dev-e2e-pge-DISP_S1/run_smoke_test.sh
@@ -293,6 +293,35 @@ if [[ "$initial_triggerable_ksc_count" -ne "$post_submission_triggerable_ksc_cou
   exit 1
 fi
 
+# ============================================================
+# Phase 2b: a forward date fed by locally produced CSLCs
+# ============================================================
+# Every forward date above entered the cascade as a metadata-only
+# cslc_catalog_ingest dataset. Operational forward processing instead ingests
+# SLCs and runs the CSLC-S1 PGE, whose datasets carry their filename metadata
+# per published file. This stage ingests the SLC behind frame 31241's next
+# acquisition after the negative-assertion window, 2019-06-13, and asserts
+# that the PGE-produced CSLCs complete the frame's cycle and k-cycle state
+# configs and produce an L3_DISP_S1 from the local .h5 files.
+#
+# 2019-06-13 is position 27 of the frame's burst-database series: its k-window
+# needs only the compressed CSLC the historical phase wrote at position 14, and
+# no forward boundary falls in between, so the date fires on its own. The SLC
+# query runs in reprocessing mode because that is the mode the CSLC-S1 trigger
+# rule matches; the temporal window selects the one IW SLC of that pass that
+# covers both bursts (S1A_IW_SLC__1SDV_20190613T172922_..._031F60_1E24).
+python ~/mozart/ops/opera-pcm/tools/disp_s1_set_whitelist.py --whitelist-regions 4
+(cd ~/mozart/ops/opera-pcm && PYTHONPATH=$PWD python conf/sds/files/test/check_disp_s1_pge_cslc_feed.py \
+  --mozart-ip "${MOZART_PVT_IP}" \
+  --job-release "${JOB_RELEASE}" \
+  --frame-id 31241 \
+  --burst-ids T117-249921-IW3 T117-249922-IW3 \
+  --sensing-date 20190613 \
+  --slc-collection SENTINEL-1A_SLC \
+  --slc-start 2019-06-13T17:29:30Z \
+  --slc-end 2019-06-13T17:29:35Z \
+  --out /tmp/pge_cslc_feed.txt) || true
+
 # Disable whitelist to not interfere with any future testing
 python ~/mozart/ops/opera-pcm/tools/disp_s1_set_whitelist.py --disable-whitelist
 

--- a/conf/sds/files/test/check_disp_s1_pge_cslc_feed.py
+++ b/conf/sds/files/test/check_disp_s1_pge_cslc_feed.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python
+"""Assert that CSLCs produced by the local CSLC-S1 PGE drive the DISP-S1 forward cascade.
+
+Every other forward date in the DISP-S1 smoke test enters the cascade as a metadata-only
+cslc_catalog_ingest dataset. Operational forward processing instead ingests SLCs and
+runs the CSLC-S1 PGE, whose datasets product2dataset publishes. This script ingests one
+SLC through the production SLC query job, in reprocessing mode because that is the mode
+the CSLC-S1 trigger rule matches, then follows the cascade for one frame and date:
+
+  1. the CSLC-S1 PGE publishes an L2_CSLC_S1 dataset for every burst of the frame, each
+     carrying metadata.burst_id and a dataset starttime at the top level;
+  2. the frame's cycle state config for the date is complete and records exactly those
+     datasets' .h5 products;
+  3. the frame's k-cycle state config for the date is complete and lists them;
+  4. an L3_DISP_S1 product for the date is published, built from them.
+
+Writes SUCCESS/ERROR lines in the same format check_datasets_file.py uses, so
+check_pcm.py can assert on the result file. Each step has its own time budget; a step
+that runs out is an ERROR, reported with the jobs that failed since the SLC was
+submitted, and the steps after it are not attempted.
+"""
+
+import argparse
+import json
+import logging
+import re
+import sys
+import time
+from datetime import datetime, timezone
+
+from opera_commons.es_connection import get_grq_es, get_mozart_es
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s",
+                    datefmt="%Y-%m-%d %H:%M:%S")
+logger = logging.getLogger("pge_cslc_feed")
+
+CSLC_INDEX = "grq_*_l2_cslc_s1-*"
+CSC_INDEX = "grq_*_cslc_s1-cycle-state-config*"
+KSC_INDEX = "grq_*_disp_s1-kcycle*"
+L3_INDEX = "grq_*_l3_disp_s1*"
+JOB_STATUS_INDEX = "job_status-current"
+
+SLC_QUERY_JOB_TYPES = {
+    "SENTINEL-1A_SLC": "slcs1a_query",
+    "SENTINEL-1B_SLC": "slcs1b_query",
+    "SENTINEL-1C_SLC": "slcs1c_query",
+    "SENTINEL-1D_SLC": "slcs1d_query",
+}
+SLC_QUERY_QUEUE = "opera-job_worker-slc_data_query"
+SLC_DOWNLOAD_QUEUE = "opera-job_worker-slc_data_download"
+TAG = "disp_s1_pge_cslc_feed"
+
+# ..._<burst>_<sensing>T..Z_<processed>T..Z_...
+CSLC_ID_RE = re.compile(r"OPERA_L2_CSLC-S1_(T\d{3}-\d{6}-IW\d)_(\d{8})T\d{6}Z_(\d{8}T\d{6}Z)_")
+
+
+def build_slc_query_params(slc_start, slc_end, job_release):
+    """Params for the SLC query job, formatted as the query-timer and batch lambdas do."""
+    return {
+        "endpoint": "--endpoint=OPS",
+        "start_datetime": f"--start-date={slc_start}",
+        "end_datetime": f"--end-date={slc_end}",
+        "bounding_box": "",
+        "no_schedule_download": "",
+        "download_job_release": f"--release-version={job_release}",
+        "download_job_queue": f"--job-queue={SLC_DOWNLOAD_QUEUE}",
+        "chunk_size": "--chunk-size=1",
+        "smoke_run": "",
+        "dry_run": "",
+        "use_temporal": "--use-temporal",
+        "max_revision": "--max-revision=1000",
+        "temporal_start_datetime": "",
+        "processing_mode": "--processing-mode=reprocessing",
+        "include_regions": "",
+        "exclude_regions": "",
+        "transfer_protocol": "--transfer-protocol=auto",
+        "provider": "--provider=ASF",
+    }
+
+
+def submit_slc_query(mozart_ip, job_release, collection, slc_start, slc_end):
+    import requests
+    import urllib3
+    urllib3.disable_warnings()
+
+    form = {
+        "queue": SLC_QUERY_QUEUE,
+        "priority": "0",
+        "tags": json.dumps([TAG]),
+        "type": f"job-{SLC_QUERY_JOB_TYPES[collection]}:{job_release}",
+        "params": json.dumps(build_slc_query_params(slc_start, slc_end, job_release)),
+        "name": f"{TAG}-{collection}-{slc_start}",
+    }
+    url = f"https://{mozart_ip}/mozart/api/v0.1/job/submit?enable_dedup=false"
+    response = requests.post(url, data=form, verify=False, timeout=60)
+    response.raise_for_status()
+    result = response.json()
+    if not result.get("success"):
+        raise RuntimeError(f"SLC query submission failed: {result}")
+    return result["result"]
+
+
+def h5_path(meta):
+    return next((p for p in (meta.get("product_s3_paths") or []) if p.endswith(".h5")), "")
+
+
+def select_pge_cslcs(hits, burst_ids, sensing_date):
+    """The newest PGE-produced VV CSLC per burst of the frame on the sensing date."""
+    newest = {}
+    for hit in hits:
+        source = hit.get("_source", {})
+        meta = source.get("metadata", {})
+        if "PGE" not in (meta.get("tags") or []):
+            continue
+        match = CSLC_ID_RE.search(hit.get("_id", ""))
+        if not match or "_VV_" not in hit["_id"]:
+            continue
+        burst_id, date, processed = match.groups()
+        if burst_id not in burst_ids or date != sensing_date:
+            continue
+        if burst_id not in newest or processed > newest[burst_id][0]:
+            newest[burst_id] = (processed, hit)
+    return {burst_id: hit for burst_id, (_, hit) in newest.items()}
+
+
+def check_cslcs(selected, burst_ids):
+    """Every burst has a PGE CSLC, and each carries the promoted top-level fields."""
+    errors = []
+    missing = sorted(set(burst_ids) - set(selected))
+    if missing:
+        errors.append(f"no PGE-produced CSLC for bursts {missing}")
+    for burst_id, hit in sorted(selected.items()):
+        source = hit["_source"]
+        meta = source.get("metadata", {})
+        if meta.get("burst_id") != burst_id:
+            errors.append(f"{hit['_id']} has metadata.burst_id={meta.get('burst_id')!r}")
+        if not source.get("starttime"):
+            errors.append(f"{hit['_id']} has no dataset starttime")
+        if not h5_path(meta):
+            errors.append(f"{hit['_id']} lists no .h5 in metadata.product_s3_paths")
+    return errors
+
+
+def check_csc(meta, expected_paths):
+    errors = []
+    if not meta.get("is_complete"):
+        errors.append(f"cycle state config incomplete: {meta.get('completeness_reason')}")
+    paths = set(meta.get("cslc_product_paths") or [])
+    if paths != set(expected_paths):
+        errors.append(f"cycle state config records {sorted(paths)}, "
+                      f"expected the PGE products {sorted(expected_paths)}")
+    return errors
+
+
+def check_ksc(meta, expected_paths):
+    errors = []
+    if not meta.get("is_complete"):
+        errors.append(f"k-cycle state config incomplete: {meta.get('completeness_reason')}")
+    if meta.get("compressed_cslc_final") is False:
+        errors.append(f"k-cycle state config waiting on compressed CSLCs "
+                      f"{meta.get('compressed_cslc_pending')}")
+    listed = set((meta.get("product_paths") or {}).get("L2_CSLC_S1") or [])
+    absent = sorted(set(expected_paths) - listed)
+    if absent:
+        errors.append(f"k-cycle state config does not list the PGE products {absent}")
+    return errors
+
+
+def find_l3(hits, frame_id, sensing_date):
+    """The L3_DISP_S1 products whose secondary date is the sensing date."""
+    pattern = re.compile(rf"_F{int(frame_id):05d}_VV_\d{{8}}T\d{{6}}Z_{sensing_date}T")
+    return [hit for hit in hits if pattern.search(hit.get("_id", ""))]
+
+
+def lineage_uses(hit, cslc_ids):
+    lineage = (hit.get("_source", {}).get("metadata", {}) or {}).get("lineage") or []
+    return [cslc_id for cslc_id in cslc_ids if any(cslc_id in str(entry) for entry in lineage)]
+
+
+class Report:
+    def __init__(self, path):
+        self.path = path
+        self.lines = []
+
+    def success(self, message):
+        logger.info(message)
+        self.lines.append(f"SUCCESS: {message}")
+
+    def error(self, message):
+        logger.error(message)
+        self.lines.append(f"ERROR: {message}")
+
+    def write(self):
+        with open(self.path, "w") as f:
+            f.write("\n".join(self.lines) + "\n")
+
+
+def failed_jobs_since(start_iso):
+    """Best-effort summary of jobs that failed after the SLC was submitted."""
+    try:
+        body = {
+            "query": {"bool": {"must": [
+                {"term": {"status": "job-failed"}},
+                {"range": {"@timestamp": {"gte": start_iso}}},
+            ]}},
+            "_source": ["job.type", "job.name", "short_error", "error"],
+            "size": 50,
+        }
+        hits = get_mozart_es(logger).query(index=JOB_STATUS_INDEX, body=body) or []
+        return [f"{h['_source'].get('job', {}).get('type')} {h['_source'].get('job', {}).get('name')}: "
+                f"{str(h['_source'].get('short_error') or h['_source'].get('error'))[:200]}"
+                for h in hits]
+    except Exception as e:
+        return [f"(could not list failed jobs: {e})"]
+
+
+def poll(what, fn, timeout_mins, poll_secs):
+    """Call fn until it returns (True, value) or the budget runs out; returns the last value."""
+    deadline = time.time() + timeout_mins * 60
+    value = None
+    while True:
+        done, value = fn()
+        if done:
+            return True, value
+        if time.time() >= deadline:
+            logger.warning(f"{what}: gave up after {timeout_mins} min")
+            return False, value
+        logger.info(f"{what}: waiting")
+        time.sleep(poll_secs)
+
+
+def run(args, eu, report):
+    burst_ids = sorted(args.burst_ids)
+    date = args.sensing_date
+    day = f"{date[:4]}-{date[4:6]}-{date[6:]}"
+
+    def l3_hits():
+        body = {"query": {"term": {"metadata.frame_id": args.frame_id}},
+                "_source": ["id", "metadata.lineage"], "size": 1000}
+        return find_l3(eu.query(index=L3_INDEX, body=body) or [], args.frame_id, date)
+
+    if l3_hits():
+        report.error(f"an L3_DISP_S1 for frame {args.frame_id} on {date} existed before the SLC "
+                     f"was ingested, so this stage cannot attribute it to the PGE CSLCs")
+        return
+
+    start_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    if not args.no_submit:
+        job_id = submit_slc_query(args.mozart_ip, args.job_release, args.slc_collection,
+                                  args.slc_start, args.slc_end)
+        logger.info(f"submitted SLC query job {job_id}")
+
+    cslc_body = {
+        "query": {"bool": {
+            "must": [
+                {"term": {"dataset_type.keyword": "L2_CSLC_S1"}},
+                {"terms": {"metadata.Files.burst_id.keyword": burst_ids}},
+            ],
+            "filter": [{"range": {"metadata.Files.acquisition_ts": {
+                "gte": f"{day}T00:00:00", "lt": f"{day}T23:59:59"}}}],
+        }},
+        "size": 200,
+    }
+
+    def cslcs_ready():
+        selected = select_pge_cslcs(eu.query(index=CSLC_INDEX, body=cslc_body) or [], burst_ids, date)
+        return set(selected) == set(burst_ids), selected
+
+    ok, selected = poll("PGE CSLCs", cslcs_ready, args.cslc_timeout_mins, args.poll_secs)
+    errors = check_cslcs(selected or {}, burst_ids)
+    if not ok or errors:
+        for e in errors or ["PGE CSLCs did not appear"]:
+            report.error(e)
+        for line in failed_jobs_since(start_iso):
+            report.error(f"failed job: {line}")
+        return
+    expected_paths = sorted(h5_path(hit["_source"]["metadata"]) for hit in selected.values())
+    cslc_ids = sorted(hit["_id"] for hit in selected.values())
+    report.success(f"CSLC-S1 PGE published {len(selected)} CSLCs for frame {args.frame_id} on "
+                   f"{date}, each with metadata.burst_id and starttime: {cslc_ids}")
+
+    csc_id = f"cslc_s1-cycle-f{args.frame_id}-{date}-state-config"
+
+    def csc_ready():
+        hits = eu.query(index=CSC_INDEX, body={"query": {"ids": {"values": [csc_id]}}}) or []
+        meta = hits[0]["_source"]["metadata"] if hits else {}
+        return bool(meta) and not check_csc(meta, expected_paths), meta
+
+    ok, meta = poll("cycle state config", csc_ready, args.csc_timeout_mins, args.poll_secs)
+    if not ok:
+        for e in (check_csc(meta, expected_paths) if meta else [f"{csc_id} was never published"]):
+            report.error(e)
+        return
+    report.success(f"{csc_id} complete ({meta.get('coverage_actual')}/{meta.get('coverage_expected')}) "
+                   f"from the PGE products")
+
+    def ksc_ready():
+        body = {"query": {"term": {"metadata.frame_id": args.frame_id}}, "size": 1000}
+        kscs = [h for h in (eu.query(index=KSC_INDEX, body=body) or [])
+                if str(h["_source"]["metadata"].get("sensing_date")) == date]
+        good = [h for h in kscs if not check_ksc(h["_source"]["metadata"], expected_paths)]
+        if good:
+            return True, good[0]
+        return False, kscs[0] if kscs else None
+
+    ok, ksc = poll("k-cycle state config", ksc_ready, args.ksc_timeout_mins, args.poll_secs)
+    if not ok:
+        if ksc is None:
+            report.error(f"no k-cycle state config for frame {args.frame_id} on {date}")
+        else:
+            for e in check_ksc(ksc["_source"]["metadata"], expected_paths):
+                report.error(f"{ksc['_id']}: {e}")
+        return
+    report.success(f"{ksc['_id']} complete and lists the PGE products")
+
+    ok, l3 = poll("L3_DISP_S1", lambda: (bool(l3_hits()), l3_hits()),
+                  args.l3_timeout_mins, args.poll_secs)
+    if not ok:
+        report.error(f"no L3_DISP_S1 for frame {args.frame_id} on {date}")
+        for line in failed_jobs_since(start_iso):
+            report.error(f"failed job: {line}")
+        return
+    used = lineage_uses(l3[0], cslc_ids)
+    report.success(f"{l3[0]['_id']} published")
+    if len(used) == len(cslc_ids):
+        report.success("its lineage includes every PGE-produced CSLC of the date")
+    else:
+        report.error(f"its lineage includes {len(used)}/{len(cslc_ids)} of the PGE-produced CSLCs")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--mozart-ip", required=True)
+    ap.add_argument("--job-release", required=True)
+    ap.add_argument("--frame-id", type=int, required=True)
+    ap.add_argument("--burst-ids", nargs="+", required=True, help="the frame's bursts, e.g. T117-249921-IW3")
+    ap.add_argument("--sensing-date", required=True, help="YYYYMMDD")
+    ap.add_argument("--slc-collection", choices=sorted(SLC_QUERY_JOB_TYPES), required=True)
+    ap.add_argument("--slc-start", required=True, help="temporal window start, YYYY-MM-DDTHH:MM:SSZ")
+    ap.add_argument("--slc-end", required=True, help="temporal window end, YYYY-MM-DDTHH:MM:SSZ")
+    ap.add_argument("--no-submit", action="store_true", help="only check; the SLC was already ingested")
+    ap.add_argument("--poll-secs", type=int, default=60)
+    ap.add_argument("--cslc-timeout-mins", type=int, default=240)
+    ap.add_argument("--csc-timeout-mins", type=int, default=60)
+    ap.add_argument("--ksc-timeout-mins", type=int, default=90)
+    ap.add_argument("--l3-timeout-mins", type=int, default=240)
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    report = Report(args.out)
+    try:
+        run(args, get_grq_es(logger), report)
+    except Exception as e:
+        report.error(f"stage aborted: {e!r}")
+    report.write()
+    print(open(args.out).read())
+    return 1 if any(line.startswith("ERROR") for line in report.lines) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/conf/settings.yaml
+++ b/conf/settings.yaml
@@ -462,7 +462,11 @@ PRODUCT_TYPES:
             # Specify the metadata key to use as the dataset version.
             #  Note: this affects the data product index name
             Dataset_Version_Key: 'product_version'
-        Dataset_Keys: {}
+        # The dataset start and end time are the burst acquisition time, so a CSLC can be
+        # selected by sensing date through the dataset's starttime.
+        Dataset_Keys:
+            starttime: acquisition_ts
+            endtime: acquisition_ts
 
     L2_CSLC_S1_STATIC:
       # Pattern for parsing output L2_CSLC-S1 static layer product filenames, such as:

--- a/data_subscriber/cslc/disp_s1_cycle_evaluator.py
+++ b/data_subscriber/cslc/disp_s1_cycle_evaluator.py
@@ -41,6 +41,57 @@ from util.common_util import backoff_wrapper, create_info_message_files
 
 logger = logging.getLogger(__name__)
 
+CSLC_H5_SUFFIX = ".h5"
+DISP_S1_POLARIZATION = "VV"
+# Upper bound on documents returned per burst for one frame and sensing date. Several
+# can legitimately exist: reprocessed granules, cross-polarization products, and the
+# same burst published by both a local PGE run and catalog ingest.
+CSLC_HITS_PER_BURST = 5
+CSLC_MIN_QUERY_SIZE = 200
+
+
+def _file_entries(meta):
+    return [entry for entry in (meta.get("Files") or []) if isinstance(entry, dict)]
+
+
+def cslc_burst_id(meta):
+    """Burst id of an L2_CSLC_S1 dataset, whichever producer wrote it.
+
+    Catalog-ingest datasets carry it at the top level of the metadata; PGE-produced
+    datasets published before the burst id was promoted carry it only on each of
+    their published files.
+    """
+    if meta.get("burst_id"):
+        return meta["burst_id"]
+    for entry in _file_entries(meta):
+        if entry.get("burst_id"):
+            return entry["burst_id"]
+    return None
+
+
+def cslc_polarization(meta):
+    """Polarization of an L2_CSLC_S1 dataset, or None when it cannot be determined."""
+    if meta.get("pol"):
+        return meta["pol"]
+    for entry in _file_entries(meta):
+        if entry.get("pol"):
+            return entry["pol"]
+    return None
+
+
+def cslc_h5_path(meta):
+    """The .h5 product path of an L2_CSLC_S1 dataset.
+
+    Catalog-ingest datasets list only the DAAC .h5; PGE-produced datasets list every
+    published file (the .h5, a browse .png, the .iso.xml) in no guaranteed order, so the
+    product is selected by suffix.
+    """
+    paths = meta.get("product_s3_paths") or []
+    for path in paths:
+        if path.endswith(CSLC_H5_SUFFIX):
+            return path
+    return ""
+
 
 class DispS1CycleEvaluator:
     """Evaluates burst completeness for a single CSLC acquisition cycle."""
@@ -260,27 +311,45 @@ class DispS1CycleEvaluator:
     def _query_cslcs_for_cycle(self, frame_id, expected_burst_ids, sensing_date):
         """Query ES for all L2_CSLC_S1 matching burst_ids at a sensing_date.
 
+        Matches both the catalog-ingest and the PGE-produced dataset shapes, keeps
+        VV products only, and records each dataset's .h5 product path.
+
         Returns (found_burst_ids, cslc_product_paths).
         """
-        # Build ES query: find all L2_CSLC_S1 for these burst_ids at this sensing_date
-        # sensing_date is YYYYMMDD; match on metadata.burst_id and starttime date range
+        # Two producers publish L2_CSLC_S1 datasets. Catalog ingest puts the burst id at
+        # metadata.burst_id and the acquisition time in the dataset starttime. The CSLC
+        # PGE carries both on each published file (metadata.Files[*].burst_id and
+        # .acquisition_ts); newer PGE datasets also carry the top-level fields, older ones
+        # do not. Match either shape so every published CSLC counts toward coverage.
+        # sensing_date is YYYYMMDD.
+        burst_ids = list(expected_burst_ids)
         date_str = f"{sensing_date[:4]}-{sensing_date[4:6]}-{sensing_date[6:]}"
+        sensing_day = {"gte": f"{date_str}T00:00:00", "lt": f"{date_str}T23:59:59"}
         body = {
             "query": {
                 "bool": {
                     "must": [
                         {"term": {"dataset_type.keyword": "L2_CSLC_S1"}},
-                        {"terms": {"metadata.burst_id.keyword": list(expected_burst_ids)}},
+                        {"bool": {
+                            "should": [
+                                {"terms": {"metadata.burst_id.keyword": burst_ids}},
+                                {"terms": {"metadata.Files.burst_id.keyword": burst_ids}},
+                            ],
+                            "minimum_should_match": 1,
+                        }},
                     ],
                     "filter": [
-                        {"range": {"starttime": {
-                            "gte": f"{date_str}T00:00:00",
-                            "lt": f"{date_str}T23:59:59"
-                        }}}
+                        {"bool": {
+                            "should": [
+                                {"range": {"starttime": sensing_day}},
+                                {"range": {"metadata.Files.acquisition_ts": sensing_day}},
+                            ],
+                            "minimum_should_match": 1,
+                        }},
                     ]
                 }
             },
-            "size": len(expected_burst_ids) * 2,  # safety margin
+            "size": max(CSLC_MIN_QUERY_SIZE, len(burst_ids) * CSLC_HITS_PER_BURST),
         }
 
         results = backoff_wrapper(
@@ -293,17 +362,30 @@ class DispS1CycleEvaluator:
         cslc_product_paths = []
 
         if results:
+            if len(results) >= body["size"]:
+                logger.warning(
+                    f"CSLC query for frame {frame_id} on {sensing_date} returned {len(results)} "
+                    f"documents, the size limit; coverage may be understated"
+                )
             for hit in results:
                 source = hit.get("_source", {})
                 meta = source.get("metadata", {})
-                burst_id = meta.get("burst_id")
+                # DISP-S1 stacks are single-polarization VV, the same rule catalog ingest
+                # applies. A dataset whose polarization cannot be read is kept.
+                polarization = cslc_polarization(meta)
+                if polarization and polarization != DISP_S1_POLARIZATION:
+                    continue
+                burst_id = cslc_burst_id(meta)
                 if burst_id and burst_id in expected_burst_ids:
+                    # The S3 path to the .h5 file (not the HySDS dataset dir URL). A burst
+                    # counts as found only when its product file is known.
+                    s3_url = cslc_h5_path(meta)
+                    if not s3_url:
+                        logger.warning(f"No .h5 product path on {hit.get('_id')}; not counted")
+                        continue
                     if burst_id not in found_burst_ids:
                         found_burst_ids.append(burst_id)
-                    # Get the ASF S3 path to the .h5 file (not the HySDS dataset dir URL)
-                    product_s3_paths = meta.get("product_s3_paths", [])
-                    s3_url = product_s3_paths[0] if product_s3_paths else ""
-                    if s3_url and s3_url not in cslc_product_paths:
+                    if s3_url not in cslc_product_paths:
                         cslc_product_paths.append(s3_url)
 
         # found_burst_ids is deduplicated by burst, but the paths were only

--- a/docker/job-spec.json.cslc_catalog_ingest
+++ b/docker/job-spec.json.cslc_catalog_ingest
@@ -9,7 +9,7 @@
     "$HOST_VERDI_HOME/.aws": "/home/ops/.aws",
     "$HOST_VERDI_HOME/verdi/etc/settings.yaml": "/home/ops/verdi/ops/opera-pcm/conf/settings.yaml"
   },
-  "recommended-queues": ["opera-job_worker-cslc_catalog_ingest"],
+  "recommended-queues": ["opera-job_worker-cslc_data_download"],
   "post": ["hysds.triage.triage"],
   "params": [
     {

--- a/opera_chimera/precondition_functions.py
+++ b/opera_chimera/precondition_functions.py
@@ -684,7 +684,15 @@ class OperaPreConditionFunctions(PreConditionFunctions):
                                 "bool": {
                                     "must": [
                                         {"term": {"dataset_type.keyword": "L2_CSLC_S1_STATIC"}},
-                                        {"terms": {"metadata.burst_id.keyword": list(burst_ids_seen)}},
+                                        # Older PGE-produced static layers carry the burst
+                                        # id only on each published file.
+                                        {"bool": {
+                                            "should": [
+                                                {"terms": {"metadata.burst_id.keyword": list(burst_ids_seen)}},
+                                                {"terms": {"metadata.Files.burst_id.keyword": list(burst_ids_seen)}},
+                                            ],
+                                            "minimum_should_match": 1,
+                                        }},
                                     ]
                                 }
                             },

--- a/product2dataset/product2dataset.py
+++ b/product2dataset/product2dataset.py
@@ -133,6 +133,13 @@ def convert(
         dataset_met_json["FileName"] = dataset_id
         dataset_met_json["id"] = dataset_id
 
+        # Filename-derived fields that select a CSLC by burst and sensing time belong at
+        # the top level, where catalog-ingest and compressed-CSLC datasets carry them.
+        if pge_name == "L2_CSLC_S1":
+            promote_file_metadata(dataset_met_json, CSLC_PROMOTED_KEYS)
+        elif pge_name == "L2_CSLC_S1_STATIC":
+            promote_file_metadata(dataset_met_json, CSLC_STATIC_PROMOTED_KEYS)
+
         with open(PurePath(work_dir, "_job.json")) as fp:
             job_json_dict = json.load(fp)
 
@@ -539,6 +546,52 @@ def decorate_compressed_cslc(dataset_met_json):
     ccslc_file = dataset_met_json["Files"][0] # There should only be one file in the dataset, so we can just grab the first one
     dataset_met_json["burst_id"] = ccslc_file["burst_id"]
     dataset_met_json["ccslc_m_index"] = build_ccslc_m_index(ccslc_file["burst_id"], str(dataset_met_json["acquisition_cycle"]))
+
+
+# Filename-derived fields the L2_CSLC_S1 and L2_CSLC_S1_STATIC patterns capture for every
+# published file of a dataset. They are identical across the files of one dataset, and the
+# consumers that select CSLCs by burst and sensing time (the DISP-S1 cycle evaluator, the
+# superseded-granule purge, the static-layer lookup) read them at the top level of the
+# dataset metadata.
+# The product version is not listed: the extractor records it as dataset_version, which the
+# merge already carries at the top level.
+CSLC_PROMOTED_KEYS = ("burst_id", "acquisition_ts", "sensor", "pol")
+CSLC_STATIC_PROMOTED_KEYS = ("burst_id", "validity_ts", "sensor")
+
+
+def promote_file_metadata(dataset_met_json, keys):
+    """Copy per-file metadata that is constant across a dataset's files to the top level.
+
+    A key already present at the top level is left alone. A key whose value differs
+    between files is not promoted, so a wrong value is never guessed.
+
+    :param dataset_met_json: merged dataset metadata carrying a "Files" list.
+    :param keys: the per-file keys to promote.
+    :return: the keys that were promoted.
+    """
+    files = dataset_met_json.get("Files") or []
+    promoted = []
+
+    for key in keys:
+        if key in dataset_met_json:
+            continue
+
+        values = [file_met[key] for file_met in files if key in file_met]
+
+        if not values:
+            continue
+
+        if any(value != values[0] for value in values[1:]):
+            logger.warning(f"Not promoting {key} to the dataset metadata: its files disagree ({values})")
+            continue
+
+        dataset_met_json[key] = values[0]
+        promoted.append(key)
+
+    if promoted:
+        logger.info(f"Promoted per-file metadata to the dataset metadata: {promoted}")
+
+    return promoted
 
 def main():
     """

--- a/tests/unit/data_subscriber/cslc/test_disp_s1_cycle_evaluator.py
+++ b/tests/unit/data_subscriber/cslc/test_disp_s1_cycle_evaluator.py
@@ -644,3 +644,199 @@ class DbExcludedStampTest(unittest.TestCase):
     def test_no_assessed_range_stamps_nothing(self):
         kwargs = self._run(self.EXCLUDED, assessed_end=None)
         self.assertFalse(kwargs["db_excluded"])
+
+
+def _acquisition_iso(sensing_ts):
+    """'20240801T010203Z' -> '2024-08-01T01:02:03.000000Z', the extractor's format."""
+    return (f"{sensing_ts[0:4]}-{sensing_ts[4:6]}-{sensing_ts[6:8]}T"
+            f"{sensing_ts[9:11]}:{sensing_ts[11:13]}:{sensing_ts[13:15]}.000000Z")
+
+
+def _pge_hit(burst_id, sensing_ts="20240801T010203Z", pol="VV", h5_position=0,
+             promoted=False, with_h5=True):
+    """An L2_CSLC_S1 document as a CSLC-S1 PGE job publishes it.
+
+    Every published file (.h5, browse .png, .iso.xml) is listed, and the filename
+    metadata sits on each file entry. ``promoted`` adds the top-level copies that
+    product2dataset now writes; without it the document has the older shape.
+    """
+    stem = f"OPERA_L2_CSLC-S1_{burst_id}_{sensing_ts}_20260910T212729Z_S1D_{pol}_v1.1"
+    prefix = f"s3://opera-dev-rs-fwd-test/products/CSLC_S1/2024/08/01/{stem}/{stem}"
+    paths = [f"{prefix}_BROWSE.png", f"{prefix}.iso.xml"]
+    if with_h5:
+        paths.insert(h5_position, f"{prefix}.h5")
+    acquisition_ts = _acquisition_iso(sensing_ts)
+    files = [{"FileName": path.rsplit("/", 1)[1], "burst_id": burst_id,
+              "acquisition_ts": acquisition_ts, "sensor": "S1D", "pol": pol}
+             for path in paths]
+    metadata = {"Files": files, "product_s3_paths": paths, "tags": ["PGE"]}
+    if promoted:
+        metadata.update(burst_id=burst_id, acquisition_ts=acquisition_ts, sensor="S1D", pol=pol)
+    return {"_id": stem, "_source": {"dataset_type": "L2_CSLC_S1", "metadata": metadata}}
+
+
+def _catalog_hit(burst_id, sensing_ts="20240801T010203Z"):
+    """An L2_CSLC_S1 document as cslc_catalog_ingest publishes it."""
+    stem = f"OPERA_L2_CSLC-S1_{burst_id}_{sensing_ts}_20240710T080810Z_S1A_VV_v1.1"
+    return {"_id": stem, "_source": {
+        "dataset_type": "L2_CSLC_S1",
+        "starttime": _acquisition_iso(sensing_ts)[:19],
+        "metadata": {
+            "burst_id": burst_id,
+            "catalog_ingest": True,
+            "product_s3_paths": [
+                f"s3://asf-cumulus-prod-opera-products/OPERA_L2_CSLC-S1/{stem}/{stem}.h5"],
+        },
+    }}
+
+
+def _values_under(node, key):
+    """Every value stored under ``key`` anywhere in a nested query body."""
+    found = []
+    if isinstance(node, dict):
+        for k, v in node.items():
+            if k == key:
+                found.append(v)
+            found.extend(_values_under(v, key))
+    elif isinstance(node, list):
+        for v in node:
+            found.extend(_values_under(v, key))
+    return found
+
+
+class TestQueryCslcsForCycleShapes(unittest.TestCase):
+    """Coverage counts CSLCs from both producers: catalog ingest and the CSLC-S1 PGE."""
+
+    def setUp(self):
+        self.burst_ids = ["T074-157286-IW3", "T074-157287-IW1", "T074-157288-IW2"]
+        self.frame_to_bursts = defaultdict(lambda: None)
+        self.frame_to_bursts[7098] = _FakeHistBursts(7098, self.burst_ids, [0, 6, 12])
+        self.es_conn = MagicMock()
+        self.evaluator = _make_evaluator(
+            self.frame_to_bursts, {b: [7098] for b in self.burst_ids}, self.es_conn)
+
+    def _query(self, hits):
+        self.es_conn.query.return_value = hits
+        return self.evaluator._query_cslcs_for_cycle(7098, self.burst_ids, "20240801")
+
+    def test_query_matches_both_metadata_shapes(self):
+        self._query([])
+
+        kwargs = self.es_conn.query.call_args.kwargs
+        body = kwargs["body"]
+        self.assertEqual(kwargs["index"], "grq_*_l2_cslc_s1-*")
+        terms_fields = {field for clause in _values_under(body, "terms") for field in clause}
+        self.assertEqual(terms_fields,
+                         {"metadata.burst_id.keyword", "metadata.Files.burst_id.keyword"})
+        for clause in _values_under(body, "terms"):
+            self.assertEqual(sorted(next(iter(clause.values()))), sorted(self.burst_ids))
+        range_fields = {field for clause in _values_under(body, "range") for field in clause}
+        self.assertEqual(range_fields, {"starttime", "metadata.Files.acquisition_ts"})
+        for clause in _values_under(body, "range"):
+            self.assertEqual(next(iter(clause.values())),
+                             {"gte": "2024-08-01T00:00:00", "lt": "2024-08-01T23:59:59"})
+        # Each alternative is an OR of exactly the two shapes.
+        self.assertEqual([len(s) for s in _values_under(body, "should")], [2, 2])
+        self.assertEqual(_values_under(body, "minimum_should_match"), [1, 1])
+        self.assertGreaterEqual(body["size"], 200)
+
+    def test_pge_shaped_documents_count_and_select_the_h5(self):
+        hits = [_pge_hit(b, h5_position=i) for i, b in enumerate(self.burst_ids)]
+
+        found, paths = self._query(hits)
+
+        self.assertEqual(sorted(found), sorted(self.burst_ids))
+        self.assertEqual(len(paths), 3)
+        self.assertTrue(all(p.endswith(".h5") for p in paths), paths)
+
+    def test_promoted_pge_documents_count(self):
+        found, paths = self._query([_pge_hit(b, promoted=True) for b in self.burst_ids])
+
+        self.assertEqual(sorted(found), sorted(self.burst_ids))
+        self.assertTrue(all(p.endswith(".h5") for p in paths), paths)
+
+    def test_catalog_ingest_documents_still_count(self):
+        found, paths = self._query([_catalog_hit(b) for b in self.burst_ids])
+
+        self.assertEqual(sorted(found), sorted(self.burst_ids))
+        self.assertTrue(all(p.startswith("s3://asf-cumulus-prod-opera-products/") for p in paths))
+
+    def test_a_burst_published_by_both_producers_counts_once(self):
+        burst_id = self.burst_ids[0]
+
+        found, paths = self._query([_pge_hit(burst_id), _catalog_hit(burst_id)])
+
+        self.assertEqual(found, [burst_id])
+        # Choosing between the two granules is latest_cslc_per_burst's job.
+        self.assertEqual(len(paths), 2)
+
+    def test_non_vv_documents_do_not_count(self):
+        found, paths = self._query([
+            _pge_hit(self.burst_ids[0], pol="VH"),
+            _pge_hit(self.burst_ids[1], pol="HH", promoted=True),
+        ])
+
+        self.assertEqual(found, [])
+        self.assertEqual(paths, [])
+
+    def test_bursts_outside_the_frame_do_not_count(self):
+        found, paths = self._query([_pge_hit("T001-000001-IW1")])
+
+        self.assertEqual(found, [])
+        self.assertEqual(paths, [])
+
+    def test_a_document_without_an_h5_product_does_not_count(self):
+        found, paths = self._query([_pge_hit(self.burst_ids[0], with_h5=False)])
+
+        self.assertEqual(found, [])
+        self.assertEqual(paths, [])
+
+    def test_reaching_the_size_limit_is_logged(self):
+        with self.assertLogs(evaluator_mod.logger, level="WARNING") as logs:
+            self._query([_catalog_hit(self.burst_ids[0])] * 200)
+
+        self.assertTrue(any("size limit" in line for line in logs.output), logs.output)
+
+
+class TestCycleEvaluatorPgeShapedInput(unittest.TestCase):
+    """A frame whose bursts were produced by the local CSLC-S1 PGE reaches full coverage."""
+
+    def setUp(self):
+        self.orig_dir = os.getcwd()
+        self.test_dir = tempfile.mkdtemp()
+        os.chdir(self.test_dir)
+
+    def tearDown(self):
+        os.chdir(self.orig_dir)
+        shutil.rmtree(self.test_dir)
+
+    def test_creates_complete_csc_from_pge_shaped_documents(self):
+        import datetime
+        burst_ids = ["T074-157286-IW3", "T074-157287-IW1", "T074-157288-IW2"]
+        frame_to_bursts = defaultdict(lambda: None)
+        frame_to_bursts[7098] = _FakeHistBursts(7098, burst_ids, [0, 6, 12])
+        _mock_cslc_utils.parse_cslc_native_id.return_value = (
+            burst_ids[0], datetime.datetime(2024, 8, 1, 1, 2, 3), {7098: 0}, [7098]
+        )
+        es_conn = MagicMock()
+        # The older PGE shape: no top-level burst id, no starttime, h5 listed last.
+        es_conn.query.return_value = [_pge_hit(b, h5_position=2) for b in burst_ids]
+
+        with patch.object(evaluator_mod, "find_csc", return_value=({}, None)):
+            evaluator = _make_evaluator(frame_to_bursts, {b: [7098] for b in burst_ids}, es_conn)
+            evaluator.evaluate(
+                input_dataset_id=_pge_hit(burst_ids[0])["_id"],
+                metadata={},
+                dataset_type="L2_CSLC_S1",
+            )
+
+        csc_dir = "cslc_s1-cycle-f7098-20240801-state-config"
+        with open(os.path.join(csc_dir, f"{csc_dir}.met.json")) as f:
+            met = json.load(f)
+        self.assertTrue(met[c.IS_COMPLETE])
+        self.assertEqual(met[c.COVERAGE_ACTUAL], 3)
+        self.assertEqual(met[c.FOUND_BURST_IDS], sorted(burst_ids))
+        self.assertEqual(len(met[c.CSLC_PRODUCT_PATHS]), 3)
+        for path in met[c.CSLC_PRODUCT_PATHS]:
+            self.assertTrue(path.startswith("s3://opera-dev-rs-fwd-test/products/CSLC_S1/"), path)
+            self.assertTrue(path.endswith(".h5"), path)

--- a/tests/unit/extractor/test_extract.py
+++ b/tests/unit/extractor/test_extract.py
@@ -135,3 +135,19 @@ def test_create_dataset_json__default_version():
 
     # ASSERT
     assert dataset_json["version"] == "1"
+
+
+def test_create_dataset_json__dataset_keys_set_starttime_and_endtime():
+    # ARRANGE
+    product_metadata = {"dataset_version": "v1.1", "acquisition_ts": "2026-09-09T22:20:12.000000Z"}
+
+    # ACT
+    dataset_json = create_dataset_json(
+        product_metadata,
+        ds_met={"starttime": "acquisition_ts", "endtime": "acquisition_ts"},
+        alt_ds_met={},
+    )
+
+    # ASSERT
+    assert dataset_json["starttime"] == "2026-09-09T22:20:12.000000Z"
+    assert dataset_json["endtime"] == "2026-09-09T22:20:12.000000Z"

--- a/tests/unit/product2dataset/test_cslc_metadata_promotion.py
+++ b/tests/unit/product2dataset/test_cslc_metadata_promotion.py
@@ -1,0 +1,151 @@
+"""CSLC filename metadata is promoted to the top level of the dataset metadata.
+
+The DISP-S1 cycle evaluator and the other consumers that select CSLC datasets by burst
+and sensing time read the burst id at the top level of the dataset metadata and the
+acquisition time from the dataset starttime. The component tests below publish
+PGE-shaped datasets offline through the real extractor, settings.yaml and
+pge_outputs.yaml, which is the path a CSLC-S1 PGE job takes on a cluster.
+"""
+import json
+import shutil
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+try:
+    import hysds.utils  # noqa: F401
+    _HYSDS_STUBS = {}
+except ImportError:
+    # util.checksum_util imports hysds, which is only installed on cluster images.
+    _HYSDS_STUBS = {"hysds": MagicMock(), "hysds.utils": MagicMock()}
+
+with patch.dict(sys.modules, _HYSDS_STUBS):
+    from product2dataset import product2dataset
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+CSLC_ID = "OPERA_L2_CSLC-S1_T091-193607-IW1_20260909T222012Z_20260910T212729Z_S1D_VV_v1.1"
+CSLC_STATIC_ID = "OPERA_L2_CSLC-S1-STATIC_T091-193607-IW1_20140101_S1D_v1.0"
+AUX_STEM = "OPERA_L2_CSLC-S1_20260910T212729Z_S1D_VV_v1.1"
+ACQUISITION_TS = "2026-09-09T22:20:12.000000Z"
+
+
+class TestPromoteFileMetadata:
+
+    def test_lifts_keys_constant_across_files(self):
+        files = [{"FileName": f"f{i}", "burst_id": "T091-193607-IW1", "pol": "VV"} for i in range(3)]
+        met = {"Files": files}
+
+        promoted = product2dataset.promote_file_metadata(met, ("burst_id", "pol", "sensor"))
+
+        assert promoted == ["burst_id", "pol"]
+        assert met["burst_id"] == "T091-193607-IW1"
+        assert met["pol"] == "VV"
+        assert "sensor" not in met
+        assert met["Files"] == files
+
+    def test_keeps_an_existing_top_level_value(self):
+        met = {"burst_id": "T001-000001-IW1", "Files": [{"burst_id": "T091-193607-IW1"}]}
+
+        promoted = product2dataset.promote_file_metadata(met, ("burst_id",))
+
+        assert promoted == []
+        assert met["burst_id"] == "T001-000001-IW1"
+
+    def test_does_not_guess_when_files_disagree(self):
+        met = {"Files": [{"burst_id": "T091-193607-IW1"}, {"burst_id": "T091-193607-IW2"}]}
+
+        promoted = product2dataset.promote_file_metadata(met, ("burst_id",))
+
+        assert promoted == []
+        assert "burst_id" not in met
+
+    def test_tolerates_a_dataset_without_files(self):
+        met = {}
+
+        assert product2dataset.promote_file_metadata(met, ("burst_id",)) == []
+        assert met == {}
+
+
+def _job_json(wf_name):
+    return {
+        "params": {"wf_name": wf_name},
+        "context": {
+            "container_specification": {"version": "v9.9.9"},
+            "job_specification": {
+                "dependency_images": [{"container_image_name": "opera_pge/cslc_s1:2.1.4"}]
+            },
+        },
+    }
+
+
+def _publish(work_dir: Path, pge_name, primary_files, mocker):
+    """Run product2dataset.convert over a fake PGE output directory, as the wrapper does."""
+    product_dir = work_dir / "pge_output_dir"
+    product_dir.mkdir()
+    for name in primary_files:
+        (product_dir / name).write_bytes(b"not a real product")
+    (product_dir / f"{AUX_STEM}.log").write_text("log")
+    (product_dir / f"{AUX_STEM}.catalog.json").write_text(
+        json.dumps({"PGE_Version": "2.1.4", "SAS_Version": "0.5.5"}))
+
+    (work_dir / "_job.json").write_text(json.dumps(_job_json(pge_name)))
+    shutil.copy(REPO_ROOT / "conf" / "sds" / "files" / "datasets.json", work_dir / "datasets.json")
+
+    # Checksums call into hysds; they are not what is under test.
+    mocker.patch.object(product2dataset, "create_dataset_checksums")
+
+    extra_met = {
+        "lineage": ["/work/input/S1D_IW_SLC.zip", "/work/input/S1D_OPER_AUX_RESORB.EOF"],
+        "runconfig": {
+            "localize": ["s3://bucket/inputs/S1D_OPER_AUX_RESORB.EOF"],
+            "input_file_group": {"input_file_paths": ["/work/input/S1D_IW_SLC.zip"]},
+        },
+    }
+    created = product2dataset.convert(
+        str(work_dir), str(product_dir), pge_name, extra_met=extra_met,
+        product_metadata={"id": "S1D_IW_SLC__1SDV_20260909T221948_20260909T222015_004507_0085FB_16EE"},
+    )
+
+    assert len(created) == 1
+    dataset_dir = Path(created[0])
+    dataset_id = dataset_dir.name
+    met = json.loads((dataset_dir / f"{dataset_id}.met.json").read_text())
+    dataset = json.loads((dataset_dir / f"{dataset_id}.dataset.json").read_text())
+    return dataset_id, met, dataset
+
+
+class TestConvertPromotesCslcMetadata:
+
+    def test_l2_cslc_s1_dataset_carries_burst_metadata_and_starttime(self, tmp_path, mocker):
+        dataset_id, met, dataset = _publish(
+            tmp_path, "L2_CSLC_S1",
+            [f"{CSLC_ID}.h5", f"{CSLC_ID}_BROWSE.png", f"{CSLC_ID}.iso.xml"], mocker)
+
+        assert dataset_id == CSLC_ID
+        assert met["burst_id"] == "T091-193607-IW1"
+        assert met["acquisition_ts"] == ACQUISITION_TS
+        assert met["sensor"] == "S1D"
+        assert met["pol"] == "VV"
+        assert met["dataset_version"] == "v1.1"
+        # The per-file entries are untouched and still carry the same fields.
+        assert len(met["Files"]) == 3
+        assert {f["burst_id"] for f in met["Files"]} == {"T091-193607-IW1"}
+        assert all(path.startswith("s3://") for path in met["product_s3_paths"])
+        assert dataset["starttime"] == ACQUISITION_TS
+        assert dataset["endtime"] == ACQUISITION_TS
+
+    def test_l2_cslc_s1_static_dataset_carries_burst_metadata(self, tmp_path, mocker):
+        dataset_id, met, dataset = _publish(
+            tmp_path, "L2_CSLC_S1_STATIC",
+            [f"{CSLC_STATIC_ID}.h5", f"{CSLC_STATIC_ID}.iso.xml"], mocker)
+
+        assert dataset_id == CSLC_STATIC_ID
+        assert met["burst_id"] == "T091-193607-IW1"
+        assert met["validity_ts"] == "2014-01-01T00:00:00.000000Z"
+        assert met["sensor"] == "S1D"
+        # Static layers are selected by burst only; they get no dataset time range.
+        assert "starttime" not in dataset
+        assert "acquisition_ts" not in met

--- a/tests/unit/test_cslc_settings_dataset_keys.py
+++ b/tests/unit/test_cslc_settings_dataset_keys.py
@@ -1,0 +1,34 @@
+"""Pin the L2_CSLC_S1 dataset time range to the burst acquisition time.
+
+The DISP-S1 cycle evaluator selects CSLCs of a sensing date through the dataset
+starttime. A dataset created from a CSLC-S1 PGE product only has one if the product
+type's Dataset_Keys names it, so a silent revert of this setting would leave locally
+produced CSLCs selectable only through the per-file fallback.
+"""
+import os
+
+import pytest
+import yaml
+
+import util.conf_util  # noqa: F401  registers the !!python/regexp YAML constructor
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+@pytest.fixture(scope="module")
+def product_types():
+    with open(os.path.join(REPO_ROOT, "conf", "settings.yaml")) as fh:
+        return yaml.safe_load(fh)["PRODUCT_TYPES"]
+
+
+def test_l2_cslc_s1_dataset_time_range_is_the_acquisition_time(product_types):
+    assert product_types["L2_CSLC_S1"]["Dataset_Keys"] == {
+        "starttime": "acquisition_ts",
+        "endtime": "acquisition_ts",
+    }
+
+
+def test_l2_cslc_s1_pattern_captures_the_acquisition_time(product_types):
+    groups = product_types["L2_CSLC_S1"]["Pattern"].groupindex
+    assert "acquisition_ts" in groups
+    assert "acquisition_ts" in product_types["L2_CSLC_S1"]["Configuration"]["Date_Time_Keys"]

--- a/tests/unit/test_job_spec_queues.py
+++ b/tests/unit/test_job_spec_queues.py
@@ -1,0 +1,50 @@
+"""Every job spec recommends a queue that the cluster terraform deploys workers for.
+
+A job submitted with default arguments lands on the first recommended queue. If no
+worker group listens there, the job is accepted and then waits forever with nothing in
+any log -- which is how cslc_catalog_ingest jobs behaved until the job spec was pointed
+at the CSLC download workers.
+"""
+import glob
+import json
+import os
+import re
+
+import pytest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+QUEUES_TF = os.path.join(REPO_ROOT, "cluster_provisioning", "modules", "common", "variables.tf")
+
+# Recommended queues the common module deliberately does not deploy.
+NOT_DEPLOYED_BY_COMMON = {
+    # Development-only DIST-S1 state-config test job; no venue runs workers for it.
+    "opera-job_worker-dist_s1_state_config",
+}
+
+
+def _deployed_queues():
+    with open(QUEUES_TF) as f:
+        return set(re.findall(r'"name"\s*=\s*"([^"]+)"', f.read()))
+
+
+def _job_specs():
+    return sorted(glob.glob(os.path.join(REPO_ROOT, "docker", "job-spec.json.*")))
+
+
+@pytest.mark.parametrize("job_spec", _job_specs(), ids=os.path.basename)
+def test_recommended_queues_are_deployed(job_spec):
+    with open(job_spec) as f:
+        recommended = json.load(f).get("recommended-queues", [])
+    deployed = _deployed_queues()
+
+    for queue in recommended:
+        if queue in NOT_DEPLOYED_BY_COMMON:
+            continue
+        assert queue in deployed, (
+            f"{os.path.basename(job_spec)} recommends {queue}, "
+            f"which no worker group in modules/common/variables.tf deploys")
+
+
+def test_cslc_catalog_ingest_runs_on_the_cslc_download_workers():
+    with open(os.path.join(REPO_ROOT, "docker", "job-spec.json.cslc_catalog_ingest")) as f:
+        assert json.load(f)["recommended-queues"] == ["opera-job_worker-cslc_data_download"]

--- a/tests/unit/tools/test_check_disp_s1_pge_cslc_feed.py
+++ b/tests/unit/tools/test_check_disp_s1_pge_cslc_feed.py
@@ -1,0 +1,125 @@
+"""The DISP-S1 smoke test's PGE-fed forward stage judges each step correctly.
+
+The stage can only run on a cluster; these tests cover the decisions it makes about the
+documents it reads back.
+"""
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+CHECKER = (Path(__file__).parents[3] / "conf" / "sds" / "files" / "test"
+           / "check_disp_s1_pge_cslc_feed.py")
+
+
+def _load_checker():
+    commons = types.ModuleType("opera_commons")
+    es = types.ModuleType("opera_commons.es_connection")
+    es.get_grq_es = lambda *a, **k: None
+    es.get_mozart_es = lambda *a, **k: None
+    commons.es_connection = es
+    with mock.patch.dict(sys.modules, {"opera_commons": commons, "opera_commons.es_connection": es}):
+        spec = importlib.util.spec_from_file_location("_check_disp_s1_pge_cslc_feed", CHECKER)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+    return module
+
+
+feed = _load_checker()
+
+BURSTS = ["T117-249921-IW3", "T117-249922-IW3"]
+DATE = "20190613"
+BUCKET = "s3://opera-dev-rs-fwd-gmanipon/products/CSLC_S1/2019/06/13"
+
+
+def _cslc(burst_id, processed="20260911T010203Z", pol="VV", tags=("PGE",), promoted=True,
+          sensing=f"{DATE}T172935Z"):
+    stem = f"OPERA_L2_CSLC-S1_{burst_id}_{sensing}_{processed}_S1A_{pol}_v1.1"
+    meta = {"tags": list(tags),
+            "product_s3_paths": [f"{BUCKET}/{stem}/{stem}_BROWSE.png", f"{BUCKET}/{stem}/{stem}.h5"]}
+    source = {"metadata": meta}
+    if promoted:
+        meta["burst_id"] = burst_id
+        source["starttime"] = "2019-06-13T17:29:35.000000Z"
+    return {"_id": stem, "_source": source}
+
+
+class SelectPgeCslcsTest(unittest.TestCase):
+
+    def test_keeps_the_newest_pge_vv_product_per_burst(self):
+        hits = [_cslc(BURSTS[0], processed="20260911T010203Z"),
+                _cslc(BURSTS[0], processed="20260912T010203Z"),
+                _cslc(BURSTS[1]),
+                _cslc(BURSTS[1], pol="VH", processed="20260913T000000Z"),
+                _cslc(BURSTS[1], tags=(), processed="20260914T000000Z"),
+                _cslc("T001-000001-IW1"),
+                _cslc(BURSTS[0], sensing="20190601T172935Z", processed="20260915T000000Z")]
+
+        selected = feed.select_pge_cslcs(hits, BURSTS, DATE)
+
+        self.assertEqual(sorted(selected), BURSTS)
+        self.assertIn("20260912T010203Z", selected[BURSTS[0]]["_id"])
+        self.assertIn("20260911T010203Z", selected[BURSTS[1]]["_id"])
+
+
+class CheckStepsTest(unittest.TestCase):
+
+    def test_cslcs_pass_when_every_burst_carries_the_promoted_fields(self):
+        selected = {b: _cslc(b) for b in BURSTS}
+
+        self.assertEqual(feed.check_cslcs(selected, BURSTS), [])
+
+    def test_cslcs_fail_on_a_missing_burst_or_the_old_shape(self):
+        errors = feed.check_cslcs({BURSTS[0]: _cslc(BURSTS[0], promoted=False)}, BURSTS)
+
+        self.assertEqual(len(errors), 3)
+        self.assertTrue(any("no PGE-produced CSLC" in e for e in errors))
+        self.assertTrue(any("metadata.burst_id" in e for e in errors))
+        self.assertTrue(any("starttime" in e for e in errors))
+
+    def test_csc_must_record_exactly_the_pge_products(self):
+        paths = [feed.h5_path(_cslc(b)["_source"]["metadata"]) for b in BURSTS]
+
+        self.assertEqual(feed.check_csc({"is_complete": True, "cslc_product_paths": paths}, paths), [])
+        daac = paths[:1] + ["s3://asf-cumulus-prod-opera-products/OPERA_L2_CSLC-S1/x/x.h5"]
+        self.assertEqual(len(feed.check_csc({"is_complete": True, "cslc_product_paths": daac}, paths)), 1)
+        self.assertEqual(len(feed.check_csc({"is_complete": False, "cslc_product_paths": paths}, paths)), 1)
+
+    def test_ksc_must_be_complete_final_and_list_the_pge_products(self):
+        paths = [feed.h5_path(_cslc(b)["_source"]["metadata"]) for b in BURSTS]
+        good = {"is_complete": True, "compressed_cslc_final": True,
+                "product_paths": {"L2_CSLC_S1": paths + ["s3://other/older.h5"]}}
+
+        self.assertEqual(feed.check_ksc(good, paths), [])
+        self.assertEqual(len(feed.check_ksc({**good, "compressed_cslc_final": False}, paths)), 1)
+        self.assertEqual(len(feed.check_ksc({**good, "product_paths": {"L2_CSLC_S1": paths[:1]}}, paths)), 1)
+
+    def test_find_l3_matches_the_secondary_date_only(self):
+        hits = [{"_id": "OPERA_L3_DISP-S1_IW_F31241_VV_20171021T172929Z_20190613T172935Z_v1.0_20260911T100000Z"},
+                {"_id": "OPERA_L3_DISP-S1_IW_F31241_VV_20190613T172935Z_20190625T172936Z_v1.0_20260911T110000Z"},
+                {"_id": "OPERA_L3_DISP-S1_IW_F31242_VV_20171021T172929Z_20190613T172935Z_v1.0_20260911T100000Z"}]
+
+        found = feed.find_l3(hits, 31241, DATE)
+
+        self.assertEqual([h["_id"] for h in found], [hits[0]["_id"]])
+
+    def test_lineage_uses(self):
+        ids = [_cslc(b)["_id"] for b in BURSTS]
+        l3 = {"_source": {"metadata": {"lineage": [f"{ids[0]}/{ids[0]}.h5", "OPERA_L2_COMPRESSED-CSLC-S1_x.h5"]}}}
+
+        self.assertEqual(feed.lineage_uses(l3, ids), ids[:1])
+
+    def test_slc_query_params_run_in_reprocessing_mode_over_a_temporal_window(self):
+        params = feed.build_slc_query_params("2019-06-13T17:29:30Z", "2019-06-13T17:29:35Z", "6.0.6")
+
+        self.assertEqual(params["processing_mode"], "--processing-mode=reprocessing")
+        self.assertEqual(params["use_temporal"], "--use-temporal")
+        self.assertEqual(params["start_datetime"], "--start-date=2019-06-13T17:29:30Z")
+        self.assertEqual(params["end_datetime"], "--end-date=2019-06-13T17:29:35Z")
+        self.assertEqual(params["download_job_release"], "--release-version=6.0.6")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/tools/test_cslc_forward_tools.py
+++ b/tests/unit/tools/test_cslc_forward_tools.py
@@ -1,0 +1,151 @@
+"""Pure parts of the operator tools for CSLC datasets and DISP-S1 cycle state configs.
+
+The tools talk to OpenSearch and Mozart only inside main(); what is tested here is the
+query, script and job-parameter construction they send.
+"""
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+TOOLS = Path(__file__).parents[3] / "tools"
+TEST_DATA = Path(__file__).parents[1] / "data_subscriber" / "test_data"
+
+
+def _load(name):
+    spec = importlib.util.spec_from_file_location(f"_{name}", TOOLS / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+backfill = _load("backfill_cslc_dataset_metadata")
+reevaluate = _load("reevaluate_disp_s1_cscs")
+region_db = _load("check_disp_s1_region_db")
+
+
+class BackfillQueryAndScriptTest(unittest.TestCase):
+
+    def test_only_documents_without_a_top_level_burst_id_are_selected(self):
+        query = backfill.build_query("L2_CSLC_S1")
+
+        self.assertEqual(query["bool"]["must"], [{"term": {"dataset_type.keyword": "L2_CSLC_S1"}}])
+        self.assertEqual(query["bool"]["must_not"], [{"exists": {"field": "metadata.burst_id"}}])
+
+    def test_a_frame_restricts_by_the_per_file_burst_id(self):
+        query = backfill.build_query("L2_CSLC_S1", ["T117-249922-IW3", "T117-249921-IW3"])
+
+        self.assertIn({"terms": {"metadata.Files.burst_id.keyword":
+                                 ["T117-249921-IW3", "T117-249922-IW3"]}},
+                      query["bool"]["must"])
+
+    def test_cslc_script_promotes_the_keys_and_sets_the_time_range(self):
+        script = backfill.build_script("L2_CSLC_S1")
+
+        self.assertEqual(script["lang"], "painless")
+        self.assertEqual(script["params"],
+                         {"keys": ["burst_id", "acquisition_ts", "sensor", "pol"],
+                          "set_time_range": True})
+        # Never overwrites: every write is guarded by an absence check, and an unchanged
+        # document is a noop rather than a reindex.
+        self.assertIn("md.get(key) == null", script["source"])
+        self.assertIn("ctx._source.get('starttime') == null", script["source"])
+        self.assertIn("ctx.op = 'noop'", script["source"])
+
+    def test_static_script_sets_no_time_range(self):
+        script = backfill.build_script("L2_CSLC_S1_STATIC")
+
+        self.assertEqual(script["params"],
+                         {"keys": ["burst_id", "validity_ts", "sensor"], "set_time_range": False})
+
+    def test_keys_match_what_product2dataset_promotes(self):
+        try:
+            import hysds.utils  # noqa: F401
+            stubs = {}
+        except ImportError:
+            stubs = {"hysds": MagicMock(), "hysds.utils": MagicMock()}
+        with patch.dict(sys.modules, stubs):
+            from product2dataset import product2dataset
+
+        self.assertEqual(backfill.PROMOTED_KEYS["L2_CSLC_S1"], list(product2dataset.CSLC_PROMOTED_KEYS))
+        self.assertEqual(backfill.PROMOTED_KEYS["L2_CSLC_S1_STATIC"],
+                         list(product2dataset.CSLC_STATIC_PROMOTED_KEYS))
+
+
+class ReevaluateCscsTest(unittest.TestCase):
+
+    HIT = {
+        "_id": "cslc_s1-cycle-f15422-20260826-state-config",
+        "_source": {
+            "dataset": "cslc_s1-cycle-state-config",
+            "urls": ["http://bucket.s3-website/state-config", "s3://bucket/state-config"],
+            "metadata": {"frame_id": 15422, "sensing_date": "20260826", "is_complete": False},
+        },
+    }
+
+    def test_query_selects_incomplete_cscs(self):
+        query = reevaluate.build_query()
+
+        self.assertEqual(query, {"bool": {"must": [{"term": {"metadata.is_complete": False}}]}})
+
+    def test_query_filters(self):
+        query = reevaluate.build_query(frame_ids=["15422", 42810], since="20260825", region=2)
+
+        must = query["bool"]["must"]
+        self.assertIn({"terms": {"metadata.frame_id": [15422, 42810]}}, must)
+        self.assertIn({"term": {"metadata.region_id": "2"}}, must)
+        self.assertEqual(query["bool"]["filter"],
+                         [{"range": {"metadata.sensing_date": {"gte": "20260825"}}}])
+
+    def test_params_match_the_trigger_rule_wiring(self):
+        params = reevaluate.build_reeval_params(self.HIT)
+
+        self.assertEqual(params, {
+            "product_paths": "s3://bucket/state-config",
+            "product_metadata": {"metadata": self.HIT["_source"]["metadata"]},
+            "dataset_type": "cslc_s1-cycle-state-config",
+            "input_dataset_id": "cslc_s1-cycle-f15422-20260826-state-config",
+        })
+
+    def test_submit_form(self):
+        form = reevaluate.build_submit_form(self.HIT, "6.0.6", "opera-job_worker-evaluator_verdi",
+                                            "20260910T000000Z")
+
+        self.assertEqual(form["type"], "job-disp_s1_cycle_evaluator:6.0.6")
+        self.assertEqual(form["queue"], "opera-job_worker-evaluator_verdi")
+        self.assertEqual(json.loads(form["params"]), reevaluate.build_reeval_params(self.HIT))
+        self.assertEqual(json.loads(form["tags"]), [reevaluate.TAG])
+        self.assertIn(self.HIT["_id"], form["name"])
+
+
+class RegionDbAuditTest(unittest.TestCase):
+
+    def setUp(self):
+        with open(TEST_DATA / "example_region_db.json") as f:
+            regions = json.load(f)
+        self.frame_region_map = {int(frame): region
+                                 for region, frames in regions.items() for frame in frames}
+
+    def test_compare_frame_sets(self):
+        missing, extra = region_db.compare_frame_sets({7098, 31241, "24718"},
+                                                      {**self.frame_region_map, 99999: "4"})
+
+        self.assertEqual(missing, [24718, 31241])
+        self.assertEqual(extra, [99999])
+
+    def test_resolve_frames_marks_unlisted_frames_unknown(self):
+        resolved = region_db.resolve_frames([7098, 31241], self.frame_region_map)
+
+        self.assertEqual(resolved, {7098: "region_a", 31241: "UNKNOWN"})
+
+    def test_region_counts(self):
+        self.assertEqual(region_db.region_counts({1: "4", 2: "4", 3: "3a"}), {"3a": 1, "4": 2})
+
+    def test_parse_frames(self):
+        self.assertEqual(region_db.parse_frames("15422, 42810,"), [15422, 42810])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/README.md
+++ b/tools/README.md
@@ -195,8 +195,8 @@ A phased batch proc looks like a normal DISP-S1 historical one plus the opt-in:
 ```
 
 Forward-phase dates are submitted to the batch proc's `download_job_queue` unless a
-`forward_job_queue` is given: the `cslc_catalog_ingest` job spec recommends a queue of its own, but
-not every cluster deploys workers for it, and a job queued there never runs.
+`forward_job_queue` is given. Submitted on its own, a `cslc_catalog_ingest` job runs on the queue its
+job spec recommends, `opera-job_worker-cslc_data_download`, which every cluster deploys.
 
 `pcm_batch.py create` also **rejects an un-phased batch proc whose k-sets would straddle a phase
 boundary**. Stepping k dates at a time from the start of the series ignores the labels, so a k-set
@@ -294,6 +294,9 @@ how many SCIFLOs are running.
 | `conf/sds/files/test/check_disp_s1_phases.py --frame-id <frame> --k <k>` | Asserts a run actually took the phased path: boundaries at phase-relative positions, no products on `no_run` dates, historical-phase state configs superseded, and **every forward date produced its product**. Counts alone cannot tell a correct phased walk from a regression to the absolute grid — nor from a walk that advanced over its forward dates without submitting anything. |
 | `purge_superseded_cslc_granules.py [--frame-id <frame>]` | Removes CSLC catalog entries superseded by a reprocessed granule — ASF republishes a burst under a new processing date and both versions sit in the catalog. Processing already selects the newest, so this is hygiene: the stale documents inflate granule audits and catalog-vs-DAAC reconciliation. Dry run by default; only the GRQ document goes, never the DAAC granule. |
 | `reevaluate_disp_s1_forward_kscs.py --frame-id <frame>` | Re-drives forward dates the walk has already passed. Needed because a no-fire disposition is *terminal*: the walk advances over the date and cannot revisit it, and re-enabling does not help — its `cslc_catalog_ingest` is a no-op once the dataset exists, so nothing re-triggers the evaluator cascade. Use after fixing whatever caused the no-fire. |
+| `reevaluate_disp_s1_cscs.py [--frame-id <frame>] [--since YYYYMMDD]` | Re-drives the cycle evaluator on every incomplete cycle state config, recounting coverage from the CSLC documents in GRQ. Needed after a change to how coverage is counted, because a past date's CSC is otherwise only recomputed when another CSLC for that date is published. Each CSC that completes triggers its k-cycle evaluation through the normal rule. Dry run by default. |
+| `backfill_cslc_dataset_metadata.py [--frame-id <frame>]` | Promotes `burst_id`, `acquisition_ts`, `sensor` and `pol` to the top level of CSLC-S1 PGE datasets published before product2dataset did so, and sets their `starttime`. The cycle evaluator reads both shapes, so this is for uniformity: queries on `metadata.burst_id` then see every CSLC. `_update_by_query` in place, idempotent, dry run by default. |
+| `check_disp_s1_region_db.py [--frames <f1,f2>]` | Lists the burst-database frames the deployed region database does not cover. Those frames are stamped `region_id=UNKNOWN` and never match the `trigger-SCIFLO_L3_DISP_S1` whitelist. With `--frames`, exits 1 if any named frame is `UNKNOWN`; run it before whitelisting regions for a test. |
 
 A k-set is only counted done once its compressed CSLC boundary has published, not when its products
 appear — the next k-set gates on that boundary, so a k-set with all its products and no boundary is
@@ -305,6 +308,26 @@ The other DISP-S1 operator tools (`disp_s1_hist_status.py`, `disp_s1_k_cycle_dat
 predate phased processing and are phase-aware as of this release. Older builds report against the
 absolute k-set grid, and the two `*_burst_db.py` tools rewrite `sensing_time_list` as a plain list,
 which silently strips the labels.
+
+### Forward processing from CSLC-S1 PGE output
+
+Two producers publish `L2_CSLC_S1` datasets, and the forward cascade counts both.
+`cslc_catalog_ingest` writes metadata-only datasets pointing at DAAC granules, with the burst id at
+`metadata.burst_id` and the acquisition time in the dataset `starttime`. A CSLC-S1 PGE job publishes
+the product itself: every published file (the `.h5`, a browse `.png`, the `.iso.xml`) is listed in
+`metadata.product_s3_paths`, and the filename metadata sits on each entry of `metadata.Files`.
+product2dataset also copies `burst_id`, `acquisition_ts`, `sensor` and `pol` to the top level and
+sets `starttime`, but datasets published before that change carry them only per file.
+
+The cycle evaluator matches either shape, counts VV products only, and records each dataset's `.h5`
+path. After deploying a release that changes coverage counting on a venue whose CSLCs were already
+published, run `reevaluate_disp_s1_cscs.py` so past dates are recounted;
+`backfill_cslc_dataset_metadata.py` is optional hygiene.
+
+The DISP-S1 smoke test proves the PGE path end to end in its "Phase 2b": it ingests the SLC behind
+frame 31241's 2019-06-13 acquisition in reprocessing mode, and
+`conf/sds/files/test/check_disp_s1_pge_cslc_feed.py` asserts that the resulting CSLCs complete the
+frame's cycle and k-cycle state configs and produce an `L3_DISP_S1` from the local `.h5` files.
 
 ## download_from_daac.py
 

--- a/tools/backfill_cslc_dataset_metadata.py
+++ b/tools/backfill_cslc_dataset_metadata.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Promote burst metadata to the top level of CSLC datasets published without it.
+
+CSLC-S1 PGE datasets published before product2dataset promoted it carry their burst
+id, acquisition time, sensor and polarization only on each published file
+(metadata.Files[*]), and have no dataset starttime. Catalog-ingest datasets and newer
+PGE datasets carry them at the top level.
+
+Nothing depends on this tool: the DISP-S1 cycle evaluator reads either shape. It makes
+the older documents uniform with the rest, so that anything querying metadata.burst_id
+or starttime -- purge_superseded_cslc_granules.py --frame-id, audits, ad hoc queries --
+sees every CSLC.
+
+Documents are rewritten in place with _update_by_query. Nothing is republished or
+deleted, and a document that already has metadata.burst_id is not touched, so the tool
+is safe to re-run. Values are copied from the first file entry; they come from the
+product filename and are the same on every file of a dataset.
+
+Run it on mozart from the PCM checkout:
+
+    cd ~/mozart/ops/opera-pcm
+    PYTHONPATH=$PWD python tools/backfill_cslc_dataset_metadata.py                  # dry run
+    PYTHONPATH=$PWD python tools/backfill_cslc_dataset_metadata.py --frame-id 15422 # one frame
+    PYTHONPATH=$PWD python tools/backfill_cslc_dataset_metadata.py --apply
+    PYTHONPATH=$PWD python tools/backfill_cslc_dataset_metadata.py --dataset-type L2_CSLC_S1_STATIC --apply
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+ES = "https://localhost:9200"
+NETRC = os.path.expanduser("~/.netrc-os")
+
+INDEX_PATTERNS = {
+    "L2_CSLC_S1": "grq_*_l2_cslc_s1-*",
+    "L2_CSLC_S1_STATIC": "grq_*_l2_cslc_s1_static*",
+}
+
+# The same keys product2dataset promotes for each product type.
+PROMOTED_KEYS = {
+    "L2_CSLC_S1": ["burst_id", "acquisition_ts", "sensor", "pol"],
+    "L2_CSLC_S1_STATIC": ["burst_id", "validity_ts", "sensor"],
+}
+
+# CSLCs are selected by sensing date through the dataset starttime; static layers are not.
+SETS_TIME_RANGE = {"L2_CSLC_S1": True, "L2_CSLC_S1_STATIC": False}
+
+PAINLESS = """
+def md = ctx._source.metadata;
+if (md == null) { ctx.op = 'noop'; return; }
+def files = md.Files;
+if (files == null || !(files instanceof List) || files.isEmpty()) { ctx.op = 'noop'; return; }
+def first = files.get(0);
+boolean changed = false;
+for (def key : params.keys) {
+  if (md.get(key) == null && first.get(key) != null) { md.put(key, first.get(key)); changed = true; }
+}
+if (params.set_time_range && ctx._source.get('starttime') == null && first.get('acquisition_ts') != null) {
+  ctx._source.put('starttime', first.get('acquisition_ts'));
+  ctx._source.put('endtime', first.get('acquisition_ts'));
+  changed = true;
+}
+if (!changed) { ctx.op = 'noop'; }
+"""
+
+
+def build_query(dataset_type, burst_ids=None):
+    """Documents of dataset_type that lack a top-level burst id, optionally for some bursts."""
+    must = [{"term": {"dataset_type.keyword": dataset_type}}]
+    if burst_ids:
+        must.append({"terms": {"metadata.Files.burst_id.keyword": sorted(burst_ids)}})
+    return {"bool": {"must": must, "must_not": [{"exists": {"field": "metadata.burst_id"}}]}}
+
+
+def build_script(dataset_type):
+    return {
+        "lang": "painless",
+        "source": PAINLESS,
+        "params": {
+            "keys": PROMOTED_KEYS[dataset_type],
+            "set_time_range": SETS_TIME_RANGE[dataset_type],
+        },
+    }
+
+
+def es(method, path, body=None):
+    cmd = ["curl", "-s", "-k", "--netrc-file", NETRC, "-X" + method, ES + path]
+    if body is not None:
+        cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(body)]
+    out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         universal_newlines=True, timeout=300).stdout
+    try:
+        response = json.loads(out)
+    except ValueError:
+        raise RuntimeError(f"{method} {path}: not a JSON response: {out[:300]}")
+    if isinstance(response, dict) and response.get("error"):
+        raise RuntimeError(f"{method} {path}: {json.dumps(response['error'])[:500]}")
+    return response
+
+
+def count_by_index(index, query):
+    response = es("POST", f"/{index}/_search", {
+        "size": 1, "track_total_hits": True, "query": query, "_source": ["id"],
+        "aggs": {"by_index": {"terms": {"field": "_index", "size": 100}}},
+    })
+    total = response["hits"]["total"]["value"]
+    buckets = {b["key"]: b["doc_count"] for b in response["aggregations"]["by_index"]["buckets"]}
+    sample = response["hits"]["hits"][0]["_id"] if response["hits"]["hits"] else None
+    return total, buckets, sample
+
+
+def frame_burst_ids(frame_id):
+    from data_subscriber import cslc_utils
+    frame_to_bursts, _, _ = cslc_utils.localize_disp_frame_burst_hist()
+    frame = frame_to_bursts.get(int(frame_id))
+    return sorted(frame.burst_ids) if frame is not None else None
+
+
+def wait_for_task(task_id, poll_secs):
+    while True:
+        response = es("GET", f"/_tasks/{task_id}")
+        if response.get("completed"):
+            return response.get("response", {}), response.get("error")
+        status = response.get("task", {}).get("status", {})
+        print(f"  ... {status.get('updated', 0) + status.get('noops', 0)}"
+              f"/{status.get('total', '?')} processed")
+        time.sleep(poll_secs)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dataset-type", choices=sorted(INDEX_PATTERNS), default="L2_CSLC_S1")
+    ap.add_argument("--frame-id", type=int, help="restrict to one DISP-S1 frame's bursts")
+    ap.add_argument("--poll-secs", type=int, default=10)
+    ap.add_argument("--apply", action="store_true", help="rewrite documents; otherwise dry run")
+    args = ap.parse_args()
+
+    burst_ids = None
+    if args.frame_id is not None:
+        burst_ids = frame_burst_ids(args.frame_id)
+        if not burst_ids:
+            print(f"frame {args.frame_id} is not in the deployed burst database")
+            return 1
+        print(f"frame {args.frame_id}: {len(burst_ids)} bursts")
+
+    index = INDEX_PATTERNS[args.dataset_type]
+    query = build_query(args.dataset_type, burst_ids)
+    total, by_index, sample = count_by_index(index, query)
+    print(f"{args.dataset_type} documents without metadata.burst_id: {total}")
+    for name, count in sorted(by_index.items()):
+        print(f"   {name}: {count}")
+    if sample:
+        print(f"   e.g. {sample}")
+
+    if not total:
+        print("nothing to do")
+        return 0
+    if not args.apply:
+        print("\nDRY RUN -- nothing changed. Re-run with --apply.")
+        return 0
+
+    response = es("POST", f"/{index}/_update_by_query?conflicts=proceed&slices=auto"
+                          f"&wait_for_completion=false&refresh=true",
+                  {"query": query, "script": build_script(args.dataset_type)})
+    task_id = response.get("task")
+    if not task_id:
+        print(f"update_by_query did not start a task: {response}")
+        return 1
+    print(f"update_by_query task {task_id}")
+
+    result, error = wait_for_task(task_id, args.poll_secs)
+    if error:
+        print(f"task failed: {json.dumps(error)[:500]}")
+        return 1
+    print(f"total={result.get('total')} updated={result.get('updated')} "
+          f"noops={result.get('noops')} version_conflicts={result.get('version_conflicts')} "
+          f"failures={len(result.get('failures') or [])}")
+
+    remaining, _, sample = count_by_index(index, query)
+    print(f"remaining without metadata.burst_id: {remaining}" + (f" (e.g. {sample})" if sample else ""))
+    return 0 if not result.get("failures") else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/check_disp_s1_region_db.py
+++ b/tools/check_disp_s1_region_db.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Compare the deployed DISP-S1 region database with the consistent burst database.
+
+Every cycle and k-cycle state config is stamped with the region its frame belongs to,
+read from the region database (settings DISP_S1_FRAME_REGION_DB). A frame the region
+database does not list is stamped UNKNOWN, and the trigger-SCIFLO_L3_DISP_S1 rule's
+region whitelist can never match it: its state configs complete and nothing runs.
+
+This reports the frames the burst database processes but the region database does not
+list, and the reverse. With --frames it also resolves each named frame and exits 1 if
+any is UNKNOWN, which is the check to run before whitelisting regions for a test.
+
+    python tools/check_disp_s1_region_db.py
+    python tools/check_disp_s1_region_db.py --frames 15422,42810
+    python tools/check_disp_s1_region_db.py --json /tmp/region_db_audit.json
+"""
+
+import argparse
+import json
+import sys
+from collections import Counter
+
+UNKNOWN = "UNKNOWN"
+
+
+def compare_frame_sets(burst_db_frames, frame_region_map):
+    """(frames with no region, region-db frames absent from the burst database), both sorted."""
+    burst_db_frames = {int(f) for f in burst_db_frames}
+    region_frames = {int(f) for f in frame_region_map}
+    return sorted(burst_db_frames - region_frames), sorted(region_frames - burst_db_frames)
+
+
+def region_counts(frame_region_map):
+    return dict(sorted(Counter(str(r) for r in frame_region_map.values()).items()))
+
+
+def resolve_frames(frame_ids, frame_region_map):
+    return {int(f): str(frame_region_map.get(int(f), UNKNOWN)) for f in frame_ids}
+
+
+def parse_frames(text):
+    return [int(f) for f in text.replace(" ", "").split(",") if f]
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--frames", type=parse_frames, help="comma-separated frame ids to resolve")
+    ap.add_argument("--json", help="also write the full report to this file")
+    args = ap.parse_args()
+
+    from data_subscriber import cslc_utils
+    frame_to_bursts, _, _ = cslc_utils.localize_disp_frame_burst_hist()
+    frame_region_map = cslc_utils._localize_region_db()
+
+    missing_region, extra_region = compare_frame_sets(frame_to_bursts.keys(), frame_region_map)
+    report = {
+        "burst_db_frames": len(frame_to_bursts),
+        "region_db_frames": len(frame_region_map),
+        "region_counts": region_counts(frame_region_map),
+        "burst_db_frames_without_region": missing_region,
+        "region_db_frames_not_in_burst_db": extra_region,
+    }
+
+    print(f"burst database frames: {report['burst_db_frames']}")
+    print(f"region database frames: {report['region_db_frames']}  {report['region_counts']}")
+    print(f"burst database frames with no region ({len(missing_region)}; stamped {UNKNOWN}):")
+    print("   " + (", ".join(str(f) for f in missing_region) or "none"))
+    print(f"region database frames not in the burst database ({len(extra_region)}):")
+    print("   " + (", ".join(str(f) for f in extra_region) or "none"))
+
+    status = 0
+    if args.frames:
+        resolved = resolve_frames(args.frames, frame_region_map)
+        report["frames"] = resolved
+        print("requested frames:")
+        for frame_id, region in resolved.items():
+            print(f"   {frame_id}: {region}")
+        if UNKNOWN in resolved.values():
+            print(f"ERROR: at least one requested frame resolves to {UNKNOWN}")
+            status = 1
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(report, f, indent=2)
+        print(f"wrote {args.json}")
+
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/reevaluate_disp_s1_cscs.py
+++ b/tools/reevaluate_disp_s1_cscs.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Re-evaluate DISP-S1 cycle state configs that are not complete.
+
+A cycle state config (CSC) records how many of a frame's bursts have been found for one
+sensing date. The cycle evaluator recomputes it whenever a CSLC of that frame and date
+is published. So when the way coverage is counted changes -- for example after a release
+that lets the evaluator see CSLC datasets published in a shape it previously missed --
+existing CSCs keep their old coverage until another CSLC for that date arrives, which
+for past dates never happens.
+
+This tool submits one disp_s1_cycle_evaluator job per incomplete CSC, triggered on the
+CSC itself (the evaluator's re-evaluation input), with dedup disabled. The evaluator
+recounts coverage from the CSLC documents in GRQ and republishes the CSC; it publishes
+nothing else. A CSC that becomes complete then triggers the k-cycle evaluator through
+the normal trigger rule, exactly as if its last burst had just arrived, so expect one
+k-cycle evaluator job for each CSC that completes. Start with --frame-id or --limit on
+a venue with many CSCs.
+
+Run it on mozart from the PCM checkout:
+
+    cd ~/mozart/ops/opera-pcm
+    PYTHONPATH=$PWD python tools/reevaluate_disp_s1_cscs.py                        # dry run
+    PYTHONPATH=$PWD python tools/reevaluate_disp_s1_cscs.py --frame-id 15422 --apply
+    PYTHONPATH=$PWD python tools/reevaluate_disp_s1_cscs.py --since 20260825 --limit 100 --apply
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+
+ES = "https://localhost:9200"
+NETRC = os.path.expanduser("~/.netrc-os")
+CSC_INDEX = "grq_*_cslc_s1-cycle-state-config*"
+CSC_DATASET_TYPE = "cslc_s1-cycle-state-config"
+DEFAULT_QUEUE = "opera-job_worker-evaluator_verdi"
+TAG = "disp_s1_csc_reevaluate"
+
+
+def es(method, path, body=None):
+    cmd = ["curl", "-s", "-k", "--netrc-file", NETRC, "-X" + method, ES + path]
+    if body is not None:
+        cmd += ["-H", "Content-Type: application/json", "-d", json.dumps(body)]
+    out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                         universal_newlines=True, timeout=300).stdout
+    try:
+        response = json.loads(out)
+    except ValueError:
+        raise RuntimeError(f"{method} {path}: not a JSON response: {out[:300]}")
+    if isinstance(response, dict) and response.get("error"):
+        raise RuntimeError(f"{method} {path}: {json.dumps(response['error'])[:500]}")
+    return response
+
+
+def build_query(frame_ids=None, since=None, region=None):
+    """Incomplete CSCs, optionally for some frames, from a sensing date, or in a region."""
+    must = [{"term": {"metadata.is_complete": False}}]
+    if frame_ids:
+        must.append({"terms": {"metadata.frame_id": [int(f) for f in frame_ids]}})
+    if region is not None:
+        must.append({"term": {"metadata.region_id": str(region)}})
+    query = {"bool": {"must": must}}
+    if since:
+        # metadata.sensing_date is mapped as a date with format yyyyMMdd.
+        query["bool"]["filter"] = [{"range": {"metadata.sensing_date": {"gte": since}}}]
+    return query
+
+
+def scan(query, page_size=1000):
+    response = es("POST", f"/{CSC_INDEX}/_search?scroll=5m",
+                  {"size": page_size, "query": query,
+                   "_source": ["dataset", "urls", "metadata"]})
+    scroll_id = response.get("_scroll_id")
+    try:
+        while True:
+            hits = response.get("hits", {}).get("hits", [])
+            if not hits:
+                return
+            for hit in hits:
+                yield hit
+            response = es("POST", "/_search/scroll", {"scroll": "5m", "scroll_id": scroll_id})
+            scroll_id = response.get("_scroll_id", scroll_id)
+    finally:
+        if scroll_id:
+            try:
+                es("DELETE", "/_search/scroll", {"scroll_id": scroll_id})
+            except RuntimeError:
+                pass
+
+
+def build_reeval_params(hit):
+    """Job params matching what the trigger rule's hysds-io would produce for this CSC."""
+    source = hit["_source"]
+    return {
+        "product_paths": next((u for u in (source.get("urls") or []) if u.startswith("s3://")), ""),
+        "product_metadata": {"metadata": source.get("metadata", {})},
+        "dataset_type": source.get("dataset") or CSC_DATASET_TYPE,
+        "input_dataset_id": hit["_id"],
+    }
+
+
+def build_submit_form(hit, job_release, queue, stamp):
+    return {
+        "queue": queue,
+        "priority": 5,
+        "tags": json.dumps([TAG]),
+        "type": f"job-disp_s1_cycle_evaluator:{job_release}",
+        "params": json.dumps(build_reeval_params(hit)),
+        "name": f"reevaluate-csc-{hit['_id']}-{stamp}",
+    }
+
+
+def describe(hit):
+    md = hit["_source"].get("metadata", {})
+    return (f"{hit['_id']}  found={md.get('coverage_actual')}/{md.get('coverage_expected')}"
+            f"  region={md.get('region_id')}  blackout={md.get('blackout')}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--frame-id", type=int, nargs="+", help="restrict to these frames")
+    ap.add_argument("--since", help="only sensing dates on or after YYYYMMDD")
+    ap.add_argument("--region", help="only CSCs stamped with this region_id")
+    ap.add_argument("--limit", type=int, help="submit at most this many jobs")
+    ap.add_argument("--job-release", help="defaults to STAGING_AREA.JOB_RELEASE from ~/.sds/config")
+    ap.add_argument("--queue", default=DEFAULT_QUEUE)
+    ap.add_argument("--sleep-secs", type=float, default=0.2, help="pause between submissions")
+    ap.add_argument("--apply", action="store_true", help="submit; otherwise dry run")
+    args = ap.parse_args()
+
+    if args.since and (len(args.since) != 8 or not args.since.isdigit()):
+        ap.error("--since takes YYYYMMDD")
+
+    hits = list(scan(build_query(args.frame_id, args.since, args.region)))
+    hits.sort(key=lambda h: h["_id"])
+    if args.limit is not None:
+        hits = hits[:args.limit]
+    print(f"{len(hits)} incomplete cycle state config(s) selected")
+    for hit in hits[:20]:
+        print("   " + describe(hit))
+    if len(hits) > 20:
+        print(f"   ... and {len(hits) - 20} more")
+
+    if not hits:
+        return 0
+    if not args.apply:
+        print("\nDRY RUN -- nothing submitted. Re-run with --apply.")
+        return 0
+
+    from util.conf_util import SettingsConf
+    import requests
+    import urllib3
+    urllib3.disable_warnings()
+
+    cfg = SettingsConf(file=os.path.expanduser("~/.sds/config")).cfg
+    release = args.job_release or cfg["STAGING_AREA"]["JOB_RELEASE"]
+    url = f"https://{cfg['MOZART_PVT_IP']}/mozart/api/v0.1/job/submit?enable_dedup=false"
+    stamp = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+
+    submitted = 0
+    for hit in hits:
+        response = requests.post(url, data=build_submit_form(hit, release, args.queue, stamp),
+                                 verify=False, timeout=120)
+        ok = response.status_code == 200 and response.json().get("success")
+        submitted += 1 if ok else 0
+        if not ok:
+            print(f"   FAILED {hit['_id']}: {response.text[:200]}")
+        time.sleep(args.sleep_secs)
+
+    print(f"\nsubmitted {submitted}/{len(hits)} disp_s1_cycle_evaluator job(s) tagged {TAG}")
+    return 0 if submitted == len(hits) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/run_disp_s1_historical_processing.py
+++ b/tools/run_disp_s1_historical_processing.py
@@ -535,9 +535,8 @@ def plan_forward_action(p, frame_id, phase, position, frame, eu, now):
         job_spec=f"job-{FORWARD_JOB_TYPE}:{JOB_RELEASE}",
         job_params=job_params,
         job_tags=["phased_forward", f"frame_{frame_id}", p.label, phase.label],
-        # The catalog ingest job spec recommends its own queue, but that queue has no workers on
-        # every cluster; the batch proc's download queue always does, since historical processing
-        # cannot run without it. forward_job_queue overrides when a venue does deploy one.
+        # Forward dates run on the batch proc's download queue, which every campaign has workers
+        # for because its historical downloads run there. forward_job_queue overrides it.
         job_queue=getattr(p, "forward_job_queue", None) or p.download_job_queue,
         phase_label=phase.label,
         # Every field of the entry is written, including the ones this date has no value for yet:


### PR DESCRIPTION
## Summary

Resolves [OPERA-2629](https://hysds-core.atlassian.net/browse/OPERA-2629)

DISP-S1 forward processing produces nothing on opera-int-fwd. The per-cycle evaluator looks for a CSLC's burst id at `metadata.burst_id` and its acquisition date at top-level `starttime`, but CSLC datasets published by the CSLC-S1 PGE carry `burst_id` and `acquisition_ts` only inside `metadata.Files[*]` and have no `starttime` at all. `merge_dataset_met_json()` lifts only `Product*` keys and `dataset_version` to the top level, so nothing else is promoted. Datasets written by `cslc_catalog_ingest` do set both fields, which is why the dev-e2e smoke test passes while live forward processing does not.

On INT at the time of analysis: 30,583 PGE-produced CSLC documents, none with `metadata.burst_id`, none with `starttime`, and 1,338 cycle state configs all sitting at coverage 0 with no k-cycle index.

This fixes both ends. New CSLC datasets are published with the burst fields at the dataset level, and the evaluator also accepts the nested shape so the documents already published on INT and OPS become usable without rewriting them.

## Changes

**Publish CSLC burst metadata at the dataset level** (`product2dataset/product2dataset.py`, `conf/settings.yaml`)

- `promote_file_metadata()` lifts per-file keys to the top of the dataset metadata when the files agree on a value, and logs a warning instead of guessing when they do not. `L2_CSLC_S1` promotes `burst_id`, `acquisition_ts`, `sensor` and `pol`; `L2_CSLC_S1_STATIC` promotes `burst_id`, `validity_ts` and `sensor`. This follows the existing `decorate_compressed_cslc()` precedent that compressed CSLCs already rely on.
- `product_version` is deliberately not promoted. The extractor stores that regex group as `dataset_version`, which the merge already lifts, so it never exists per file.
- `L2_CSLC_S1` gains `Dataset_Keys: {starttime: acquisition_ts, endtime: acquisition_ts}`, which is the existing mechanism that puts the time range into `dataset.json` and from there onto the GRQ document.
- The static layer products are not tied to an acquisition, so their files carry `validity_ts` and no `acquisition_ts`. Lifting `Files[0]["acquisition_ts"]` unconditionally raised a `KeyError` for both `L2_CSLC_S1_STATIC` and `L2_RTC_S1_STATIC`; that lift now goes through the same promotion helper.

**Accept both document shapes in the cycle evaluator** (`data_subscriber/cslc/disp_s1_cycle_evaluator.py`, `opera_chimera/precondition_functions.py`)

- The coverage query matches `metadata.burst_id.keyword` or `metadata.Files.burst_id.keyword`, and ranges on `starttime` or `metadata.Files.acquisition_ts`. The dual-shape query was run against INT's live mapping and returns the expected documents.
- A burst counts as found only when an `.h5` path is known, selected by suffix rather than by taking `product_s3_paths[0]`. The state config record is the audit trail the RunConfig lineage and accountability read, so recording the browse image there was wrong even though the SCIFLO would still have worked.
- Non-VV granules are skipped, mirroring what catalog ingest already does, and the result size cap is `max(200, 5 x bursts)` with a warning when it is hit.
- The DISP-S1 static-layer fallback query accepts the nested burst id the same way.

**Point catalog ingest at a queue that exists** (`docker/job-spec.json.cslc_catalog_ingest`)

- `recommended-queues` becomes `opera-job_worker-cslc_data_download`. No terraform stack defines `opera-job_worker-cslc_catalog_ingest`, so the job as specified had nowhere to run. The download workers are already the default of `tools/run_disp_s1_forward_serial.py`, the fix applied to the phased-historical tool, and the runbook workaround. A dedicated ASG was considered and rejected for now: it needs matching edits in three variables files plus a terraform apply on INT and OPS, and catalog ingest is a low-volume operator-driven job. If review wants isolation later it is one line flipped back plus the three terraform blocks.
- `tests/unit/test_job_spec_queues.py` pins every `recommended-queues` entry of every job spec to a queue name defined in `modules/common/variables.tf`, so a job spec can never again recommend a queue that no stack deploys.
- `tools/run_disp_s1_historical_processing.py` only has its comment updated: it no longer says the catalog ingest job spec recommends a queue without workers.

**Operator tools** (`tools/`, documented in `tools/README.md`)

- `backfill_cslc_dataset_metadata.py` promotes the fields on already-published documents with `update_by_query` and a painless script. Dry run is the default.
- `reevaluate_disp_s1_cscs.py` resubmits a cycle-evaluator job per incomplete state config so coverage is recomputed from the real documents. Re-evaluating is preferred over purging: a purge leaves the frame-date with no state at all, while a state config that stays at 0 after re-evaluation is truthful. Note the load, since every complete state config spawns one k-cycle evaluator job. Use `--limit` or `--frame-id` first.
- `check_disp_s1_region_db.py` compares the deployed burst DB against the region DB and exits non-zero if a requested frame resolves to `UNKNOWN`. 121 of 1,421 burst-DB frames have no region today.

**Smoke coverage for the PGE-produced shape** (`cluster_provisioning/dev-e2e-pge-DISP_S1/`, `conf/sds/files/test/check_disp_s1_pge_cslc_feed.py`)

- A new phase ingests one real SLC through the CSLC-S1 PGE and asserts that the resulting CSLCs drive a complete cycle state config, a k-cycle state config and an L3 product for frame 31241, with those CSLCs present in the RunConfig lineage. The existing phases only ever exercised the catalog-ingest shape, which is why this defect reached production.
- It drives the production `job-slcs1a_query` in reprocessing mode over a five-second temporal window rather than the subscriber CLI with `--native-id`. The native-id job cannot set the processing mode the CSLC trigger rule requires, and the CLI on mozart would need GDAL.

Out of scope, worth separate tickets: persisting the region whitelist across `import_rules.sh` re-imports, the same `starttime` and promotion treatment for RTC-S1, the legacy `cslc_query_timer` Lambda, and regenerating the region DB for the 121 frames without a region.

## Documentation

- `tools/README.md` gains entries for the three new tools with their common invocations.
- Building the compressed-CSLC lineage on INT, setting the region whitelist, and the forward restart itself are operator procedures and stay in the runbook rather than this repo.

## Test plan

**Unit tests.** Full suite on this branch: 722 passed, 16 failed, 6 errors. Clean `develop` at `51eca8b2`: 612 passed, 16 failed, 6 errors. The failing and erroring sets are identical, so all 110 added tests pass and nothing regressed. All 16 failures are in `tests/unit/dist_s1/test_gap_finder.py`, and the 6 errors are collection errors in six other test modules. Both occur on `develop` too.

New coverage: metadata promotion at the unit level and through `convert()` for both the acquisition and static products; the `Dataset_Keys` setting; both evaluator query shapes and a full PGE-shaped-input evaluator run; the job-spec queue pin; the three tools; and the smoke checker's pure helpers. The `convert()` component tests run with `PGE_SIMULATION_MODE` on, so they do not exercise the ISO polygon and polarization extraction that `develop` added to the CSLC publish path. The rerun below covers that.

**Dev venue runs.** The two runs below deployed `a905d51f`, which is this branch before the static-layer fix and before `develop` was merged in.

**`dev-e2e-pge-DISP_S1` on gmanipon-0040.** `check_pcm.py` passed 4 of 5 tests. The new `test_pge_cslc_feed` passed with all five of its checks SUCCESS: frame 31241 went from two PGE-produced CSLCs to a complete cycle state config, a k-cycle state config, and an L3 product whose lineage includes both CSLCs. That is the end-to-end proof of the defect being fixed.

`test_forward_expected_datasets` failed. `datasets_e2e.json` expects 55 forward L3 products and 6 compressed CSLCs, a count already known to be stale on `develop`. The forward stage fired 11 dates, the same 11 that `develop` fires, and frame 31241 ended with 26 L3 products and 2 compressed CSLCs: 14 historical, 11 forward and 1 from the new stage. Correcting that expectation is outside this ticket.

```
FAILED mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1/check_pcm.py::TestPCM::test_forward_expected_datasets - assert None is not None
===== 1 failed, 4 passed in 0.09s ======

# /tmp/datasets_hist.txt
SUCCESS: Found 1 expected area_of_interest datasets of version '2.0'.
SUCCESS: Found 14 expected L3_DISP_S1 datasets of version 'v1.0'.
SUCCESS: Found 2 expected L2_CSLC_S1_COMPRESSED datasets of version '1'.
# /tmp/datasets_hist_phased.txt
SUCCESS: Found 14 expected L3_DISP_S1 datasets of version 'v1.0'.
SUCCESS: Found 3 expected L2_CSLC_S1_COMPRESSED datasets of version '1'.
# /tmp/phases_hist_phased.txt
SUCCESS: frame 24718 phases: no_run[11], historical_03[15], forward_03[10]
SUCCESS: compressed CSLC boundaries at ['20251231'] (1 k-set(s) across 1 historical phase(s))
SUCCESS: 11 no_run date(s) produced no products
SUCCESS: every historical/no_run phase KSC is superseded
SUCCESS: frame has no forward dates owed yet (cursor at 26, 10 forward date(s) not reached)
# /tmp/datasets_fwd.txt
ERROR: Failed to find 55 expected L3_DISP_S1 datasets of version 'v1.0'.
# /tmp/pge_cslc_feed.txt (new phase)
SUCCESS: CSLC-S1 PGE published 2 CSLCs for frame 31241 on 20190613, each with metadata.burst_id and starttime: ['OPERA_L2_CSLC-S1_T117-249921-IW3_20190613T172935Z_20260911T200944Z_S1A_VV_v1.1', 'OPERA_L2_CSLC-S1_T117-249922-IW3_20190613T172938Z_20260911T200944Z_S1A_VV_v1.1']
SUCCESS: cslc_s1-cycle-f31241-20190613-state-config complete (2/2) from the PGE products
SUCCESS: disp_s1-kcycle-k15-m3-f31241-20190613-state-config complete and lists the PGE products
SUCCESS: OPERA_L3_DISP-S1_IW_F31241_VV_20190601T172935Z_20190613T172935Z_v1.0_20260911T205227Z published
SUCCESS: its lineage includes every PGE-produced CSLC of the date
```

**`dev-e2e-pge-DISP_S1-all_phases` on pyoon-0048.** The run first failed both `check_pcm.py` tests with 28 of 31 products. The phased walk itself was correct; the three missing forward products were the region whitelist gate defaulting to `["0"]` while frame 17235 is in region 4. That is pre-existing `develop` behavior, reproduced on a clean branch from a second session, and `develop` now carries the smoke-test fix for it. Regression coverage across the run: 890 cycle-evaluator jobs and 87 k-cycle-evaluator jobs with zero failures, and the historical state configs complete at 27 of 27.

```
FAILED mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/check_pcm.py::TestPCM::test_all_phases_expected_datasets - assert None is not None
FAILED mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1-all_phases/check_pcm.py::TestPCM::test_all_phases_structure - assert <re.Match object; span=(317,...
========== 2 failed in 0.09s ===========

# /tmp/datasets_all_phases.txt
ERROR: Failed to find 31 expected L3_DISP_S1 datasets of version 'v1.0'.
# /tmp/phases_all_phases.txt
SUCCESS: frame 17235 phases: historical_01[15], forward_01[1], historical_02[15], forward_02[2], no_run[9]
SUCCESS: compressed CSLC boundaries at ['20170906', '20210804'] (2 k-set(s) across 2 historical phase(s))
SUCCESS: 9 no_run date(s) produced no products
SUCCESS: every historical/no_run phase KSC is superseded
ERROR: 3 forward date(s) produced no product: ['20170918', '20210828', '20210909']
```

Recovery on a venue where the whitelist is set late is: set the whitelist, delete the stranded k-cycle state configs, then re-drive the evaluator, in that order. With that applied the run reached 31 of 31 and every phase assertion passed.

```
L3 frame 17235: 31 of 31
CCSLC frame 17235: 54 of 54
failed jobs: 0

# check_disp_s1_phases.py after recovery
SUCCESS: frame 17235 phases: historical_01[15], forward_01[1], historical_02[15], forward_02[2], no_run[9]
SUCCESS: compressed CSLC boundaries at ['20170906', '20210804'] (2 k-set(s) across 2 historical phase(s))
SUCCESS: 9 no_run date(s) produced no products
SUCCESS: every historical/no_run phase KSC is superseded
SUCCESS: all 3 forward date(s) produced a product
```

**Rerun at the PR head, `dev-e2e-pge-DISP_S1` on gmanipon-0041.** Finished 2026-09-16 after 21h37m, deploying `08b15504` with the same boundary-serial forward mode as gmanipon-0040. `check_pcm.py` passed 4 of 5, failing only on the same stale forward expectation of 55 products. The new phase passed all five of its checks, this time with `develop` merged in.

```
FAILED mozart/ops/opera-pcm/cluster_provisioning/dev-e2e-pge-DISP_S1/check_pcm.py::TestPCM::test_forward_expected_datasets - assert None is not None
===== 1 failed, 4 passed in 0.09s ======

# deployed code on mozart
08b15504 Merge branch 'develop' into OPERA-2629

# /tmp/pge_cslc_feed.txt (new phase)
SUCCESS: CSLC-S1 PGE published 2 CSLCs for frame 31241 on 20190613, each with metadata.burst_id and starttime: ['OPERA_L2_CSLC-S1_T117-249921-IW3_20190613T172935Z_20260916T154857Z_S1A_VV_v1.1', 'OPERA_L2_CSLC-S1_T117-249922-IW3_20190613T172938Z_20260916T154857Z_S1A_VV_v1.1']
SUCCESS: cslc_s1-cycle-f31241-20190613-state-config complete (2/2) from the PGE products
SUCCESS: disp_s1-kcycle-k15-m3-f31241-20190613-state-config complete and lists the PGE products
SUCCESS: OPERA_L3_DISP-S1_IW_F31241_VV_20190601T172935Z_20190613T172935Z_v1.0_20260916T163523Z published
SUCCESS: its lineage includes every PGE-produced CSLC of the date

# historical and phased stages
SUCCESS: Found 14 expected L3_DISP_S1 datasets of version 'v1.0'.
SUCCESS: Found 2 expected L2_CSLC_S1_COMPRESSED datasets of version '1'.
SUCCESS: frame 24718 phases: no_run[11], historical_03[15], forward_03[10]
SUCCESS: every historical/no_run phase KSC is superseded
```

This run also settles a defect the earlier runs hid. `develop`'s cleanup of non-.h5 files from staged CSLC inputs works: after the DISP-S1 job consumed the two PGE-produced CSLCs, all 18 CSLC dataset directories from that SLC still hold 13 files including their .h5. On gmanipon-0040, which ran before that `develop` commit, the two directories the job consumed came back with 12 files and no .h5, so forward processing was corrupting its own inputs.

One caveat on this run's job accounting. The cluster came up on a base image whose metrics host ships a stale redis password, so HySDS fails when it records job info after a job's command has already exited 0. All 627 job failures were confirmed to be that, with zero real failures, and datasets, state configs and triggers were unaffected. It is unrelated to this PR and is being tracked with the image owners.

Both earlier clusters have been torn down. Their result files and `check_pcm.xml` are archived on opera-pcm-ci.
